### PR TITLE
PRESIDECMS-1110: MSSQL does not work with MAX function on a bit column type

### DIFF
--- a/support/tests/integration/api/security/PermissionServiceTest.cfc
+++ b/support/tests/integration/api/security/PermissionServiceTest.cfc
@@ -277,9 +277,9 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		permsService.$( "listUserGroups" ).$args( user="me" ).$results( [ "somegroup", "anothergroup" ] );
 
 		mockContextPermDao.$( "selectData" ).$args(
-			  selectFields = [ "Max( granted ) as granted", "context_key" ]
+			  selectFields = [ "granted", "context_key" ]
 			, filter       = { context = "someContext", permission_key = "a.new.key", security_group = [ "somegroup", "anothergroup" ] }
-			, groupBy      = "context_key"
+			, orderBy      = "context_key, granted"
 			, useCache     = false
 		).$results( mockContextPerms );
 
@@ -300,9 +300,9 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		permsService.$( "listUserGroups" ).$args( user="me" ).$results( [ "somegroup", "anothergroup" ] );
 
 		mockContextPermDao.$( "selectData" ).$args(
-			  selectFields = [ "Max( granted ) as granted", "context_key" ]
+			  selectFields = [ "granted", "context_key" ]
 			, filter       = { context = "someContext", permission_key = "a.new.key", security_group = [ "somegroup", "anothergroup" ] }
-			, groupBy      = "context_key"
+			, orderBy      = "context_key, granted"
 			, useCache     = false
 		).$results( mockContextPerms );
 
@@ -323,9 +323,9 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		permsService.$( "listUserGroups" ).$args( user="me" ).$results( [ "somegroup", "anothergroup" ] );
 
 		mockContextPermDao.$( "selectData" ).$args(
-			  selectFields = [ "Max( granted ) as granted", "context_key" ]
+			  selectFields = [ "granted", "context_key" ]
 			, filter       = { context = "someContext", permission_key = "my.perm.key", security_group = [ "somegroup", "anothergroup" ] }
-			, groupBy      = "context_key"
+			, orderBy      = "context_key, granted"
 			, useCache     = false
 		).$results( mockContextPerms );
 
@@ -350,9 +350,9 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		permsService.$( "listUserGroups" ).$args( user="me" ).$results( [ "somegroup", "anothergroup" ] );
 
 		mockContextPermDao.$( "selectData" ).$args(
-			  selectFields = [ "Max( granted ) as granted", "context_key" ]
+			  selectFields = [ "granted", "context_key" ]
 			, filter       = { context = "someContext", permission_key = "a.new.key", security_group = [ "somegroup", "anothergroup" ] }
-			, groupBy      = "context_key"
+			, orderBy      = "context_key, granted"
 			, useCache     = false
 		).$results( mockContextPerms );
 
@@ -508,9 +508,9 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		permsService.$( "listUserGroups" ).$args( user="me" ).$results( [ "somegroup", "anothergroup" ] );
 
 		mockContextPermDao.$( "selectData" ).$args(
-			  selectFields = [ "Max( granted ) as granted", "context_key" ]
+			  selectFields = [ "granted", "context_key" ]
 			, filter       = { context = "someContext", permission_key = "a.new.key", security_group = [ "somegroup", "anothergroup" ] }
-			, groupBy      = "context_key"
+			, orderBy      = "context_key, granted"
 			, useCache     = false
 		).$results( mockContextPerms );
 

--- a/system/services/security/PermissionService.cfc
+++ b/system/services/security/PermissionService.cfc
@@ -319,9 +319,9 @@ component displayName="Admin permissions service" {
 		var cachedContextPerms = _getCacheProvider().getOrSet( objectKey=cacheKey, produce=function(){
 			var permsToCache = {};
 			var permsFromDb  = _getContextPermDao().selectData(
-				  selectFields = [ "Max( granted ) as granted", "context_key" ]
+				  selectFields = [ "granted", "context_key" ]
 				, filter       = { context = args.context, permission_key = args.permissionKey, security_group = userGroups }
-				, groupBy      = "context_key"
+				, orderBy      = "context_key, granted"
 				, useCache     = false
 			);
 


### PR DESCRIPTION
My first PR and hope it works. 
I tried the perform the unit tests but had technical problems with it (out of memory 2GB RAM)  and must investigate (spend more time).

I used an MSSQL 2016 database server and the problem came up while login with a new backend user.
Before it was used withe sysadmin only.