### PR TITLE
PRESIDECMS-1318 Changed default sorting in case pagination is used in MSSQL2012

### DIFF
--- a/system/services/database/adapters/MsSql2012Adapter.cfc
+++ b/system/services/database/adapters/MsSql2012Adapter.cfc
@@ -62,7 +62,7 @@ component extends="MsSqlAdapter" {
 		if ( arguments.maxRows ) {
 			if ( IsEmpty( Trim( arguments.orderBy ) ) ) {
 				// using offset/fetch requires 'order by'
-				sql &= " order by (select 0)";
+				sql &= " order by 1";
 			}
 			sql &= " offset #arguments.startRow-1# rows fetch next #arguments.maxRows# rows only";
 		}


### PR DESCRIPTION
In case "distinct" is used the current "select 0" concept used as default sorting throws an error.
If changing to "select 1" this means it will automatically sort by the first column in the select list.