### PR TITLE
PRESIDECMS-1425 Remove obsolete quote

### DIFF
--- a/system/views/admin/datamanager/_listingActions.cfm
+++ b/system/views/admin/datamanager/_listingActions.cfm
@@ -7,7 +7,7 @@
 				<cfif IsSimpleValue( action )>
 					#action#
 				<cfelse>
-					<a class="<cfif i == 1>row-link</cfif><cfif Len( Trim( action.class ?: "" ))> #action.class#"</cfif>"<cfif Len( Trim( action.contextKey ?: "" ))> data-context-key="#action.contextKey#"</cfif> href="#( action.link ?: "" )#"<cfif Len( Trim( action.title ?: "" ))> title="#HtmlEditFormat( action.title )#"</cfif><cfif Len( Trim( action.target ?: "" ))> target="#action.target#"</cfif>>
+					<a class="<cfif i == 1>row-link</cfif><cfif Len( Trim( action.class ?: "" ))> #action.class#</cfif>"<cfif Len( Trim( action.contextKey ?: "" ))> data-context-key="#action.contextKey#"</cfif> href="#( action.link ?: "" )#"<cfif Len( Trim( action.title ?: "" ))> title="#HtmlEditFormat( action.title )#"</cfif><cfif Len( Trim( action.target ?: "" ))> target="#action.target#"</cfif>>
 						<i class="fa fa-fw #( action.icon ?: "" )#"></i>
 					</a>
 				</cfif>


### PR DESCRIPTION
I removed an obsolete quote in the view.

Generated before:
`<a class=" abc123"" data-context-key="s">`

After:
`<a class=" abc123" data-context-key="s">`
