### PR TITLE
fix: [Error] SELECT list contains nonaggregated column 'preside.page.title'

### DIFF
--- a/system/handlers/core/SiteTreePageRequestHandler.cfc
+++ b/system/handlers/core/SiteTreePageRequestHandler.cfc
@@ -65,7 +65,7 @@ component output=false {
 				  view          = view
 				, presideObject = pageType.getPresideObject()
 				, filter        = { page = pageId }
-				, groupby       = pageType.getPresideObject() & ".id" // ensure we only get a single record should the view be joining on one-to-many relationships
+				, groupby       = pageType.getPresideObject() & ".id,title,main_content" // ensure we only get a single record should the view be joining on one-to-many relationships
 			);
 		}
 


### PR DESCRIPTION
The following error will display on the first page of the site.

```
Application Execution Exception
Error Type: database : 0
Error Messages: 
Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'preside.page.title' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

PresideCMS  | Application Server  | Database Server | Java  | Operating System
---|---|---|---|---
10.7.39.01225| Lucee (5.1.2.24) | MySQL (5.7.17) | 1.8.0_40 | Mac OS X (10.12.3)

**SQL Sent:**
```
select page.title as title, page.main_content as main_content, homepage.id as _id from `_version_psys_homepage` `homepage` inner join `_version_psys_page` `page` on (`page`.`id` = `homepage`.`page`) and (page._version_number = homepage._version_number) where (`homepage`.`page` = 'A53CD66E-B863-4952-8B6FC01FB99A8EAF') and (homepage._version_is_latest_draft = true) group by homepage.id
```
**Stack Trace:**
```
lucee.runtime.exp.DatabaseException: 
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:404)
	at com.mysql.jdbc.Util.getInstance(Util.java:387)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:939)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3878)
	at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3814)
	at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2478)
	at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2625)
	at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2551)
	at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:1861)
	at com.mysql.jdbc.PreparedStatement.execute(PreparedStatement.java:1192)
	at lucee.runtime.type.util.QueryUtil.execute(QueryUtil.java:301)
	at lucee.runtime.type.QueryImpl.execute(QueryImpl.java:275)
	at lucee.runtime.type.QueryImpl.(QueryImpl.java:221)
	at lucee.runtime.tag.Query.executeDatasoure(Query.java:839)
	at lucee.runtime.tag.Query.doEndTag(Query.java:597)
	at org.lucee.cfml.base_cfc$cf.udfCall1(/org/lucee/cfml/Base.cfc:110)
	at org.lucee.cfml.base_cfc$cf.udfCall(/org/lucee/cfml/Base.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:225)
	at lucee.runtime.type.scope.UndefinedImpl.call(UndefinedImpl.java:772)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:755)
	at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:1697)
	at org.lucee.cfml.query_cfc$cf.udfCall(/org/lucee/cfml/Query.cfc:53)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:225)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:697)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.call(ComponentImpl.java:1918)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:755)
	at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:1697)
	at system.services.database.sqlrunner_cfc$cf.udfCall(/preside/system/services/database/SqlRunner.cfc:55)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:698)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:1935)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.services.presideobjects.presideobjectservice_cfc$cf.udfCall7(/preside/system/services/presideObjects/PresideObjectService.cfc:2155)
	at system.services.presideobjects.presideobjectservice_cfc$cf.udfCall(/preside/system/services/presideObjects/PresideObjectService.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.type.scope.UndefinedImpl.callWithNamedValues(UndefinedImpl.java:781)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.services.presideobjects.presideobjectservice_cfc$cf.udfCall5(/preside/system/services/presideObjects/PresideObjectService.cfc:1730)
	at system.services.presideobjects.presideobjectservice_cfc$cf.udfCall(/preside/system/services/presideObjects/PresideObjectService.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.type.scope.UndefinedImpl.callWithNamedValues(UndefinedImpl.java:781)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.services.presideobjects.presideobjectservice_cfc$cf.udfCall1(/preside/system/services/presideObjects/PresideObjectService.cfc:213)
	at system.services.presideobjects.presideobjectservice_cfc$cf.udfCall(/preside/system/services/presideObjects/PresideObjectService.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:698)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:1935)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.services.presideobjects.presideobjectviewservice_cfc$cf.udfCall1(/preside/system/services/presideObjects/PresideObjectViewService.cfc:104)
	at system.services.presideobjects.presideobjectviewservice_cfc$cf.udfCall(/preside/system/services/presideObjects/PresideObjectViewService.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:698)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:1935)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.helpers.presideproxies_cfm$cf.udfCall1(/preside/system/helpers/presideProxies.cfm:27)
	at system.helpers.presideproxies_cfm$cf.udfCall(/preside/system/helpers/presideProxies.cfm)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.type.scope.UndefinedImpl.callWithNamedValues(UndefinedImpl.java:781)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.handlers.core.sitetreepagerequesthandler_cfc$cf.udfCall(/preside/system/handlers/core/SiteTreePageRequestHandler.cfc:68)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:698)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:1931)
	at lucee.runtime.tag.Invoke.doComponent(Invoke.java:221)
	at lucee.runtime.tag.Invoke.doEndTag(Invoke.java:194)
	at system.web.controller_cfc$cf.udfCall6(/coldbox/system/web/Controller.cfc:764)
	at system.web.controller_cfc$cf.udfCall(/coldbox/system/web/Controller.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:225)
	at lucee.runtime.type.scope.UndefinedImpl.call(UndefinedImpl.java:772)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:755)
	at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:1697)
	at system.web.controller_cfc$cf.udfCall5(/coldbox/system/web/Controller.cfc:648)
	at system.web.controller_cfc$cf.udfCall(/coldbox/system/web/Controller.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:211)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:698)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:1935)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:825)
	at lucee.runtime.PageContextImpl.getFunctionWithNamedValues(PageContextImpl.java:1712)
	at system.coldboxmodifications.bootstrap_cfc$cf.udfCall(/preside/system/coldboxModifications/Bootstrap.cfc:117)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:225)
	at lucee.runtime.type.scope.UndefinedImpl.call(UndefinedImpl.java:772)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:755)
	at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:1697)
	at system.coldboxmodifications.bootstrap_cfc$cf.udfCall(/preside/system/coldboxModifications/Bootstrap.cfc:22)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:225)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:697)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.call(ComponentImpl.java:1918)
	at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:755)
	at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:1697)
	at preside.system.bootstrap_cfc$cf.udfCall1(/preside/system/Bootstrap.cfc:42)
	at preside.system.bootstrap_cfc$cf.udfCall(/preside/system/Bootstrap.cfc)
	at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:106)
	at lucee.runtime.type.UDFImpl._call(UDFImpl.java:338)
	at lucee.runtime.type.UDFImpl.call(UDFImpl.java:225)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:697)
	at lucee.runtime.ComponentImpl._call(ComponentImpl.java:580)
	at lucee.runtime.ComponentImpl.call(ComponentImpl.java:1918)
	at lucee.runtime.listener.ModernAppListener.call(ModernAppListener.java:422)
	at lucee.runtime.listener.ModernAppListener._onRequest(ModernAppListener.java:134)
	at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:43)
	at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2394)
	at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2385)
	at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2353)
	at lucee.runtime.engine.CFMLEngineImpl.serviceCFML(CFMLEngineImpl.java:907)
	at lucee.loader.engine.CFMLEngineWrapper.serviceCFML(CFMLEngineWrapper.java:102)
	at lucee.loader.servlet.CFMLServlet.service(CFMLServlet.java:62)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)
	at org.cfmlprojects.regexpathinfofilter.RegexPathInfoFilter.doFilter(RegexPathInfoFilter.java:47)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:274)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchToPath(ServletInitialHandler.java:209)
	at io.undertow.servlet.spec.RequestDispatcherImpl.forwardImpl(RequestDispatcherImpl.java:221)
	at io.undertow.servlet.spec.RequestDispatcherImpl.forwardImplSetup(RequestDispatcherImpl.java:147)
	at io.undertow.servlet.spec.RequestDispatcherImpl.forward(RequestDispatcherImpl.java:111)
	at org.tuckey.web.filters.urlrewrite.NormalRewrittenUrl.doRewrite(NormalRewrittenUrl.java:213)
	at org.tuckey.web.filters.urlrewrite.RuleChain.handleRewrite(RuleChain.java:171)
	at org.tuckey.web.filters.urlrewrite.RuleChain.doRules(RuleChain.java:145)
	at org.tuckey.web.filters.urlrewrite.UrlRewriter.processRequest(UrlRewriter.java:92)
	at org.tuckey.web.filters.urlrewrite.UrlRewriteFilter.doFilter(UrlRewriteFilter.java:389)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:292)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:138)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
	at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:272)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:104)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:211)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:809)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

Although there's a way to disable `only_full_group_by setting` in MySQL (http://stackoverflow.com/a/35729681), I don't feel it's the right way to do it.

