### PR TITLE
PRESIDECMS-675: ensuring uniqueness of HTML element IDs 

### DIFF
--- a/system/views/formcontrols/checkboxList/index.cfm
+++ b/system/views/formcontrols/checkboxList/index.cfm
@@ -1,36 +1,37 @@
 <cfscript>
-	inputName      = args.name            ?: "";
-	inputId        = args.id              ?: "";
-	inputClass     = args.class           ?: "";
-	values         = args.values          ?: "";
-	defaultValue   = args.defaultValue    ?: "";
-	extraClasses   = args.extraClasses    ?: "";
-	values         = args.values          ?: "";
-	labels         = len( args.labels )   ?  args.labels : args.values;
+    inputName      = args.name            ?: "";
+    inputId        = args.id              ?: "";
+    inputClass     = args.class           ?: "";
+    values         = args.values          ?: "";
+    defaultValue   = args.defaultValue    ?: "";
+    extraClasses   = args.extraClasses    ?: "";
+    values         = args.values          ?: "";
+    labels         = len( args.labels )   ?  args.labels : args.values;
 
-	if ( IsSimpleValue( values ) ) { values = ListToArray( values ); }
-	if ( IsSimpleValue( labels ) ) { labels = ListToArray( labels ); }
+    if ( IsSimpleValue( values ) ) { values = ListToArray( values ); }
+    if ( IsSimpleValue( labels ) ) { labels = ListToArray( labels ); }
 
-	value  = event.getValue( name=inputName, defaultValue=defaultValue );
-	if ( not IsSimpleValue( value ) ) {
-		value = "";
-	}
+    value  = event.getValue( name=inputName, defaultValue=defaultValue );
+    if ( not IsSimpleValue( value ) ) {
+        value = "";
+    }
 
-	value = HtmlEditFormat( value );
-	valueFound = false;
+    value = HtmlEditFormat( value );
+    valueFound = false;
 </cfscript>
 
 <cfoutput>
-	<cfloop array="#values#" index="i" item="selectValue">
-		<cfset checked   = ListFindNoCase( value, selectValue ) />
-		<cfset valueFound = valueFound || checked />
+    <cfloop array="#values#" index="i" item="selectValue">
+        <cfset checked    = ListFindNoCase( value, selectValue ) />
+        <cfset valueFound = valueFound || checked />
+        <cfset elementId  = inputId & "_" & i />
 
-		<div class="checkbox">
-			<label>
-				<input type="checkbox" id="#inputId#" name="#inputName#" value="#HtmlEditFormat( selectValue )#" class="#inputClass# #extraClasses#" tabindex="#getNextTabIndex()#" <cfif checked>checked</cfif>>
-				#HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#
-			</label>
-		</div>
-	</cfloop>
-	<label for="#inputName#" class="error"></label>
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" id="#elementId#" name="#inputName#" value="#HtmlEditFormat( selectValue )#" class="#inputClass# #extraClasses#" tabindex="#getNextTabIndex()#" <cfif checked>checked</cfif>>
+                #HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#
+            </label>
+        </div>
+    </cfloop>
+    <label for="#inputName#" class="error"></label>
 </cfoutput>

--- a/system/views/formcontrols/matrix/index.cfm
+++ b/system/views/formcontrols/matrix/index.cfm
@@ -1,51 +1,52 @@
 <cfscript>
-	inputName        = args.name         ?: "";
-	inputId          = args.id           ?: "";
-	inputClass       = args.class        ?: "";
-	defaultValue     = args.defaultValue ?: "";
-	rows             = args.rows         ?: [];
-	columns          = args.columns      ?: [];
-	questionInputIds = args.questionInputIds ?: [];
-	multiple     = IsTrue( args.multiple ?: "" );
+    inputName        = args.name         ?: "";
+    inputId          = args.id           ?: "";
+    inputClass       = args.class        ?: "";
+    defaultValue     = args.defaultValue ?: "";
+    rows             = args.rows         ?: [];
+    columns          = args.columns      ?: [];
+    questionInputIds = args.questionInputIds ?: [];
+    multiple     = IsTrue( args.multiple ?: "" );
 
-	value = event.getValue( name=inputName, defaultValue=defaultValue );
-	if ( not IsSimpleValue( value ) ) {
-		value = "";
-	}
+    value = event.getValue( name=inputName, defaultValue=defaultValue );
+    if ( not IsSimpleValue( value ) ) {
+        value = "";
+    }
 
-	value = HtmlEditFormat( value );
-	valueFound = false;
-	inputType = multiple ? 'checkbox' : 'radio';
+    value = HtmlEditFormat( value );
+    valueFound = false;
+    inputType = multiple ? 'checkbox' : 'radio';
 </cfscript>
 
 <cfoutput>
