### PR TITLE
PRESIDECMS-1473 Set filename as asset title when not submitted in assetData

### DIFF
--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -661,7 +661,7 @@ component displayName="AssetManager Service" {
 		asset.asset_type       = fileTypeInfo.typeName;
 		asset.storage_path     = newFileName;
 		asset.size             = asset.size  ?: Len( arguments.fileBinary );
-		asset.title            = asset.title ?: "";
+		asset.title            = asset.title ?: arguments.fileName;
 
 		isAssetAllowedInFolder(
 			  type       = asset.asset_type


### PR DESCRIPTION
When adding assets programmatically with addAsset and having two files with the same file name the current code returns an error. The problem is, that asset.title is used in in _ensureUniqueTitle(). If it is missing in the assetData struct it will never be modified to a unique name. The solution is setting the asset.title to arguments.fileName if it not set.