### PR TITLE
PRESIDECMS-955 check stickerBundle file prior to processing

### DIFF
--- a/system/plugins/StickerForPreside.cfc
+++ b/system/plugins/StickerForPreside.cfc
@@ -36,9 +36,9 @@ component extends="coldbox.system.Plugin" output="false" singleton="true" {
 		       .addBundle( rootDirectory=siteAssetsPath, rootUrl=rootUrl & siteAssetsUrl, config=settings );
 
 		for( var ext in settings.activeExtensions ) {
-			try {
+			if ( fileExists( ( ext.directory ?: "" ) & "/assets/StickerBundle.cfc" ) ) {
 				sticker.addBundle( rootDirectory=( ext.directory ?: "" ) & "/assets", rootUrl=extensionsRootUrl & ListLast( ext.directory, "\/" ) & "/assets" );
-			} catch ( any e ) {}
+			}
 		}
 
 		sticker.load();


### PR DESCRIPTION
 Replace try catch statement with StickerBundle file exists check to reveal any hidden asset definition error