### PR TITLE
PRESIDECMS-559 Fix null filters for Postrges/MSSQL

### DIFF
--- a/system/services/database/SqlRunner.cfc
+++ b/system/services/database/SqlRunner.cfc
@@ -72,8 +72,8 @@ component output=false singleton=true {
 		var preClause  = arguments.sql.reReplaceNoCase( "^(.*?\swhere)\s.*$", "\1" );
 		var postClause = arguments.sql.reReplaceNoCase( "^.*?\swhere\s", " " );
 
-		postClause = postClause.reReplaceNoCase("\s!= :#arguments.paramName#", " is not :#arguments.paramName#", "all" );
-		postClause = postClause.reReplaceNoCase("\s= :#arguments.paramName#", " is :#arguments.paramName#", "all" );
+		postClause = postClause.reReplaceNoCase("\s!= :#arguments.paramName#", " is not null", "all" );
+		postClause = postClause.reReplaceNoCase("\s= :#arguments.paramName#", " is null", "all" );
 
 		return preClause & postClause
 	}


### PR DESCRIPTION
Use null keyword when filtering against null values, instead of a null query param.
