### PR TITLE
PRESIDECMS-937: Check field type before comparing old with new data

### DIFF
--- a/system/services/presideObjects/VersioningService.cfc
+++ b/system/services/presideObjects/VersioningService.cfc
@@ -251,16 +251,27 @@ component {
 					changedFields.append( field );
 				}
 			} else {
-				var propDbType = ( properties[ field ].dbtype ?: "" );
-				if ( IsEmpty( arguments.newData[ field ] ?: "" ) ) {
-					if ( propDbType == "boolean" ) {
-						arguments.newData[ field ] = 0;
-					}
+
+				if ( !StructKeyExists( oldData, field ) ) {
+					continue;
 				}
-				if ( StructKeyExists( oldData, field ) && Compare( oldData[ field ], arguments.newData[ field ] ?: "" ) ) {
+
+				var propDbType = ( properties[ field ].dbtype ?: "" );
+
+				if ( propDbType == "boolean" && IsEmpty( arguments.newData[ field ] ?: "" ) ) {
+					arguments.newData[ field ] = 0;
+				}
+
+				if ( ( propDbType == "datetime" || propDbType == "date" ) && isDate( arguments.newData[ field ] ?: "" ) ) {
+					if ( dateCompare( oldData[ field ], arguments.newData[ field ] ) ) {
+						changedFields.append( field );
+					}
+
+				} else if ( Compare( oldData[ field ], arguments.newData[ field ] ?: "" ) ) {
 					changedFields.append( field );
 				}
 			}
+
 		}
 
 		return changedFields;


### PR DESCRIPTION
Now checking for dbtype date/datetime and using dateCompare instead of Compare