### PR TITLE
URL Redirect Rule 500 server error issue

### DIFF
--- a/system/handlers/admin/UrlRedirects.cfc
+++ b/system/handlers/admin/UrlRedirects.cfc
@@ -2,6 +2,7 @@ component extends="preside.system.base.AdminHandler" output=false {
 
 	property name="urlRedirectsService" inject="urlRedirectsService";
 	property name="ruleDao"             inject="presidecms:object:url_redirect_rule";
+	property name="messageBox"          inject="coldbox:plugin:messageBox";
 
 // public handlers
 	public void function preHandler( event ) output=false {


### PR DESCRIPTION
Hi @DominicWatson ,

Just fixed the issue that causing the 500 server error when trying the add URL rewrite rule that already exist. Just added the following on the URLRedirects service.

property name="messageBox"          inject="coldbox:plugin:messageBox";

Before: http://screencast.com/t/Zj7Usj5O7
Now: http://screencast.com/t/XNoNwvTs

Thank you!
