### PR TITLE
Feature PRESIDECMS-858 - Fix the time on the task manager once run time starts evaluating minutes

### DIFF
--- a/system/handlers/renderers/content/TaskTimeTaken.cfc
+++ b/system/handlers/renderers/content/TaskTimeTaken.cfc
@@ -11,17 +11,17 @@ component output=false {
 			return "< 1s"
 		}
 
-		data = data / 1000;
+		data = data \ 1000;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "s";
 		}
 
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "m";
 		}
 
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 24 ) {
 			return NumberFormat( data ) & "h";
 		}
@@ -41,19 +41,19 @@ component output=false {
 			return "< 1s"
 		}
 
-		data = data / 1000;
+		data = data \ 1000;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "s";
 		}
 
 		remainder = data mod 60;
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 60 ) {
 			return NumberFormat( data ) & "m " & NumberFormat( remainder ) & "s";
 		}
 
 		remainder = data mod 60;
-		data = data / 60;
+		data = data \ 60;
 		if ( data < 24 ) {
 			return NumberFormat( data ) & "h " & NumberFormat( data ) & "m " & NumberFormat( remainder mod 60 ) & "s";
 		}


### PR DESCRIPTION
Switching to the integer division operator means there is no remainder making the time tak calculations more accurate when the seconds accumulate over the 30 second mark for each minute.