### PR TITLE
PRESIDECMS-1548 Enable all output from task threads

### DIFF
--- a/system/services/concurrency/ThreadUtil.cfc
+++ b/system/services/concurrency/ThreadUtil.cfc
@@ -40,15 +40,14 @@ component {
 	}
 
 	/**
-	 * Sets some sensible defaults for background threads. Sets
-	 * cfoutputonly to true, turns off debug output and sets
-	 * the request timeout to 100 years.
+	 * Sets some sensible defaults for background threads. Turns
+	 * off debug output and sets the request timeout to 100 years.
 	 *
 	 * @autodoc true
 	 *
 	 */
 	public void function setThreadRequestDefaults() {
-		setting enablecfoutputonly=true showdebugoutput=false requesttimeout=oneHundredYears;
+		setting showdebugoutput=false requesttimeout=oneHundredYears;
 	}
 
 	/**


### PR DESCRIPTION
Testing has shown no noticeable difference with the setting enabled or disabled.

It should only make any difference anyway if the scheduled task is either rendering output, or is running a tag-based CFC without output=false...