### PR TITLE
PRESIDECMS-1119 Aligned attribute value to the used value in the adapters

### DIFF
--- a/system/preside-objects/assetManager/asset.cfc
+++ b/system/preside-objects/assetManager/asset.cfc
@@ -16,7 +16,7 @@ component extends="preside.system.base.SystemPresideObject" labelfield="title" o
 	property name="raw_text_content"  type="string"  dbtype="longtext";
 	property name="width"             type="numeric" dbtype="int"                       required=false;
 	property name="height"            type="numeric" dbtype="int"                       required=false;
-	property name="active_version"    relationship="many-to-one" relatedTo="asset_version" required=false ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
+	property name="active_version"    relationship="many-to-one" relatedTo="asset_version" required=false ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 
 	property name="is_trashed"        type="boolean" dbtype="boolean"                   required=false default=false;
 	property name="trashed_path"      type="string"  dbtype="varchar" maxLength=255     required=false;
@@ -27,7 +27,7 @@ component extends="preside.system.base.SystemPresideObject" labelfield="title" o
 	property name="full_login_required"                  type="boolean" dbtype="boolean"               required=false default=false;
 	property name="grantaccess_to_all_logged_in_users"   type="boolean" dbtype="boolean"               required=false default=false;
 
-	property name="access_condition" relationship="many-to-one" relatedto="rules_engine_condition" required=false control="conditionPicker" ruleContext="webrequest" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
-	property name="created_by"       relationship="many-to-one" relatedTo="security_user"          required=false generator="loggedInUserId"  ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
-	property name="updated_by"       relationship="many-to-one" relatedTo="security_user"          required=false generator="loggedInUserId"  ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
+	property name="access_condition" relationship="many-to-one" relatedto="rules_engine_condition" required=false control="conditionPicker" ruleContext="webrequest" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
+	property name="created_by"       relationship="many-to-one" relatedTo="security_user"          required=false generator="loggedInUserId"  ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
+	property name="updated_by"       relationship="many-to-one" relatedTo="security_user"          required=false generator="loggedInUserId"  ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 }

--- a/system/preside-objects/assetManager/asset_folder.cfc
+++ b/system/preside-objects/assetManager/asset_folder.cfc
@@ -20,6 +20,6 @@ component output="false" extends="preside.system.base.SystemPresideObject" displ
 	property name="storage_location" relationship="many-to-one" relatedTo="asset_storage_location" required=false;
 	property name="access_condition" relationship="many-to-one" relatedto="rules_engine_condition" required=false control="conditionPicker" ruleContext="webrequest";
 
-	property name="created_by"  relationship="many-to-one" relatedTo="security_user" required="false" generator="loggedInUserId" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
-	property name="updated_by"  relationship="many-to-one" relatedTo="security_user" required="false" generator="loggedInUserId" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
+	property name="created_by"  relationship="many-to-one" relatedTo="security_user" required="false" generator="loggedInUserId" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
+	property name="updated_by"  relationship="many-to-one" relatedTo="security_user" required="false" generator="loggedInUserId" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 }

--- a/system/preside-objects/assetManager/asset_version.cfc
+++ b/system/preside-objects/assetManager/asset_version.cfc
@@ -20,7 +20,7 @@ component extends="preside.system.base.SystemPresideObject" labelfield="title" o
 	property name="is_trashed"   type="boolean" dbtype="boolean"               required=false default=false;
 	property name="trashed_path" type="string"  dbtype="varchar" maxLength=255 required=false;
 
-	property name="created_by"  relationship="many-to-one" relatedTo="security_user" required=false generator="loggedInUserId" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
-	property name="updated_by"  relationship="many-to-one" relatedTo="security_user" required=false generator="loggedInUserId" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
+	property name="created_by"  relationship="many-to-one" relatedTo="security_user" required=false generator="loggedInUserId" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
+	property name="updated_by"  relationship="many-to-one" relatedTo="security_user" required=false generator="loggedInUserId" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 
 }

--- a/system/preside-objects/core/page.cfc
+++ b/system/preside-objects/core/page.cfc
@@ -17,7 +17,7 @@ component extends="preside.system.base.SystemPresideObject" labelfield="title" o
 	property name="trashed"      type="boolean" dbtype="boolean"                  required=false default=false control="none";
 	property name="old_slug"     type="string"  dbtype="varchar" maxLength="50"   required=false;
 
-	property name="main_image"       relationship="many-to-one" relatedTo="asset"                   required=false allowedTypes="image" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
+	property name="main_image"       relationship="many-to-one" relatedTo="asset"                   required=false allowedTypes="image" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 	property name="parent_page"      relationship="many-to-one" relatedTo="page"                    required=false                     uniqueindexes="slug|1" control="none"  ondelete="cascade-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 	property name="created_by"       relationship="many-to-one" relatedTo="security_user"           required=true                                             control="none" generator="loggedInUserId" onupdate="cascade-if-no-cycle-check";
 	property name="updated_by"       relationship="many-to-one" relatedTo="security_user"           required=true                                             control="none" generator="loggedInUserId" onupdate="cascade-if-no-cycle-check";

--- a/system/preside-objects/email/email_template.cfc
+++ b/system/preside-objects/email/email_template.cfc
@@ -20,7 +20,7 @@ component extends="preside.system.base.SystemPresideObject" displayname="Email t
 	property name="attachments" relationship="many-to-many" relatedto="asset" relatedVia="email_template_attachment";
 
 	property name="email_blueprint"  relationship="many-to-one" relatedTo="email_blueprint";
-	property name="recipient_filter" relationship="many-to-one" relatedto="rules_engine_condition" ondelete="set-null-if-no-cascade-check" onupdate="cascade-if-no-cycle-check";
+	property name="recipient_filter" relationship="many-to-one" relatedto="rules_engine_condition" ondelete="set-null-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
 
 	property name="sending_method" type="string" dbtype="varchar" maxlength=20 required=false default="auto" enum="emailSendingMethod" ignoreChangesForVersioning=true;
 


### PR DESCRIPTION
changed  attributes 
from: ondelete="set-null-if-no-cascade-check" 
to: ondelete="set-null-if-no-cycle-check"

value is used in the BaseAdapter and MSSqlAdater to handle MSSQL specific cascading issues