### PR TITLE
PRESIDECMS-1339 Added argument bypassTenants to renderLabel

### DIFF
--- a/system/services/rendering/ContentRendererService.cfc
+++ b/system/services/rendering/ContentRendererService.cfc
@@ -59,6 +59,7 @@ component {
 		, required string recordId
 		,          string keyField      = "id"
 		,          string labelRenderer = $getPresideObjectService().getObjectAttribute( arguments.objectName, "labelRenderer" )
+		,          array bypassTenants = []
 	) {
 
 		var labelRendererService = _getLabelRendererService();
@@ -68,6 +69,7 @@ component {
 			, filter             = { "#keyField#"=arguments.recordId }
 			, selectFields       = selectFields
 			, allowDraftVersions = $getRequestContext().showNonLiveContent()
+			, bypassTenants     = arguments.bypassTenants
 		);
 
 		if ( Len( Trim( arguments.labelRenderer ) ) ) {


### PR DESCRIPTION
i.e. _articles_ published on _pages_ of different _sites_, where _pages_ have tenant="_sites_", 
the labelRenderer needs to be able to bypass the "sites" tenancy to get the label field for the pages object..
