### PR TITLE
Presidecms 1408 mssql cast fix

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"Preside",
-    "version":"10.9.0",
+    "version":"10.10.0",
     "author":"Pixl8 Interactive",
     "createPackageDirectory":true,
     "packageDirectory":"preside",

--- a/system/migrations/upgrades/10-10-0.cfc
+++ b/system/migrations/upgrades/10-10-0.cfc
@@ -25,7 +25,7 @@ component {
 
 		if ( dbInfo.database_productName == "Microsoft SQL Server" ) {
 			var sql = "update #escapedTableName#
-			           set #escapedLinkCol# = Replace( Replace( #escapedDataCol#, '{""link"":""', '' ), '""}', '' )
+			           set #escapedLinkCol# = Replace( Replace( cast( #escapedDataCol# as varchar ), '{""link"":""', '' ), '""}', '' )
 			           where #escapedDataCol# is not null
 			           and cast( #escapedDataCol# as varchar ) != '{}'";
 		} else {


### PR DESCRIPTION
Fixing another occurence of db type text used as varchar without casting. Also fixed the box.json version number so that db migration scripts run when project is started and preside is used without package manager.