### PR TITLE
Fix edit websiteuser permission

### DIFF
--- a/system/handlers/admin/WebsiteUserManager.cfc
+++ b/system/handlers/admin/WebsiteUserManager.cfc
@@ -101,7 +101,7 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	function editUserAction( event, rc, prc ) {
-		_checkPermissions( event=event, key="usermanager.edit" );
+		_checkPermissions( event=event, key="websiteUserManager.edit" );
 
 		runEvent(
 			  event          = "admin.dataManager._editRecordAction"


### PR DESCRIPTION
Wrong permissions was evaluated when editing a website user in the Preside admin.