### PR TITLE
Feature presidecms 1385 cleanup redundant injected dependencies in handlers

### DIFF
--- a/system/handlers/Errors.cfc
+++ b/system/handlers/Errors.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="websiteLoginService" inject="websiteLoginService";
 
 <!--- VIEWLETS --->

--- a/system/handlers/General.cfc
+++ b/system/handlers/General.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="applicationReloadService"    inject="applicationReloadService";
 	property name="databaseMigrationService"    inject="databaseMigrationService";
 	property name="applicationsService"         inject="applicationsService";

--- a/system/handlers/admin/DataHelpers.cfc
+++ b/system/handlers/admin/DataHelpers.cfc
@@ -6,7 +6,6 @@
 component extends="preside.system.base.adminHandler" {
 
 	property name="adminDataViewsService"   inject="adminDataViewsService";
-	property name="dataManagerService"      inject="dataManagerService";
 	property name="presideObjectService"    inject="presideObjectService";
 	property name="dataExportService"       inject="dataExportService";
 	property name="adhocTaskManagerService" inject="adhocTaskManagerService";

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -7,11 +7,9 @@ component extends="preside.system.base.AdminHandler" {
 	property name="customizationService"             inject="dataManagerCustomizationService";
 	property name="dataExportService"                inject="dataExportService";
 	property name="formsService"                     inject="formsService";
-	property name="validationEngine"                 inject="validationEngine";
 	property name="siteService"                      inject="siteService";
 	property name="versioningService"                inject="versioningService";
 	property name="rulesEngineFilterService"         inject="rulesEngineFilterService";
-	property name="adminDataViewsService"            inject="adminDataViewsService";
 	property name="dtHelper"                         inject="jqueryDatatablesHelpers";
 	property name="messageBox"                       inject="messagebox@cbmessagebox";
 	property name="sessionStorage"                   inject="sessionStorage";

--- a/system/handlers/admin/FormBuilder.cfc
+++ b/system/handlers/admin/FormBuilder.cfc
@@ -5,7 +5,6 @@ component extends="preside.system.base.AdminHandler" {
 	property name="itemTypesService"            inject="formBuilderItemTypesService";
 	property name="actionsService"              inject="formBuilderActionsService";
 	property name="messagebox"                  inject="messagebox@cbmessagebox";
-	property name="spreadsheetLib"              inject="spreadsheetLib";
 	property name="adHocTaskManagerService"     inject="adHocTaskManagerService";
 
 

--- a/system/handlers/admin/Login.cfc
+++ b/system/handlers/admin/Login.cfc
@@ -4,8 +4,6 @@ component extends="preside.system.base.AdminHandler" {
 	property name="passwordPolicyService" inject="passwordPolicyService";
 	property name="applicationsService"   inject="applicationsService";
 	property name="sessionStorage"        inject="sessionStorage";
-	property name="messageBox"            inject="messagebox@cbmessagebox";
-	property name="i18n"                  inject="i18n";
 	property name="loginProviderService"  inject="adminLoginProviderService";
 
 

--- a/system/handlers/admin/SiteTree.cfc
+++ b/system/handlers/admin/SiteTree.cfc
@@ -1,9 +1,9 @@
 component extends="preside.system.base.AdminHandler" {
+
 	property name="siteTreeService"                  inject="siteTreeService";
 	property name="presideObjectService"             inject="presideObjectService";
 	property name="formsService"                     inject="formsService";
 	property name="pageTypesService"                 inject="pageTypesService";
-	property name="validationEngine"                 inject="validationEngine";
 	property name="websitePermissionService"         inject="websitePermissionService";
 	property name="dataManagerService"               inject="dataManagerService";
 	property name="versioningService"                inject="versioningService";

--- a/system/handlers/admin/StaticAssetDownload.cfc
+++ b/system/handlers/admin/StaticAssetDownload.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="i18n"       inject="i18n";
 	property name="appMapping" inject="coldbox:setting:appMapping";
 

--- a/system/handlers/admin/UrlRedirects.cfc
+++ b/system/handlers/admin/UrlRedirects.cfc
@@ -1,6 +1,5 @@
 component extends="preside.system.base.AdminHandler" {
 
-	property name="urlRedirectsService" inject="urlRedirectsService";
 	property name="ruleDao"             inject="presidecms:object:url_redirect_rule";
 	property name="messageBox"          inject="messagebox@cbmessagebox";
 

--- a/system/handlers/admin/UserManager.cfc
+++ b/system/handlers/admin/UserManager.cfc
@@ -4,7 +4,6 @@ component extends="preside.system.base.AdminHandler" {
 	property name="loginService"         inject="loginService";
 	property name="permissionService"    inject="permissionService";
 	property name="messageBox"           inject="messagebox@cbmessagebox";
-	property name="bCryptService"        inject="bCryptService";
 
 	function prehandler( event, rc, prc ) output=false {
 		super.preHandler( argumentCollection = arguments );

--- a/system/handlers/admin/WebsiteBenefitsManager.cfc
+++ b/system/handlers/admin/WebsiteBenefitsManager.cfc
@@ -3,7 +3,6 @@ component extends="preside.system.base.AdminHandler" {
 	property name="websitePermissionService" inject="websitePermissionService";
 	property name="websiteBenefitDao"        inject="presidecms:object:website_benefit";
 	property name="messageBox"               inject="messagebox@cbmessagebox";
-	property name="bCryptService"            inject="bCryptService";
 
 	function prehandler( event, rc, prc ) output=false {
 		super.preHandler( argumentCollection = arguments );

--- a/system/handlers/admin/WebsiteUserManager.cfc
+++ b/system/handlers/admin/WebsiteUserManager.cfc
@@ -4,7 +4,6 @@ component extends="preside.system.base.AdminHandler" {
 	property name="websiteLoginService"      inject="websiteLoginService";
 	property name="presideObjectService"     inject="presideObjectService";
 	property name="messageBox"               inject="messagebox@cbmessagebox";
-	property name="bCryptService"            inject="bCryptService";
 	property name="passwordPolicyService"    inject="passwordPolicyService";
 
 	function prehandler( event, rc, prc ) {

--- a/system/handlers/admin/emailCenter/CustomTemplates.cfc
+++ b/system/handlers/admin/emailCenter/CustomTemplates.cfc
@@ -10,7 +10,6 @@ component extends="preside.system.base.AdminHandler" {
 	property name="formsService"               inject="formsService";
 	property name="cloningService"             inject="presideObjectCloningService";
 	property name="dao"                        inject="presidecms:object:email_template";
-	property name="blueprintDao"               inject="presidecms:object:email_blueprint";
 	property name="messageBox"                 inject="messagebox@cbmessagebox";
 
 

--- a/system/handlers/core/SiteTreePageRequestHandler.cfc
+++ b/system/handlers/core/SiteTreePageRequestHandler.cfc
@@ -1,9 +1,6 @@
 component {
 
 	property name="pageTypesService"              inject="pageTypesService";
-	property name="presideObjectService"          inject="presideObjectService";
-	property name="websitePermissionService"      inject="websitePermissionService";
-	property name="websiteLoginService"           inject="websiteLoginService";
 	property name="websiteUserActionService"      inject="websiteUserActionService";
 	property name="delayedViewletRendererService" inject="delayedViewletRendererService";
 

--- a/system/handlers/email/template/CmsWelcome.cfc
+++ b/system/handlers/email/template/CmsWelcome.cfc
@@ -39,5 +39,4 @@ component {
 		return renderView( view="/email/template/cmsWelcome/defaultTextBody" );
 	}
 
-
 }

--- a/system/handlers/email/template/Notification.cfc
+++ b/system/handlers/email/template/Notification.cfc
@@ -51,5 +51,4 @@ component {
 		return renderView( view="/email/template/notification/defaultTextBody" );
 	}
 
-
 }

--- a/system/handlers/email/template/WebsiteWelcome.cfc
+++ b/system/handlers/email/template/WebsiteWelcome.cfc
@@ -31,5 +31,4 @@ component {
 		return renderView( view="/email/template/websiteWelcome/defaultTextBody" );
 	}
 
-
 }

--- a/system/handlers/formbuilder/Core.cfc
+++ b/system/handlers/formbuilder/Core.cfc
@@ -3,7 +3,6 @@ component {
 	property name="formBuilderService"           inject="formBuilderService";
 	property name="formBuilderValidationService" inject="formBuilderValidationService";
 	property name="validationEngine"             inject="validationEngine";
-	property name="storageProvider" 			 inject="formBuilderStorageProvider";
 
 	public any function submitAction( event, rc, prc ) {
 		var formId       = rc.form ?: "";

--- a/system/handlers/formbuilder/DefaultRenderers.cfc
+++ b/system/handlers/formbuilder/DefaultRenderers.cfc
@@ -18,4 +18,5 @@ component {
 	private array function responseForExport( event, rc, prc, args={} ) {
 		return [ args.response ?: "" ];
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/Checkbox.cfc
+++ b/system/handlers/formbuilder/item-types/Checkbox.cfc
@@ -16,4 +16,5 @@ component {
 			, required           = IsTrue( args.mandatory      ?: "" )
 		);
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/CheckboxList.cfc
+++ b/system/handlers/formbuilder/item-types/CheckboxList.cfc
@@ -15,4 +15,5 @@ component {
 			, labels             = ListToArray( args.labels ?: "", Chr(10) & Chr(13) )
 		);
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/Date.cfc
+++ b/system/handlers/formbuilder/item-types/Date.cfc
@@ -93,4 +93,5 @@ component {
 		}
 		return rules;
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/FileUpload.cfc
+++ b/system/handlers/formbuilder/item-types/FileUpload.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="assetManagerService"        inject="assetManagerService";
 	property name="formBuilderStorageProvider" inject="formBuilderStorageProvider";
 
@@ -93,4 +94,5 @@ component {
 
 		return SerializeJson( response );
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/Number.cfc
+++ b/system/handlers/formbuilder/item-types/Number.cfc
@@ -35,4 +35,5 @@ component {
 
 		return rules;
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/Radio.cfc
+++ b/system/handlers/formbuilder/item-types/Radio.cfc
@@ -37,4 +37,5 @@ component {
 	private array function renderResponseForExport( event, rc, prc, args={} ) {
 		return [ renderResponse( argumentCollection=arguments ) ];
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/Select.cfc
+++ b/system/handlers/formbuilder/item-types/Select.cfc
@@ -55,4 +55,5 @@ component {
 		args.delim = ", ";
 		return [ renderResponse( argumentCollection=arguments ) ];
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/StarRating.cfc
+++ b/system/handlers/formbuilder/item-types/StarRating.cfc
@@ -2,7 +2,7 @@ component {
 
 	private string function renderInput( event, rc, prc, args={} ) {
 		event.include( assetId="/css/frontend/formbuilder/starRating/" );
-		event.include( assetId="/js/frontend/formbuilder/starRating/" );
+		event.include( assetId="/js/frontend/formbuilder/starRating/"  );
 
 		return renderFormControl(
 			  argumentCollection = args
@@ -13,4 +13,5 @@ component {
 			, required           = IsTrue( args.mandatory ?: "" )
 		);
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/TextArea.cfc
+++ b/system/handlers/formbuilder/item-types/TextArea.cfc
@@ -13,4 +13,5 @@ component {
 			, required           = IsTrue( args.mandatory ?: "" )
 		);
 	}
+
 }

--- a/system/handlers/formbuilder/item-types/TextInput.cfc
+++ b/system/handlers/formbuilder/item-types/TextInput.cfc
@@ -13,4 +13,5 @@ component {
 			, required           = IsTrue( args.mandatory ?: "" )
 		);
 	}
+
 }

--- a/system/handlers/formcontrols/AssetFolderPicker.cfc
+++ b/system/handlers/formcontrols/AssetFolderPicker.cfc
@@ -18,4 +18,5 @@ component {
 
 		return renderView( view="formcontrols/objectPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/AssetPicker.cfc
+++ b/system/handlers/formcontrols/AssetPicker.cfc
@@ -40,4 +40,5 @@ component {
 		event.include( assetId="/css/admin/specific/assetpicker/" );
 		return renderView( view="formcontrols/assetPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/AssetStorageLocationPicker.cfc
+++ b/system/handlers/formcontrols/AssetStorageLocationPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="storageLocationDao" inject="presidecms:object:asset_storage_location";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -14,4 +15,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/AuditActionPicker.cfc
+++ b/system/handlers/formcontrols/AuditActionPicker.cfc
@@ -27,4 +27,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/AuditTypePicker.cfc
+++ b/system/handlers/formcontrols/AuditTypePicker.cfc
@@ -27,4 +27,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/ConditionPicker.cfc
+++ b/system/handlers/formcontrols/ConditionPicker.cfc
@@ -30,4 +30,5 @@ component  {
 
 		return renderViewlet( event="formcontrols.objectPicker.index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/CropHintPicker.cfc
+++ b/system/handlers/formcontrols/CropHintPicker.cfc
@@ -1,7 +1,9 @@
 component {
+
 	public string function index( event, rc, prc, args={} ) {
 		args.currentValue = args.savedData[ args.name ] ?: "";
 
 		return renderView( view="/formcontrols/cropHintPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/DataExportFieldPicker.cfc
+++ b/system/handlers/formcontrols/DataExportFieldPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="dataExportService"    inject="dataExportService";
 	property name="presideObjectService" inject="presideObjectService";
 
@@ -34,4 +35,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/DataExporterPicker.cfc
+++ b/system/handlers/formcontrols/DataExporterPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="dataExportService" inject="dataExportService";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -6,4 +7,5 @@ component {
 
 		return renderView( view="formcontrols/dataExporterPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/DerivativePicker.cfc
+++ b/system/handlers/formcontrols/DerivativePicker.cfc
@@ -21,4 +21,5 @@ component {
 		return renderView( view="formcontrols/select/index", args=args );
 
 	}
+
 }

--- a/system/handlers/formcontrols/EmailLayoutPicker.cfc
+++ b/system/handlers/formcontrols/EmailLayoutPicker.cfc
@@ -15,4 +15,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/EmailServiceProviderPicker.cfc
+++ b/system/handlers/formcontrols/EmailServiceProviderPicker.cfc
@@ -27,4 +27,5 @@ component {
 
 		return renderView( view="formcontrols/emailServiceProviderPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/EmailTemplatePicker.cfc
+++ b/system/handlers/formcontrols/EmailTemplatePicker.cfc
@@ -31,4 +31,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/EnumRadioList.cfc
+++ b/system/handlers/formcontrols/EnumRadioList.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="enumService" inject="enumService";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -11,4 +12,5 @@ component {
 
 		return renderView( view="formcontrols/enumRadioList/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/EnumSelect.cfc
+++ b/system/handlers/formcontrols/EnumSelect.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="enumService" inject="enumService";
 
 	public string function index( event, rc, prc, args={} ) {

--- a/system/handlers/formcontrols/FileTypePicker.cfc
+++ b/system/handlers/formcontrols/FileTypePicker.cfc
@@ -32,4 +32,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/FilterPicker.cfc
+++ b/system/handlers/formcontrols/FilterPicker.cfc
@@ -39,4 +39,5 @@ component  {
 
 		return renderViewlet( event="formcontrols.objectPicker.index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/FocalPointPicker.cfc
+++ b/system/handlers/formcontrols/FocalPointPicker.cfc
@@ -1,7 +1,9 @@
 component {
+
 	public string function index( event, rc, prc, args={} ) {
 		args.currentValue = args.savedData[ args.name ] ?: "";
 
 		return renderView( view="/formcontrols/focalPointPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/FormBuilderFieldLayoutPicker.cfc
+++ b/system/handlers/formcontrols/FormBuilderFieldLayoutPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="formBuilderRenderingService" inject="formBuilderRenderingService";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -20,4 +21,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/FormBuilderFieldPicker.cfc
+++ b/system/handlers/formcontrols/FormBuilderFieldPicker.cfc
@@ -23,4 +23,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/FormBuilderFormLayoutPicker.cfc
+++ b/system/handlers/formcontrols/FormBuilderFormLayoutPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="formBuilderRenderingService" inject="formBuilderRenderingService";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -18,4 +19,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/ManyToManySelect.cfc
+++ b/system/handlers/formcontrols/ManyToManySelect.cfc
@@ -30,4 +30,5 @@ component {
 
 		return renderFormControl( argumentCollection=args, type="objectPicker", layout="" );
 	}
+
 }

--- a/system/handlers/formcontrols/ManyToOneSelect.cfc
+++ b/system/handlers/formcontrols/ManyToOneSelect.cfc
@@ -7,4 +7,5 @@ component {
 
 		return renderFormControl( argumentCollection=args, type="objectPicker", layout="" );
 	}
+
 }

--- a/system/handlers/formcontrols/NotificationTopicPicker.cfc
+++ b/system/handlers/formcontrols/NotificationTopicPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="notificationService" inject="notificationService";
 
 	public string function index( event, rc, prc, args={} ) output=false {
@@ -17,4 +18,5 @@ component {
 
 		return renderView( view="formcontrols/notificationTopicPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/OneToManyConfigurator.cfc
+++ b/system/handlers/formcontrols/OneToManyConfigurator.cfc
@@ -29,4 +29,5 @@ component {
 
 		return renderView( view="formcontrols/oneToManyConfigurator/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/OneToManySelect.cfc
+++ b/system/handlers/formcontrols/OneToManySelect.cfc
@@ -25,4 +25,5 @@ component {
 
 		return renderFormControl( argumentCollection=args, type="objectPicker", layout="" );
 	}
+
 }

--- a/system/handlers/formcontrols/PageTypePicker.cfc
+++ b/system/handlers/formcontrols/PageTypePicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="pageTypesService" inject="pageTypesService";
 
 	public string function index( event, rc, prc, args={} ) output=false {
@@ -12,4 +13,5 @@ component {
 
 		return renderView( view="formcontrols/select/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/ParentPagePicker.cfc
+++ b/system/handlers/formcontrols/ParentPagePicker.cfc
@@ -8,4 +8,5 @@ component {
 			, args  = args
 		);
 	}
+
 }

--- a/system/handlers/formcontrols/Password.cfc
+++ b/system/handlers/formcontrols/Password.cfc
@@ -1,5 +1,4 @@
 component {
-	property name="passwordPolicyService" inject="passwordPolicyService";
 
 	private string function index( event, rc, prc, args={} ) {
 		if ( Len( Trim( args.passwordPolicyContext ?: "" ) ) ) {
@@ -9,4 +8,5 @@ component {
 
 		return renderView( view="/formcontrols/password/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/PasswordStrengthPicker.cfc
+++ b/system/handlers/formcontrols/PasswordStrengthPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="passwordPolicyService" inject="passwordPolicyService";
 
 	private string function index( event, rc, prc, args={} ) {
@@ -6,4 +7,5 @@ component {
 
 		return renderView( view="/formcontrols/passwordStrengthPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/RestApiPicker.cfc
+++ b/system/handlers/formcontrols/RestApiPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="presideRestService" inject="presideRestService";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -6,4 +7,5 @@ component {
 
 		return renderView( view="formcontrols/restApiPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/Richeditor.cfc
+++ b/system/handlers/formcontrols/Richeditor.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="ckeditorToolbarHelper" inject="ckeditorToolbarHelper";
 	property name="ckeditorSettings"      inject="coldbox:setting:ckeditor";
 	property name="sticker"               inject="StickerForPreside";

--- a/system/handlers/formcontrols/RolePicker.cfc
+++ b/system/handlers/formcontrols/RolePicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="permissionService" inject="permissionService";
 
 	public string function index( event, rc, prc, args={} ) output=false {
@@ -6,4 +7,5 @@ component {
 
 		return renderView( view="formcontrols/rolepicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/RulesEngineFilterBuilder.cfc
+++ b/system/handlers/formcontrols/RulesEngineFilterBuilder.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="expressionService" inject="rulesEngineExpressionService";
 
 	private string function index( event, rc, prc, args={} ) {

--- a/system/handlers/formcontrols/SimpleColourPicker.cfc
+++ b/system/handlers/formcontrols/SimpleColourPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="simpleColourPickerService" inject="SimpleColourPickerService";
 
 	public string function index( event, rc, prc, args={} ) {
@@ -13,4 +14,5 @@ component {
 
 		return renderView( view="/formcontrols/simpleColourPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/SiteTreePagePicker.cfc
+++ b/system/handlers/formcontrols/SiteTreePagePicker.cfc
@@ -38,4 +38,5 @@ component {
 
 		return renderView( view="formcontrols/sitetreePagePicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/TimeZoneSelect.cfc
+++ b/system/handlers/formcontrols/TimeZoneSelect.cfc
@@ -1,11 +1,12 @@
 component {
+
 	property name="timeZoneSelectService" inject="TimeZoneSelectService";
 
 	public string function index( event, rc, prc, args={} ) {
 		var defaultToSystemTimezone = isTrue( args.defaultToSystemTimezone ?: "" );
 		var systemTimeZone          = getTimezone();
 		var timeZones               = timeZoneSelectService.getTimeZones();
-		
+
 		args.values = [ "" ];
 		args.labels = [ "" ];
 

--- a/system/handlers/formcontrols/WebsitePermissionsPicker.cfc
+++ b/system/handlers/formcontrols/WebsitePermissionsPicker.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="websitePermissionService" inject="websitePermissionService";
 
 	public string function index( event, rc, prc, args={} ) output=false {
@@ -18,4 +19,5 @@ component {
 
 		return renderView( view="formcontrols/websitePermissionsPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/formcontrols/pageLayoutPicker.cfc
+++ b/system/handlers/formcontrols/pageLayoutPicker.cfc
@@ -34,4 +34,5 @@ component {
 
 		return renderView( view="formcontrols/pageLayoutPicker/index", args=args );
 	}
+
 }

--- a/system/handlers/renderers/content/AdminGroupRoles.cfc
+++ b/system/handlers/renderers/content/AdminGroupRoles.cfc
@@ -1,7 +1,5 @@
 component {
 
-	property name="permissionService" inject="permissionService";
-
 	private string function default( event, rc, prc, args={} ){
 		var roles = ListToArray( args.data ?: "" );
 		var output = "<dl>";

--- a/system/handlers/renderers/content/Asset.cfc
+++ b/system/handlers/renderers/content/Asset.cfc
@@ -24,8 +24,6 @@ component {
 		args.renderedAsset = renderAsset( assetId=fkId, args={ derivative="icon" } );
 
 		return renderView( view="/renderers/content/asset/adminView", args=args );
-
-
 	}
 
 }

--- a/system/handlers/renderers/content/AssetStorageProvider.cfc
+++ b/system/handlers/renderers/content/AssetStorageProvider.cfc
@@ -5,4 +5,5 @@ component {
 
 		return translateResource( uri="storage-providers.#provider#:title", defaultValue=provider );
 	}
+
 }

--- a/system/handlers/renderers/content/EmailClickedLink.cfc
+++ b/system/handlers/renderers/content/EmailClickedLink.cfc
@@ -1,7 +1,5 @@
 component {
 
-	property name="userDao" inject="presidecms:object:security_user";
-
 	private string function default( event, rc, prc, args={} ){
 		var link = args.data ?: "";
 		var uuidPattern = "[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{16}";

--- a/system/handlers/renderers/content/ManyToOne.cfc
+++ b/system/handlers/renderers/content/ManyToOne.cfc
@@ -25,7 +25,6 @@ component {
 
 		return renderView( view="/renderers/content/manyToOne/adminView", args=args );
 
-
 	}
 
 }

--- a/system/handlers/renderers/content/ObjectRelatedRecords.cfc
+++ b/system/handlers/renderers/content/ObjectRelatedRecords.cfc
@@ -1,8 +1,5 @@
 component {
 
-	property name="adminDataViewsService" inject="adminDataViewsService";
-	property name="presideObjectService"  inject="presideObjectService";
-
 	public string function adminView( event, rc, prc, args={} ){
 		return renderViewlet( event="admin.dataHelpers.relatedRecordsDatatable", args=args );
 	}

--- a/system/handlers/renderers/content/RichEditor.cfc
+++ b/system/handlers/renderers/content/RichEditor.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="contentRendererService" inject="contentRendererService";
 
 	public string function default( event, rc, prc, args={} ){

--- a/system/handlers/rules/fieldtypes/FormBuilderField.cfc
+++ b/system/handlers/rules/fieldtypes/FormBuilderField.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'form builder field' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/FormbuilderFieldMultiChoiceValue.cfc
+++ b/system/handlers/rules/fieldtypes/FormbuilderFieldMultiChoiceValue.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'form builder multi-choice field' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/Number.cfc
+++ b/system/handlers/rules/fieldtypes/Number.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'number' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/Object.cfc
+++ b/system/handlers/rules/fieldtypes/Object.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'object' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/Operator.cfc
+++ b/system/handlers/rules/fieldtypes/Operator.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'operator' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/PageType.cfc
+++ b/system/handlers/rules/fieldtypes/PageType.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'page type' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/Select.cfc
+++ b/system/handlers/rules/fieldtypes/Select.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'select' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/Text.cfc
+++ b/system/handlers/rules/fieldtypes/Text.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'text' type
  *
  */
 component {

--- a/system/handlers/rules/fieldtypes/TimePeriod.cfc
+++ b/system/handlers/rules/fieldtypes/TimePeriod.cfc
@@ -1,5 +1,5 @@
 /**
- * Handler for rules engine 'boolean type'
+ * Handler for rules engine 'time period' type
  *
  */
 component {

--- a/system/handlers/widgets/ConditionalContent.cfc
+++ b/system/handlers/widgets/ConditionalContent.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="rulesEngineWebRequestService" inject="rulesEngineWebRequestService";
 
 	/**

--- a/system/handlers/widgets/FormBuilderForm.cfc
+++ b/system/handlers/widgets/FormBuilderForm.cfc
@@ -1,4 +1,5 @@
 component {
+
 	property name="formbuilderService" inject="formbuilderService";
 
 	private function index( event, rc, prc, args={} ) {


### PR DESCRIPTION
Cleaning up handlers by:

- Removing redundant injected services
- Tidying up whitespace 

I have run a local site without issue so may be worth someone else doing a final test/inspection before merging this into the release / stable branches.