### PR TITLE
PRESIDECMS-1338 OneToManyConfigurator Arguments: add,edit,removable

### DIFF
--- a/system/assets/js/admin/presidecore/preside.object.configurator.js
+++ b/system/assets/js/admin/presidecore/preside.object.configurator.js
@@ -8,6 +8,8 @@
 
 			if ( this.$originalInput.hasClass( 'configurator-add' ) ) {
 				this.setupConfiguratorAdd();
+			}
+			if ( this.$originalInput.hasClass( 'configurator-edit' ) ) {
 			 	this.setupConfiguratorEdit();
 			}
 		}
@@ -19,6 +21,8 @@
 				  allow_single_deselect  : true
 				, inherit_select_classes : true
 				, searchable             : !this.$originalInput.hasClass( 'non-searchable' )
+				, removable              : !this.$originalInput.hasClass( 'non-removable' )
+				, editable               : this.$originalInput.hasClass( 'configurator-edit' )
 			});
 			this.$uberSelect = this.$originalInput.next();
 			this.uberSelect = this.$originalInput.data( "uberSelect" );
@@ -47,17 +51,21 @@
 				if ( item.disabled ) {
 					choice.addClass('search-choice-disabled');
 				} else {
-					edit_link = $('<a />', {
-						"class": 'edit-choice-link fa fa-pencil'
-					});
-					choice.append( edit_link );
-					close_link = $('<a />', {
-						"class": 'remove-choice-link fa fa-times'
-					});
-					close_link.bind('click.chosen', function(evt) {
-						return _this.choice_destroy_link_click(evt);
-					});
-					choice.append( close_link );
+					if(_this.options.editable) {
+						edit_link = $('<a />', {
+							"class": 'edit-choice-link fa fa-pencil'
+						});
+						choice.append( edit_link );
+					}
+					if(_this.options.removable) {
+						close_link = $('<a />', {
+							"class": 'remove-choice-link fa fa-times'
+						});
+						close_link.bind('click.chosen', function(evt) {
+							return _this.choice_destroy_link_click(evt);
+						});
+						choice.append( close_link );
+					}
 				}
 
 				choice.data( "item", item );

--- a/system/handlers/formcontrols/OneToManyConfigurator.cfc
+++ b/system/handlers/formcontrols/OneToManyConfigurator.cfc
@@ -23,6 +23,9 @@ component {
 		args.formName      = args.formName      ?: presideObjectService.getObjectAttribute( targetObject, "configuratorFormName" );
 		args.fields        = args.fields        ?: "";
 		args.targetFields  = args.targetFields  ?: "";
+		args.add           = args.add           ?: true;
+		args.edit          = args.edit          ?: true;
+		args.removable     = args.removable     ?: true;
 
 		return renderView( view="formcontrols/oneToManyConfigurator/index", args=args );
 	}

--- a/system/views/formcontrols/oneToManyConfigurator/index.cfm
+++ b/system/views/formcontrols/oneToManyConfigurator/index.cfm
@@ -8,6 +8,9 @@
 	defaultValue            = args.defaultValue     ?: "";
 	records                 = args.records          ?: QueryNew('');
 	extraClasses            = args.extraClasses     ?: "";
+	addButtonClass          = args.add              ? "configurator-add" : "";
+	editButtonClass         = args.edit             ? "configurator-edit" : "";
+	removableClass          = args.removable        ? "" : "non-removable";
 	multiple                = isBoolean( args.multiple ?: "" ) && args.multiple;
 	sortable                = isBoolean( args.sortable ?: "" ) && args.sortable;
 	disabled                = isBoolean( args.disabled ?: "" ) && args.disabled;
@@ -20,14 +23,15 @@
 	configuratorLabelUrl    = event.buildAdminLink( linkTo="labels.renderJson", querystring="labelRenderer=#labelRenderer#" );
 	configuratorAddUrl      = event.buildAdminLink( linkTo="datamanager.configuratorForm", querystring="object=#object#&formName=#formName#" );
 	objectSingularName      = translateResource( "preside-objects.#object#:title.singular" );
-	configuratorModalTitle  = translateResource( uri=args.quickAddModalTitle ?: "cms:datamanager.configurator.add.modal.title", data=[ lcase( objectSingularName ) ] );
+	configuratorModalTitle  = translateResource( uri=args.quickAddModalTitle ?: "cms:datamanager.configurator.add.modal.title", data=[ objectSingularName ] );
 
 	value = event.getValue( name=inputName, defaultValue=defaultValue );
 	if ( not IsSimpleValue( value ) ) {
 		value = "";
 	}
 
-	extraClasses = ListAppend( extraClasses, "configurator-add non-searchable", ' ' );
+	extraClasses = ListAppend( extraClasses, "#addButtonClass# #editButtonClass# #removableClass# non-searchable", ' ' );
+
 </cfscript>
 
 <cfoutput>


### PR DESCRIPTION
This allows for specifying the available options in oneToManyConfigurator formcontrols.
i.e. Only allow editing of data, but not adding or removing exisiting entries.