### PR TITLE
PRESIDECMS-695 update asset_url when version is made active.

### DIFF
--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -1368,10 +1368,20 @@ component displayName="AssetManager Service" {
 				, "asset_version.created_by"
 				, "asset_version.updated_by"
 				, "asset.title"
+				, "asset.asset_folder"
+				, "asset.is_trashed"
 			]
 		);
 
 		var versionImageDimension =  _getImageInfo( getAssetBinary( arguments.assetId, arguments.versionId ) );
+
+		var generatedAssetUrl = generateAssetUrl(
+			  id          = arguments.assetId
+			, versionId   = arguments.versionId
+			, storagePath = versionToMakeActive.storage_path
+			, folder      = versionToMakeActive.asset_folder
+			, trashed 	  = IsBoolean(versionToMakeActive.is_trashed) && versionToMakeActive.is_trashed
+		);
 
 		if ( versionToMakeActive.recordCount ) {
 			var result = _getAssetDao().updateData( id=arguments.assetId, data={
@@ -1384,6 +1394,7 @@ component displayName="AssetManager Service" {
 				, updated_by       = versionToMakeActive.updated_by
 				, width            = versionImageDimension.width  ?: ""
 				, height           = versionImageDimension.height ?: ""
+				, asset_url 	   = generatedAssetUrl
 			} );
 
 			for( var a in versionToMakeActive ) { var auditDetail = a; }


### PR DESCRIPTION
I have made so that the asset active_url is updated when an asset_version is made active. This should cover addAsset and makeVersionActive action. URL is generated based on the getAssetUrl method.

