### PR TITLE
Feature presidecms 695 asset url not updated when new version added

### DIFF
--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -915,7 +915,7 @@ component displayName="AssetManager Service" {
 			return "";
 		}
 
-		if ( Len( Trim( asset.asset_url ) ) ) {
+		if ( Len( Trim( asset.asset_url ) ) && findNoCase( UrlEncodedFormat( version ), asset.asset_url ) ) {
 			return asset.asset_url;
 		}
 


### PR DESCRIPTION
Check the existing asset_url if it contains the latest version before returning the url, else generate a new url so that new version is always honoured.