### PR TITLE
Feature PRESIDECMS-858 - Fix the time on the task manager once run time starts evaluating minutes hours

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"PresideCMS",
-    "version":"10.7.41",
+    "version":"10.7.42",
     "author":"Pixl8 Interactive",
     "createPackageDirectory":true,
     "packageDirectory":"preside",

--- a/box.json.no.deps
+++ b/box.json.no.deps
@@ -1,6 +1,6 @@
 {
     "name":"PresideCMS",
-    "version":"10.7.41",
+    "version":"10.7.42",
     "author":"Pixl8 Interactive",
     "createPackageDirectory":true,
     "packageDirectory":"preside",

--- a/support/build/build.properties
+++ b/support/build/build.properties
@@ -2,5 +2,5 @@ build.number.remote.url=http://downloads.presidecms.com/presidecms/build.number
 
 ##############################
 # MANUALLY UPDATE EACH VERSION
-preside.version=10.7.41
+preside.version=10.7.42
 ##############################

--- a/system/handlers/renderers/content/TaskTimeTaken.cfc
+++ b/system/handlers/renderers/content/TaskTimeTaken.cfc
@@ -1,4 +1,4 @@
-component output=false {
+component {
 
 	public string function default( event, rc, prc, args={} ){
 		var data    = Val( args.data ?: "" );
@@ -11,17 +11,17 @@ component output=false {
 			return "< 1s"
 		}
 
-		data = data / 1000;
+		data = data \ 1000;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "s";
 		}
 
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "m";
 		}
 
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 24 ) {
 			return NumberFormat( data ) & "h";
 		}
@@ -41,19 +41,19 @@ component output=false {
 			return "< 1s"
 		}
 
-		data = data / 1000;
+		data = data \ 1000;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "s";
 		}
 
 		remainder = data mod 60;
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "m " & NumberFormat( remainder ) & "s";
 		}
 
 		remainder = data mod 60;
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 24 ) {
 			return NumberFormat( data ) & "h " & NumberFormat( data ) & "m " & NumberFormat( remainder mod 60 ) & "s";
 		}

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -503,7 +503,7 @@ component {
 			var fieldRelationship = _getPresideObjectService().getObjectProperties( arguments.objectName )["#orderByField#"].relationship ?: "";
 
 			if ( fieldRelationship == "many-to-one" ) {
-				var relatedLabelField = _getFullFieldName( "label", _getPresideObjectService().getObjectProperties( arguments.objectName )["#orderByField#"].relatedTo );
+				var relatedLabelField = _getFullFieldName( "${labelfield}", _getPresideObjectService().getObjectProperties( arguments.objectName )["#orderByField#"].relatedTo );
 
 				return relatedLabelField & " " & ListRest( arguments.orderBy, " " );
 			}


### PR DESCRIPTION
Using the integer division operator "\" rather than the standard division operator "/" we get the integer result back for minutes which is then NOT rounded up and causing inaccuracy in the displayed time taken