### PR TITLE
Feature presidecms 1299 filename encoding for form builder export

### DIFF
--- a/system/services/routeHandlers/PlainStoredFileRouteHandler.cfc
+++ b/system/services/routeHandlers/PlainStoredFileRouteHandler.cfc
@@ -16,7 +16,7 @@ component implements="iRouteHandler" singleton=true {
 	}
 
 	public void function translate( required string path, required any event ) output=false {
-		var storagePath     = ToString( ToBinary( ReReplace( UrlDecode( arguments.path ), "^/file/(.*?)/.*$", "\1" ) ) );
+		var storagePath     = ToString( ToBinary( ReReplace( UrlDecode( arguments.path ), "^/file/(.*?)/.*$", "\1" ) ), "UTF-8" );
 		var storageProvider = ListFirst( storagePath, "/" );
 		var filename        = ListLen( storagePath, "|" ) > 1 ? ListRest( storagePath, "|" ) : ListLast( storagePath, "/" );
 		var derivativeId = "";
@@ -45,7 +45,7 @@ component implements="iRouteHandler" singleton=true {
 			path &= "|" & buildArgs.filename;
 		}
 
-		var link = "/file/#ToBase64( path )#/";
+		var link = "/file/#ToBase64( path, "UTF-8" )#/";
 
 		return event.getSiteUrl( includeLanguageSlug=false ) & link;
 	}


### PR DESCRIPTION
Ensure `toBase64` and `toString` uses UTF-8 encoding instead of pulling default encoding of the page on which the function is called.