### PR TITLE
Fixing MessageBox text on adding & editing a asset in AssetManager

### DIFF
--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -113,7 +113,7 @@ component extends="preside.system.base.AdminHandler" {
 
 				event.renderData( type="json", data={
 					  success = true
-					, title   = ( rc.label ?: "" )
+					, title   = ( rc.title ?: "" )
 					, id      = assetId
 				} );
 			} catch( "PresideCMS.AssetManager.asset.wrong.type.for.folder" e ) {
@@ -561,7 +561,7 @@ component extends="preside.system.base.AdminHandler" {
 				, denyUsers     = ListToArray( rc.deny_access_to_users     ?: "" )
 			);
 
-			messagebox.info( translateResource( uri="cms:assetmanager.asset.edit.success", data=[ formData.label ?: "" ] ) );
+			messagebox.info( translateResource( uri="cms:assetmanager.asset.edit.success", data=[ formData.title ?: "" ] ) );
 			setNextEvent( url=event.buildAdminLink( linkTo="assetManager", queryString="folder=#folderId#" ) );
 		} else {
 			messagebox.error( translateResource( "cms:assetmanager.asset.edit.unexpected.error" ) );


### PR DESCRIPTION
Asset name was missing in MessageBox notification while adding & editing a asset in AssetManager
![while_add_asset_in_assetmanager](https://cloud.githubusercontent.com/assets/532401/11338130/4ebb6108-9218-11e5-86b2-897a8ab6c64e.png)
![while_edit_asset_in_assetmanager](https://cloud.githubusercontent.com/assets/532401/11338131/4f698f58-9218-11e5-9fce-cfa8c4ba90a0.png)
