### PR TITLE
Feature presidecms 1056 10.10 allow for sites to run in subfolder of root

### DIFF
--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -4,6 +4,11 @@
  */
 component extends="coldbox.system.web.context.RequestContextDecorator" {
 
+	// constructor
+	/**
+	 * @assetManagerService.inject assetManagerService
+	 */
+
 // URL related
 	public void function setSite( required struct site ) {
 		getModel( "tenancyService" ).setTenantId( tenant="site", id=( site.id ?: "" ) );
@@ -194,7 +199,8 @@ component extends="coldbox.system.web.context.RequestContextDecorator" {
 	}
 
 	public string function getAdminPath() {
-		var path = getController().getSetting( "preside_admin_path" );
+		var path = getController().getSetting( "preside_admin_base_path" );
+		path = path & getController().getSetting( "preside_admin_path" );
 
 		return Len( Trim( path ) ) ? "/#path#/" : "/";
 	}
@@ -860,7 +866,7 @@ component extends="coldbox.system.web.context.RequestContextDecorator" {
 		    && !event.valueExists( "fwreinit" )
 		    && !this.isAdminUser()
 		    && event.getHTTPMethod() == "GET"
-		    && !this.getCurrentUrl().startsWith( "/asset/" )
+		    && !this.getCurrentUrl().startsWith( assetManagerService._getAssetPath() ) /* /asset/ */
 		    && !( IsBoolean( prc._cachePage ?: "" ) && !prc._cachePage );
 	}
 

--- a/system/coldboxModifications/services/RoutingService.cfc
+++ b/system/coldboxModifications/services/RoutingService.cfc
@@ -61,11 +61,17 @@ component extends="coldbox.system.web.services.RoutingService" accessors=true {
 	}
 
 // private utility methods
-	private void function _detectIncomingSite( event, interceptData ) {
+	private void function _detectIncomingSite( event, interceptData ) output="true" {
 		var pathInfo       = _getCGIElement( "path_info", event );
 		var domain         = _getCGIElement( "server_name", event );
 		var explicitSiteId = event.getValue( name="_sid", defaultValue="" ).trim();
 		var site           = {};
+		var presideSystemAssetPath = pathInfo.startsWith( "/preside/system/assets/" );
+		//var presideSystemDynamicAssetPath = pathInfo.startsWith( "/preside/system/assets/_dynamic/i18nBundle.js" );
+
+		if ( presideSystemAssetPath ) {
+			return;
+		}
 
 		if ( explicitSiteId.len() ) {
 			site = siteService.getSite( explicitSiteId );
@@ -159,6 +165,11 @@ component extends="coldbox.system.web.services.RoutingService" accessors=true {
 		var pathToRemove = ( site.path ?: "" ).reReplace( "/$", "" );
 		var fullPath     = _getCGIElement( "path_info", event );
 		var presidePath  = "";
+		var adminBasePath = adminRouteHandler.getAdminBasePath();
+		if ( right( adminBasePath, 1 ) == "/" ) {
+			adminBasePath = left( adminBasePath, len( adminBasePath) -1 );
+		}
+		adminBasePath = "/" & adminBasePath;
 		var languageSlug = event.getLanguageSlug();
 		if ( Len( Trim( languageSlug ) ) ) {
 			pathToRemove = pathToRemove & "/" & languageSlug & "/";
@@ -170,8 +181,11 @@ component extends="coldbox.system.web.services.RoutingService" accessors=true {
 			presidePath = fullPath;
 		}
 
-
-		event.setCurrentPresideUrlPath( presidePath );
+		if ( adminRouteHandler.match( adminBasePath & presidePath, fullPath ) ) {
+			event.setCurrentPresideUrlPath( adminBasePath & presidePath );
+		} else {
+			event.setCurrentPresideUrlPath(presidePath);
+		}
 	}
 
 	private boolean function _routePresideSESRequest( event, interceptData ) {

--- a/system/coldboxModifications/services/RoutingService.cfc
+++ b/system/coldboxModifications/services/RoutingService.cfc
@@ -65,13 +65,12 @@ component extends="coldbox.system.web.services.RoutingService" accessors=true {
 	}
 
 // private utility methods
-	private void function _detectIncomingSite( event, interceptData ) output="true" {
+	private void function _detectIncomingSite( event, interceptData ) {
 		var pathInfo       = _getCGIElement( "path_info", event );
 		var domain         = _getCGIElement( "server_name", event );
 		var explicitSiteId = event.getValue( name="_sid", defaultValue="" ).trim();
 		var site           = {};
 		var presideSystemAssetPath = pathInfo.startsWith( "/preside/system/assets/" );
-		//var presideSystemDynamicAssetPath = pathInfo.startsWith( "/preside/system/assets/_dynamic/i18nBundle.js" );
 
 		if ( presideSystemAssetPath ) {
 			return;

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -5,6 +5,7 @@ component {
 		settings = {};
 
 		settings.appMapping    = ( request._presideMappings.appMapping ?: "app" ).reReplace( "^/", "" );
+		settings.appBasePath   = request._presideMappings.appBasePath;
 		settings.assetsMapping = request._presideMappings.assetsMapping ?: "/assets";
 		settings.logsMapping   = request._presideMappings.logsMapping   ?: "/logs";
 
@@ -151,6 +152,7 @@ component {
 		settings.widgets                     = {};
 		settings.templates                   = [];
 		settings.adminDefaultEvent           = "sitetree";
+		settings.preside_admin_base_path     = settings.appBasePath ?: "";
 		settings.preside_admin_path          = "admin";
 		settings.presideHelpAndSupportLink   = "http://www.pixl8.co.uk";
 		settings.dsn                         = "preside";
@@ -211,7 +213,7 @@ component {
 
 		settings.adminLoginProviders = [ "preside" ];
 
-		settings.uploads_directory = ExpandPath( "/uploads" );
+		settings.uploads_directory = ExpandPath( settings.appBasePath & "/uploads" );
 		settings.storageProviders = {
 			filesystem = { class="preside.system.services.fileStorage.fileSystemStorageProvider" }
 		};
@@ -305,7 +307,7 @@ component {
 		};
 
 		settings.static = {
-			  rootUrl        = ""
+			  rootUrl        = settings.appBasePath
 			, siteAssetsPath = "/assets"
 			, siteAssetsUrl  = "/assets"
 		};

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -5,6 +5,7 @@ component {
 		settings = {};
 
 		settings.appMapping    = ( request._presideMappings.appMapping ?: "app" ).reReplace( "^/", "" );
+		settings.appBasePath   = request._presideMappings.appBasePath;
 		settings.assetsMapping = request._presideMappings.assetsMapping ?: "/assets";
 		settings.logsMapping   = request._presideMappings.logsMapping   ?: "/logs";
 
@@ -159,6 +160,7 @@ component {
 		settings.widgets                     = {};
 		settings.templates                   = [];
 		settings.adminDefaultEvent           = "sitetree";
+		settings.preside_admin_base_path     = settings.appBasePath ?: "";
 		settings.preside_admin_path          = "admin";
 		settings.presideHelpAndSupportLink   = "http://www.pixl8.co.uk";
 		settings.dsn                         = "preside";
@@ -219,7 +221,7 @@ component {
 
 		settings.adminLoginProviders = [ "preside" ];
 
-		settings.uploads_directory = ExpandPath( "/uploads" );
+		settings.uploads_directory = ExpandPath( settings.appBasePath & "/uploads" );
 		settings.storageProviders = {
 			filesystem = { class="preside.system.services.fileStorage.fileSystemStorageProvider" }
 		};
@@ -313,7 +315,7 @@ component {
 		};
 
 		settings.static = {
-			  rootUrl        = ""
+			  rootUrl        = settings.appBasePath
 			, siteAssetsPath = "/assets"
 			, siteAssetsUrl  = "/assets"
 		};

--- a/system/handlers/admin/StaticAssetDownload.cfc
+++ b/system/handlers/admin/StaticAssetDownload.cfc
@@ -6,7 +6,7 @@ component {
 		var staticAssetPath = _translatePath( rc.staticAssetPath ?: "" );
 		var assetFile       = ExpandPath( staticAssetPath );
 
-		if ( rc.staticAssetPath.startsWith( "/preside/system/assets/_dynamic/i18nBundle.js" ) ) {
+		if ( staticAssetPath.startsWith( "/preside/system/assets/_dynamic/i18nBundle.js" ) ) {
 			_serveI18nBundle( argumentCollection = arguments );
 		}
 

--- a/system/services/routeHandlers/AdminRouteHandler.cfc
+++ b/system/services/routeHandlers/AdminRouteHandler.cfc
@@ -7,12 +7,14 @@ component implements="iRouteHandler" {
 // constructor
 	/**
 	 * @adminPath.inject           coldbox:setting:preside_admin_path
+	 * @adminBasePath.inject       coldbox:setting:preside_admin_base_path
 	 * @eventName.inject           coldbox:setting:eventName
 	 * @sysConfigService.inject    delayedInjector:systemConfigurationService
 	 * @applicationsService.inject delayedInjector:applicationsService
 	 * @controller.inject          coldbox
 	 */
-	public any function init( required string adminPath, required string eventName, required any applicationsService, required any sysConfigService, required any controller ) {
+	public any function init( string adminBasePath = "", required string adminPath, required string eventName, required any applicationsService, required any sysConfigService, required any controller ) {
+		_setAdminBasePath( arguments.adminBasePath );
 		_setAdminPath( arguments.adminPath );
 		_setEventName( arguments.eventName );
 		_setApplicationsService( arguments.applicationsService );
@@ -56,6 +58,11 @@ component implements="iRouteHandler" {
 		return event.getSiteUrl( includePath=false, includeLanguageSlug=false ) & link;
 	}
 
+	public string function getAdminBasePath() {
+		return _getAdminBasePath();
+	}
+
+
 // private helpers
 	private string function _getDefaultEvent() {
 		return _getApplicationsService().getDefaultEvent();
@@ -68,7 +75,33 @@ component implements="iRouteHandler" {
 		return Len( Trim( fromSysConfig ) ) ? fromSysConfig : _adminPath;
 	}
 	private void function _setAdminPath( required string adminPath ) {
-		_adminPath = arguments.adminPath;
+		_adminPath = _getAdminBasePath() & arguments.adminPath;
+	}
+
+	private string function _getAdminBasePath() {
+		return _adminBasePath;
+	}
+	private void function _setAdminBasePath( string adminBasePath ) {
+		var adminBasePath = "";
+
+		if ( Len( arguments.adminBasePath ) ) {
+			adminBasePath = arguments.adminBasePath;
+		} else {
+			var appSettings = getApplicationSettings();
+			adminBasePath = request._presideMappings.appBasePath;
+		}
+
+		if ( Len(adminBasePath) ) {
+			if ( left(adminBasePath, 1) == "/" ) {
+				adminBasePath = right( adminBasePath, len(adminBasePath) - 1 );
+			}
+
+			if ( right(adminBasePath, 1 ) != "/" ) {
+				adminBasePath = adminBasePath & "/";
+			}
+		}
+
+		_adminBasePath = adminBasePath;
 	}
 
 	private string function _getEventName() {

--- a/system/services/routeHandlers/AssetRouteHandler.cfc
+++ b/system/services/routeHandlers/AssetRouteHandler.cfc
@@ -43,9 +43,9 @@ component implements="iRouteHandler" singleton=true {
 	}
 
 	public string function build( required struct buildArgs, required any event ) output=false {
-		var assetId    = buildArgs.assetId    ?: ""
-		var derivative = buildArgs.derivative ?: ""
-		var versionId  = buildArgs.versionId  ?: ""
+		var assetId    = buildArgs.assetId    ?: "";
+		var derivative = buildArgs.derivative ?: "";
+		var versionId  = buildArgs.versionId  ?: "";
 		var trashed    = IsBoolean( buildArgs.trashed ?: "" ) && buildArgs.trashed;
 		var link       = "";
 

--- a/system/services/sticker/StickerForPreside.cfc
+++ b/system/services/sticker/StickerForPreside.cfc
@@ -40,7 +40,8 @@ component {
 		var extensionsRootUrl = "/preside/system/assets/extension/";
 		var siteAssetsPath    = settings.static.siteAssetsPath ?: "/assets";
 		var siteAssetsUrl     = settings.static.siteAssetsUrl  ?: "/assets";
-		var rootURl           = ( settings.static.rootUrl ?: "" );
+		_setRootUrl();
+		var rootUrl = Len( settings.static.rootUrl ) ? settings.static.rootUrl : _getRootUrl();
 
 		sticker.addBundle( rootDirectory=sysAssetsPath , rootUrl=sysAssetsPath, config=settings );
 
@@ -73,6 +74,28 @@ component {
 	}
 	private void function _setSticker( required any sticker ) {
 		_sticker = arguments.sticker;
+	}
+
+	private any function _getRootUrl() {
+		return _rootUrl;
+	}
+	private string function _setRootUrl() {
+		var appSettings = getApplicationSettings();
+
+		rootUrl = request._presideMappings.appBasePath;
+		if ( Len(rootUrl) ) {
+
+			if ( right(rootUrl, 1) == "/" ) {
+				rootUrl = left( rootUrl, len(rootUrl) - 1 );
+			}
+
+			if ( left(rootUrl, 1) != "/" ) {
+				rootUrl ="/" & rootUrl;
+			}
+
+		}
+
+		_rootUrl = rootUrl;
 	}
 
 }

--- a/system/services/sticker/StickerForPreside.cfc
+++ b/system/services/sticker/StickerForPreside.cfc
@@ -40,7 +40,8 @@ component {
 		var extensionsRootUrl = "/preside/system/assets/extension/";
 		var siteAssetsPath    = settings.static.siteAssetsPath ?: "/assets";
 		var siteAssetsUrl     = settings.static.siteAssetsUrl  ?: "/assets";
-		var rootURl           = ( settings.static.rootUrl ?: "" );
+		_setRootUrl();
+		var rootUrl = Len( settings.static.rootUrl ) ? settings.static.rootUrl : _getRootUrl();
 
 		sticker.addBundle( rootDirectory=sysAssetsPath , rootUrl=sysAssetsPath          , config=settings )
 		       .addBundle( rootDirectory=siteAssetsPath, rootUrl=rootUrl & siteAssetsUrl, config=settings );
@@ -72,6 +73,28 @@ component {
 	}
 	private void function _setSticker( required any sticker ) {
 		_sticker = arguments.sticker;
+	}
+
+	private any function _getRootUrl() {
+		return _rootUrl;
+	}
+	private string function _setRootUrl() {
+		var appSettings = getApplicationSettings();
+
+		rootUrl = request._presideMappings.appBasePath;
+		if ( Len(rootUrl) ) {
+
+			if ( right(rootUrl, 1) == "/" ) {
+				rootUrl = left( rootUrl, len(rootUrl) - 1 );
+			}
+
+			if ( left(rootUrl, 1) != "/" ) {
+				rootUrl ="/" & rootUrl;
+			}
+
+		}
+
+		_rootUrl = rootUrl;
 	}
 
 }


### PR DESCRIPTION
To replace the existing pull request and make compatible with 10.10
Sites - Application.cfc
Specify the appBasePath
e.g. 
super.setupApplication( id = "mysite", appBasePath = "/{subfolder}" );
Update the path in the DB for the site (psys_site) "/{subfolder}
system/Bootstrap.cfc line 575 - can we reference the site.path at this stage? We could then do without the appBasePath reference in Application.cfc
I also have a problem with /preside/system/assets/_dynamic/i18nBundle.js returning 404 when using Tomcat rewrite rules. Works fine with tuckey.
urlrewrite.xml changes
`<rule>
		<note>
			All request to *.html or ending in / will be rewritten to /index.cfm
		</note>
		<from>^(/{subfolder}((.*?)(\.html|/))?)$</from>
		<to last="true">%{context-path}/{subfolder}/index.cfm</to>
	</rule>`
`<rule>
		<note>
			All request to system static assets that live under /preside/system/assets
			should go through CFML and will be rewritten to /index.cfm
		</note>
		<from>^/preside/system/assets/.*$</from>
		<to last="true">%{context-path}/{subfolder}/index.cfm</to>
	</rule>`
