### PR TITLE
Feature presidecms 1143 limit notification count

### DIFF
--- a/system/assets/js/admin/specific/notifications/navbarNotificationTopic.js
+++ b/system/assets/js/admin/specific/notifications/navbarNotificationTopic.js
@@ -1,0 +1,21 @@
+( function( $ ){
+	$('a#notificationBar').on('click',function(){
+		var $link = $( this );
+		
+		if( !$link.parent().hasClass('open') ){
+			var remoteUrl       = $link.data( 'href' );
+			var targetContainer = $link.data( 'container' );
+		
+			$.ajax({
+				  url  : remoteUrl
+				, success : function( saveSuccess ) {
+					$(targetContainer).find('li:not(:first-child):not(:last-child)').remove();
+					$(targetContainer).find('li:nth-last-child(1)').before(saveSuccess);
+				}
+				, error : function( error ) {
+				}
+			});
+		}
+	});
+
+} )( presideJQuery );

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -180,6 +180,7 @@ component {
 		settings.maintenanceModeViewlet      = "errors.maintenanceMode";
 		settings.injectedConfig              = Duplicate( application.injectedConfig ?: {} );
 		settings.notificationTopics          = [];
+		settings.notificationCountLimit      = 100;
 		settings.syncDb                      = IsBoolean( settings.injectedConfig.syncDb ?: ""  ) ? settings.injectedConfig.syncDb : true;
 		settings.autoSyncDb                  = IsBoolean( settings.injectedConfig.autoSyncDb ?: ""  ) && settings.injectedConfig.autoSyncDb;
 		settings.autoRestoreDeprecatedFields = true;

--- a/system/handlers/admin/Notifications.cfc
+++ b/system/handlers/admin/Notifications.cfc
@@ -236,10 +236,26 @@ component extends="preside.system.base.AdminHandler" {
 
 // VIEWLETS
 	private string function notificationNavPromo( event, rc, prc, args={} ) {
-		args.notificationCount   = notificationService.getUnreadNotificationCount( userId = event.getAdminUserId() );
-		args.latestNotifications = notificationService.getUnreadTopics( userId = event.getAdminUserId() );
+		args.notificationCount   = notificationService.getUnreadNotificationCount( 
+			  userId  = event.getAdminUserId()
+			, maxRows = getSetting( "notificationCountLimit" ) + 1
+		);
 
 		return renderView( view="/admin/notifications/notificationNavPromo", args=args );
+	}
+
+	public string function getAjaxUnreadTopics( event, rc, prc, args={} ) {
+		
+		args.latestNotifications = notificationService.getUnreadTopics(
+			  userId = event.getAdminUserId()
+			, maxRows = getSetting( "notificationCountLimit" ) + 1
+		);
+		
+		return renderView( 
+			  view = "/admin/notifications/_notificationNavTopic"
+			, args = args
+		);
+
 	}
 
 // HELPERS

--- a/system/views/admin/notifications/_notificationNavTopic.cfm
+++ b/system/views/admin/notifications/_notificationNavTopic.cfm
@@ -1,0 +1,19 @@
+<cfscript>
+	notifications = args.latestNotifications ?: QueryNew('');
+</cfscript>
+
+<cfoutput>
+	<cfloop query="notifications">
+		<li>
+			<a href="#event.buildAdminLink( linkTo="notifications", queryString="topic=#notifications.topic#" )#">
+				<div class="clearfix">
+					<span class="pull-left">
+						<i class="fa fa-fw #translateResource( 'notifications.#notifications.topic#:iconClass', 'fa-bell' )#"></i>
+						#translateResource( 'notifications.#notifications.topic#:title', notifications.topic )#
+					</span>
+					<span class="pull-right badge badge-info">#notifications.notification_count lt getSetting( "notificationCountLimit" )?notifications.notification_count:( getSetting( "notificationCountLimit" )&"+" ) #</span>
+				</div>
+			</a>
+		</li>
+	</cfloop>
+</cfoutput>

--- a/system/views/admin/notifications/notificationNavPromo.cfm
+++ b/system/views/admin/notifications/notificationNavPromo.cfm
@@ -1,40 +1,28 @@
 <cfscript>
-	notificationCount = args.notificationCount   ?: 0;
-	notifications     = args.latestNotifications ?: QueryNew('');
+	event.include( "/js/admin/specific/notifications/" );
+
+	notificationCount      = args.notificationCount   ?: 0;
+	notificationCountLabel = notificationCount lt getSetting( "notificationCountLimit" )?notificationCount:( getSetting( "notificationCountLimit" )&"+")
+	notifications          = args.latestNotifications ?: QueryNew('');
 </cfscript>
 
 
 <cfoutput>
-	<a href="##" class="dropdown-toggle" data-toggle="preside-dropdown">
+	<a href="##" class="dropdown-toggle" id="notificationBar" data-href="#event.buildAdminLink( linkTo="notifications.getAjaxUnreadTopics" )#"  data-container="##notificationDropDown" data-toggle="preside-dropdown">
 		<i class="fa fa-bell-o<cfif notificationCount> icon-animated-bell</cfif>"></i>
-		<span class="badge <cfif notificationCount>badge-important</cfif>">#notificationCount#</span>
+		<span class="badge <cfif notificationCount>badge-important</cfif>">#notificationCountLabel#</span>
 	</a>
 
-	<ul class="dropdown-navbar dropdown-menu dropdown-caret dropdown-close">
+	<ul class="dropdown-navbar dropdown-menu dropdown-caret dropdown-close" id="notificationDropDown">
 		<li class="dropdown-header">
 			<cfif notificationCount>
 				<i class="icon-warning-sign"></i>
-				#translateResource( uri="cms:notifications.navpromo.count", data=[ notificationCount ] )#
+				#translateResource( uri="cms:notifications.navpromo.count", data=[ notificationCountLabel ] )#
 			<cfelse>
 				<i class="icon-check"></i>
 				#translateResource( "cms:notifications.navpromo.no.new.notifications" )#
 			</cfif>
 		</li>
-
-		<cfloop query="notifications">
-			<li>
-				<a href="#event.buildAdminLink( linkTo="notifications", queryString="topic=#notifications.topic#" )#">
-					<div class="clearfix">
-						<span class="pull-left">
-							<i class="fa fa-fw #translateResource( 'notifications.#notifications.topic#:iconClass', 'fa-bell' )#"></i>
-							#translateResource( 'notifications.#notifications.topic#:title', notifications.topic )#
-						</span>
-						<span class="pull-right badge badge-info">#notifications.notification_count#</span>
-					</div>
-				</a>
-			</li>
-		</cfloop>
-
 		<li>
 			<a href="#event.buildAdminLink( linkTo="notifications" )#">
 				#translateResource( 'cms:notifications.navpromo.link.title' )#


### PR DESCRIPTION
- Limit the notification count
- Ajax load notification topics as suggested by @john5onCheng 
[](https://presidecms.atlassian.net/browse/PRESIDECMS-1143)

Default value in  _Preside core config.cfc_
> settings.notificationCountLimit      = 100; 

Notification query will select with **LIMIT**  ( _Limit value = setting.notifcationCountLimit +1_ )  
`select(index_field) from table where condition limit 101`

If notification.count is more than 100 , then count = limit with _plus_ sign at the back [`count+` ]   // **100+**
else it will display normally [`count`]  // **37**
