### PR TITLE
PRESIDECMS-1452 param for missing request variable

### DIFF
--- a/system/config/Router.cfc
+++ b/system/config/Router.cfc
@@ -33,6 +33,7 @@ component extends="coldbox.system.web.routing.Router" {
 
 	function pathInfoProvider( event ) {
 		var requestData = GetHttpRequestData();
+		param name='request[ "javax.servlet.forward.request_uri" ]' default="";
 		var uri         = ListFirst( ( requestData.headers['X-Original-URL'] ?: request[ "javax.servlet.forward.request_uri" ] ), '?' );
 		var qs          = "";
 

--- a/system/config/Router.cfc
+++ b/system/config/Router.cfc
@@ -33,8 +33,7 @@ component extends="coldbox.system.web.routing.Router" {
 
 	function pathInfoProvider( event ) {
 		var requestData = GetHttpRequestData();
-		param name='request[ "javax.servlet.forward.request_uri" ]' default="";
-		var uri         = ListFirst( ( requestData.headers['X-Original-URL'] ?: request[ "javax.servlet.forward.request_uri" ] ), '?' );
+		var uri         = ListFirst( ( requestData.headers['X-Original-URL'] ?: (request[ "javax.servlet.forward.request_uri" ] ?: "") ), '?' );
 		var qs          = "";
 
 		if ( !Len( Trim( uri ) ) ) {


### PR DESCRIPTION
The fix for Apache2/Tomcat constellation may fails if request[ "javax.servlet.forward.request_uri" ] doesn't exist. Added a defaultvalue.