-	<table class="table">
-		<tr>
-			<td>&nbsp;</td>
-			<cfloop array="#columns#" index="i" item="answer">
-				<td><label>#answer#</label></td>
-			</cfloop>
-		</tr>
-		<cfloop array="#rows#" item="question" index="i">
-			<cfset questionInputId = questionInputIds[ i ] ?: question />
-			<tr>
-				<td>
-					<label>#question#</label>
-					<label class="error"></label>
-				</td>
-				<cfloop array="#columns#" index="i" item="answer">
-					<cfset selected = ListFindNoCase( value, answer ) />
-					<td>
-						<input type     = "#inputType#"
-						       class    = "#inputClass#"
-						       name     = "#questionInputId#"
-						       id       = "#questionInputId#"
-						       tabindex = "#getNextTabIndex()#"
-						       value    = "#HtmlEditFormat( answer )#"
-						       <cfif selected> checked="checked"</cfif> >
-					</td>
-				</cfloop>
-			</tr>
-		</cfloop>
-	</table>
+    <table class="table">
+        <tr>
+            <td>&nbsp;</td>
+            <cfloop array="#columns#" index="i" item="answer">
+                <td><label>#answer#</label></td>
+            </cfloop>
+        </tr>
+        <cfloop array="#rows#" item="question" index="i">
+            <cfset questionInputId = questionInputIds[ i ] ?: question />
+            <tr>
+                <td>
+                    <label>#question#</label>
+                    <label class="error"></label>
+                </td>
+                <cfloop array="#columns#" index="j" item="answer">
+                    <cfset selected  = ListFindNoCase( value, answer ) />
+                    <cfset elementId = questionInputId & "_" & j />
+                    <td>
+                        <input type     = "#inputType#"
+                               class    = "#inputClass#"
+                               name     = "#questionInputId#"
+                               id       = "#elementId#"
+                               tabindex = "#getNextTabIndex()#"
+                               value    = "#HtmlEditFormat( answer )#"
+                               <cfif selected> checked="checked"</cfif> >
+                    </td>
+                </cfloop>
+            </tr>
+        </cfloop>
+    </table>
 </cfoutput>

--- a/system/views/formcontrols/radio/index.cfm
+++ b/system/views/formcontrols/radio/index.cfm
@@ -1,42 +1,43 @@
 <cfscript>
-	inputName      = args.name            ?: "";
-	inputId        = args.id              ?: "";
-	inputClass     = args.class           ?: "";
-	values         = args.values          ?: "";
-	defaultValue   = args.defaultValue    ?: "";
-	extraClasses   = args.extraClasses    ?: "";
-	values         = args.values          ?: "";
-	labels         = len( args.labels )   ?  args.labels : args.values;
+    inputName      = args.name            ?: "";
+    inputId        = args.id              ?: "";
+    inputClass     = args.class           ?: "";
+    values         = args.values          ?: "";
+    defaultValue   = args.defaultValue    ?: "";
+    extraClasses   = args.extraClasses    ?: "";
+    values         = args.values          ?: "";
+    labels         = len( args.labels )   ?  args.labels : args.values;
 
-	if ( IsSimpleValue( values ) ) { values = ListToArray( values ); }
-	if ( IsSimpleValue( labels ) ) { labels = ListToArray( labels ); }
+    if ( IsSimpleValue( values ) ) { values = ListToArray( values ); }
+    if ( IsSimpleValue( labels ) ) { labels = ListToArray( labels ); }
 
-	value  = event.getValue( name=inputName, defaultValue=defaultValue );
-	if ( not IsSimpleValue( value ) ) {
-		value = "";
-	}
+    value  = event.getValue( name=inputName, defaultValue=defaultValue );
+    if ( not IsSimpleValue( value ) ) {
+        value = "";
+    }
 
-	value = HtmlEditFormat( value );
-	valueFound = false;
+    value = HtmlEditFormat( value );
+    valueFound = false;
 </cfscript>
 
 <cfoutput>
-	<cfloop array="#values#" index="i" item="selectValue">
-		<cfset checked   = ListFindNoCase( value, selectValue ) />
-		<cfset valueFound = valueFound || checked />
+    <cfloop array="#values#" index="i" item="selectValue">
+        <cfset checked    = ListFindNoCase( value, selectValue ) />
+        <cfset valueFound = valueFound || checked />
+        <cfset elementId  = inputId & "_" & i />
 
-		<div class="radio">
-		  	<label>
-		  		<input type="radio"
-		  		   id="#inputId#"
-		  		   name="#inputName#"
-		  		   value="#HtmlEditFormat( selectValue )#"
-		  		   class="#inputClass# #extraClasses#"
-		  		   tabindex="#getNextTabIndex()#"
-		  		   <cfif checked>checked</cfif>>
-		  		   #HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#
-			</label>
-		</div>
-	</cfloop>
-	<label for="#inputName#" class="error"></label>
+        <div class="radio">
+            <label>
+                <input type="radio"
+                   id="#elementId#"
+                   name="#inputName#"
+                   value="#HtmlEditFormat( selectValue )#"
+                   class="#inputClass# #extraClasses#"
+                   tabindex="#getNextTabIndex()#"
+                   <cfif checked>checked</cfif>>
+                   #HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#
+            </label>
+        </div>
+    </cfloop>
+    <label for="#inputName#" class="error"></label>
 </cfoutput>


### PR DESCRIPTION
...for generated radio/checkbox formcontrols

Sorry for the indentation mess. In my editor it showed up as tab-indented and I changed it to indent using 4 spaces (i thought that is used in Preside by default). Therefore the whole indentation changed. :-(

The real changes are:
- added loop index as a suffix to input element IDs for checkbox/radio lists and the matrix control
- renamed the inner loop index variable on the matrix formcontrol ('i' was used twice)