### PR TITLE
PRESIDECMS-1230

### DIFF
--- a/system/services/security/CsrfProtectionService.cfc
+++ b/system/services/security/CsrfProtectionService.cfc
@@ -59,7 +59,7 @@ component {
 
 // PRIVATE HELPERS
 	private struct function _getToken() {
-		return _getSessionStorage().getVar( "_csrfToken", {} );
+		return _getSessionStorage().getVar( name="_csrfToken", default={} );
 	}
 
 	private void function _setToken( required struct token ) {


### PR DESCRIPTION
Add parameter name so that it always return with given default value instead of empty string from session storage getVar function

Hi @DominicWatson,

Could you help to merge into 10.8 and 10.9?

Many thanks
J