### PR TITLE
Fix bug on _generateCacheKey that requires numeric cacheTimeout 

### DIFF
--- a/system/services/presideObjects/PresideObjectViewService.cfc
+++ b/system/services/presideObjects/PresideObjectViewService.cfc
@@ -286,8 +286,8 @@ component displayName="Preside Object View Service" {
 		  required string  presideObject
 		, required string  view
 		, required boolean cacheAutoKey
-		,          numeric cacheTimeout
-		,          numeric cacheLastAccessTimeout
+		,          any     cacheTimeout = ""
+		,          any     cacheLastAccessTimeout = ""
 		,          string  cacheSuffix
 		,          string  cacheProvider = "template"
 


### PR DESCRIPTION
Fix bug on _generateCacheKey that requires numeric cacheTimeout and numeric cacheLastAccessTimeout which are default to empty string if not provided