### PR TITLE
Simply use the _getDefaultPostLogoutUrl() function to control where the ...

### DIFF
--- a/system/handlers/Login.cfc
+++ b/system/handlers/Login.cfc
@@ -41,8 +41,7 @@ component output=false {
 
 	public void function logout( event, rc, prc ) output=false {
 		websiteLoginService.logout();
-
-		setNextEvent( url=( Len( Trim( cgi.http_referer ) ) ? cgi.http_referer : _getDefaultPostLogoutUrl( argumentCollection=arguments ) ) );
+		setNextEvent( url=_getDefaultPostLogoutUrl( argumentCollection=arguments ) );
 	}
 
 	public void function sendResetInstructions( event, rc, prc ) output=false {


### PR DESCRIPTION
...user is taken post logout.  http_referer removed.