### PR TITLE
Feature presidecms 717 request context and meta data fixes

### DIFF
--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -102,7 +102,7 @@ component extends="coldbox.system.web.context.RequestContextDecorator" output=fa
 	}
 
 	public string function getProtocol() output=false {
-		return Len( cgi.https ) && compare( cgi.https, "on" ) == 0 ? "https" : "http";
+		return ( cgi.https ?: "" ) == "on" ? "https" : "http";
 	}
 
 	public string function getServerName() output=false {

--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -102,7 +102,7 @@ component extends="coldbox.system.web.context.RequestContextDecorator" output=fa
 	}
 
 	public string function getProtocol() output=false {
-		return cgi.server_protocol contains "https" ? "https" : "http";
+		return Len( cgi.https ) && compare( cgi.https, "on" ) == 0 ? "https" : "http";
 	}
 
 	public string function getServerName() output=false {

--- a/system/views/general/_openGraphMeta.cfm
+++ b/system/views/general/_openGraphMeta.cfm
@@ -1,9 +1,10 @@
 <cfscript>
-	local.teaser       = Trim( event.getPageProperty( "teaser"        ) );
-	local.description  = Trim( event.getPageProperty( "description"   ) );
-	local.browsertitle = Trim( event.getPageProperty( "browser_title" ) );
-	local.title        = Trim( event.getPageProperty( "title"         ) );
-	local.mainImage    = Trim( event.getPageProperty( "main_image"    ) );
+	local.teaser       = Trim( event.getPageProperty( "teaser"             ) );
+	local.description  = Trim( event.getPageProperty( "description"        ) );
+	local.browsertitle = Trim( event.getPageProperty( "browser_title"      ) );
+	local.title        = Trim( event.getPageProperty( "title"              ) );
+	local.mainImage    = Trim( event.getPageProperty( "main_image"         ) );
+	local.ogType       = Trim( event.getPageProperty( "og_type", "website" ) );
 
 	local.title  = Len( local.browserTitle ) ? local.browserTitle : local.title;
 	local.teaser = Len( local.teaser       ) ? local.teaser       : local.description;
@@ -11,6 +12,7 @@
 
 <cfoutput>
 	<meta property="og:title" content="#XmlFormat( local.title )#" />
+	<meta property="og:type"  content="#local.ogType#" />
 	<meta property="og:url"   content="#event.getBaseUrl()##HtmlEditFormat( event.getCurrentUrl() )#" />
 	<cfif Len( local.teaser )>
 		<meta property="og:description" content="#HtmlEditFormat( local.teaser )#" />

--- a/system/views/general/_openGraphMeta.cfm
+++ b/system/views/general/_openGraphMeta.cfm
@@ -1,10 +1,11 @@
 <cfscript>
+	local.site         = event.getSite();
 	local.teaser       = Trim( event.getPageProperty( "teaser"             ) );
 	local.description  = Trim( event.getPageProperty( "description"        ) );
 	local.browsertitle = Trim( event.getPageProperty( "browser_title"      ) );
 	local.title        = Trim( event.getPageProperty( "title"              ) );
 	local.mainImage    = Trim( event.getPageProperty( "main_image"         ) );
-	local.ogType       = Trim( event.getPageProperty( "og_type", "website" ) );
+	local.ogType       = local.site.og_type ?: "website";
 
 	local.title  = Len( local.browserTitle ) ? local.browserTitle : local.title;
 	local.teaser = Len( local.teaser       ) ? local.teaser       : local.description;


### PR DESCRIPTION
Hi Dom,

I have updated getProtocol() function as cgi.server_protocol return ( http/1.0 for https and http/1.1 for http )
Have also added meta for **og:type** which defaulted to website


Thank you
Nelson