### PR TITLE
Fixed - PRESIDECMS-251 (Removed the extra white spaces)

### DIFF
--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -58,7 +58,7 @@ component extends="coldbox.system.web.context.RequestContextDecorator" {
 		return site.id ?: "";
 	}
 
-	public string function buildLink() {
+	public string function buildLink() output=false{
 		var prc = getRequestContext().getCollection( private=true );
 
 		announceInterception(


### PR DESCRIPTION
Hi @DominicWatson ,

Good day! I just added output=false to buildLink method on the RequestContentDecorator.cfc and then the line break issue is gone :)

Thanks and have a  great day ahead.
