### PR TITLE
Changed Javaloader dependency to use a fix version

### DIFF
--- a/box.json
+++ b/box.json
@@ -33,7 +33,7 @@
         "cbi18n":"1.3.1+56",
         "cbmessagebox":"2.2.0+10",
         "cbstorages":"1.3.0+14",
-        "cbjavaloader":"^1.3.3+25"
+        "cbjavaloader":"1.5.0+35"
     },
     "devDependencies":{
         "testbox":"2.7.0"


### PR DESCRIPTION
The cbjavaloader dependency used to be a fuzzy version (give me any stable version newer than...) which will be problematic in terms of later rebuilding the same Preside package version. If the javaloader package changes in between the resulting Preside package could differ. Therefore I suggest using a fixed version, which is 1.5.0+35 as of now.