### PR TITLE
Feature presidecms 921 excel export invalid characters in name too long

### DIFF
--- a/system/handlers/dataExporters/Excel.cfc
+++ b/system/handlers/dataExporters/Excel.cfc
@@ -23,6 +23,7 @@ component {
 		var objectUriRoot = presideObjectService.getResourceBundleUriRoot( arguments.objectName );
 		var objectTitle   = translateResource( uri=objectUriRoot & "title", defaultValue=arguments.objectname );
 
+		objectTitle = Left( objectTitle, 31 );
 		spreadsheetLib.renameSheet( workbook, objectTitle, 1 );
 
 		for( var i=1; i <= arguments.selectFields.len(); i++ ){


### PR DESCRIPTION
Simple fix to ensure a sheet title doesn't exceed the 31 character limit given the title comes from the objects i18n