### PR TITLE
PresideCMS-250 :: Asset Manager's Root folder label in the breadcrumb

### DIFF
--- a/system/views/admin/assetmanager/index.cfm
+++ b/system/views/admin/assetmanager/index.cfm
@@ -9,7 +9,7 @@
 
 	prc.pageIcon     = "picture-o";
 	prc.pageTitle    = translateResource( "cms:assetManager" );
-	prc.pageSubtitle = folderTitle;
+	prc.pageSubtitle = folderTitle == "$root" ? "#translateResource( "cms:assetmanager.root.folder" )#(#prc.folderTree[1].asset_count#)" : folderTitle;
 
 
 </cfscript>


### PR DESCRIPTION
Fixed the Asset Manager's Root folder label in the breadcrumb issue
