### PR TITLE
Fix bug on renderview when cachetimeout is not numeric.

### DIFF
--- a/system/coldboxModifications/services/Renderer.cfc
+++ b/system/coldboxModifications/services/Renderer.cfc
@@ -127,7 +127,7 @@ component accessors="true" serializable="false" singleton="true" extends="coldbo
 		struct args="#getRequestContext().getCurrentViewArgs()#",
 		module="",
 		boolean cache=false,
-		cacheTimeout="",
+		numeric cacheTimeout,
 		cacheLastAccessTimeout="",
 		cacheSuffix="",
 		cacheProvider="template",


### PR DESCRIPTION
Fix bug on renderview when cachetimeout is not numeric causing error in _generateCacheKey which requires numeric value