### PR TITLE
Feature presidecms 1582 formbuilder fileupload download url

### DIFF
--- a/system/handlers/formbuilder/item-types/FileUpload.cfc
+++ b/system/handlers/formbuilder/item-types/FileUpload.cfc
@@ -64,10 +64,11 @@ component {
 		}
 
 		if( Len( Trim( args.accept ?: "" ) ) ){
+			var allowedTypes = ArrayToList( assetManagerService.expandTypeList( listToArray(args.accept) ) );
 			rules.append( {
 				  fieldname = args.name ?: ""
 				, validator = "fileType"
-				, params    = { allowedTypes=args.accept, allowedExtensions=args.accept }
+				, params    = { allowedTypes=allowedTypes, allowedExtensions=allowedTypes }
 			} );
 		}
 

--- a/system/handlers/formbuilder/item-types/FileUpload.cfc
+++ b/system/handlers/formbuilder/item-types/FileUpload.cfc
@@ -89,7 +89,7 @@ component {
 		var response = args.response ?: "";
 
 		if ( IsBinary( response.binary ?: "" ) ) {
-			var savedPath = "/#( args.formId ?: '' )#/#CreateUUId()#/#( response.tempFileInfo.clientFile ?: 'uploaded.file' )#";
+			var savedPath = "/#( args.formId ?: '' )#/#CreateUUId()#/#( Len( response.tempFileInfo.clientFile ?: '' ) ? urlEncode( response.tempFileInfo.clientFile ) : 'uploaded.file' )#";
 
 			formBuilderStorageProvider.putObject(
 				  object = response.binary


### PR DESCRIPTION
When a user uploaded a file that has a plenty special characters in it (specifically '?'), Preside then will generate a forward slash () when converting the uploaded file to base64.

Thus, when we do the translate in the built link, Preside couldn't locate the file because of the extra forward slash generated in the URL.