### PR TITLE
Lucee 5 hint "Manual install of Preside"

### DIFF
--- a/support/docs/docs/04.serverguides/01.serversetupfoundation/page.md
+++ b/support/docs/docs/04.serverguides/01.serversetupfoundation/page.md
@@ -65,7 +65,9 @@ PresideCMS requires the use of a couple of non-default settings in Lucee that ca
 
 ### Preserve case for structs
 
-Log in to the Lucee _Server_ admin and go to **Settings -> Language/Compiler**. Choose the **"Keep original case"** option for the **Dot notation** setting and hit **update**.
+Log in to the Lucee _Server_ admin and go to **Settings -> Language/Compiler**. 
+(Lucee 4.x) Choose the **"Keep original case"** option for the **Dot notation** setting and hit **update**.
+(Lucee 5.x) Choose the **"Preserve case"** option for the **Key case** setting and hit **update**.
 
 ### Lucee Admin API password
 


### PR DESCRIPTION
I installed PresideCMS on a new testing and integration server manually. I followed the setup and was not able to find the correct settings. Lucee 5 (I use Lucee 5.2.4.37) has changed the the names. I suppose other "newbies" to Lucee will be unsure about the correct setting.

... at least the documentation should be up2date.