### PR TITLE
Feature presidecms 1180 form builder no grou java.lang.index out of bounds exception error

### DIFF
--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -408,12 +408,13 @@ component {
 	) {
 		arguments.type = arguments.type == "text" ? "text" : "html";
 		var replaced = JavaCast( "String", arguments.text );
+		var Matcher  = CreateObject( "java", "java.util.regex.Matcher" );
 
 		for( var paramName in arguments.params ) {
 			var token = "(?i)\Q${#paramName#}\E";
 			var value = IsSimpleValue( arguments.params[ paramName ] ) ? arguments.params[ paramName ] : ( arguments.params[ paramName ][ arguments.type ] ?: "" );
 
-			replaced = replaced.replaceAll( token, value );
+			replaced = replaced.replaceAll( token, Matcher.quoteReplacement( value ) );
 		}
 
 		return replaced;


### PR DESCRIPTION
fixed the java error due to user insert a value such as '$6' cause java interprets this as a reference to a capturing group, and looks for that group in the regex match