### PR TITLE
PRESIDECMS-1202: get records before getting record counts for pagination

### DIFF
--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -295,15 +295,15 @@ component {
 			result.totalRecords = result.records.recordCount;
 		} else {
 			args = {
-				  objectName      = arguments.objectName
-				, id              = arguments.recordId
-				, recordCountOnly = true
+				  objectName = arguments.objectName
+				, id         = arguments.recordId
 			};
+
 			if ( Len( Trim( arguments.property ) ) ) {
 				args.fieldName = arguments.property;
 			}
 
-			result.totalRecords = _getPresideObjectService().getRecordVersions( argumentCollection = args );
+			result.totalRecords = _getPresideObjectService().getRecordVersions( argumentCollection = args ).recordCount;
 		}
 
 		return result;


### PR DESCRIPTION
The issue here was `_getPresideObjectService().getRecordVersions()` just returned:
`return selectData( argumentCollection = args );` but because we were using `recordCountOnly=true`, that meant a numeric was being returned instead.

`getRecordVersions` is being used elsewhere so didn't want to change it