### PR TITLE
PRESIDECMS-1143 limit notification count

### DIFF
--- a/system/assets/js/admin/specific/notifications/navbarNotificationTopic.js
+++ b/system/assets/js/admin/specific/notifications/navbarNotificationTopic.js
@@ -1,0 +1,21 @@
+( function( $ ){
+	$('a#notificationBar').on('click',function(){
+		var $link = $( this );
+		
+		if( !$link.parent().hasClass('open') ){
+			var remoteUrl       = $link.data( 'href' );
+			var targetContainer = $link.data( 'container' );
+		
+			$.ajax({
+				  url  : remoteUrl
+				, success : function( saveSuccess ) {
+					$(targetContainer).find('li:not(:first-child):not(:last-child)').remove();
+					$(targetContainer).find('li:nth-last-child(1)').before(saveSuccess);
+				}
+				, error : function( error ) {
+				}
+			});
+		}
+	});
+
+} )( presideJQuery );

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -180,6 +180,7 @@ component {
 		settings.maintenanceModeViewlet      = "errors.maintenanceMode";
 		settings.injectedConfig              = Duplicate( application.injectedConfig ?: {} );
 		settings.notificationTopics          = [];
+		settings.notificationCountLimit      = 100;
 		settings.syncDb                      = IsBoolean( settings.injectedConfig.syncDb ?: ""  ) ? settings.injectedConfig.syncDb : true;
 		settings.autoSyncDb                  = IsBoolean( settings.injectedConfig.autoSyncDb ?: ""  ) && settings.injectedConfig.autoSyncDb;
 		settings.autoRestoreDeprecatedFields = true;

--- a/system/handlers/admin/Notifications.cfc
+++ b/system/handlers/admin/Notifications.cfc
@@ -238,7 +238,6 @@ component extends="preside.system.base.AdminHandler" {
 	private string function notificationNavPromo( event, rc, prc, args={} ) {
 		args.notificationCount   = notificationService.getUnreadNotificationCount( 
 			  userId  = event.getAdminUserId()
-			, maxRows = getSetting( "notificationCountLimit" ) + 1
 		);
 
 		return renderView( view="/admin/notifications/notificationNavPromo", args=args );

--- a/system/handlers/admin/Notifications.cfc
+++ b/system/handlers/admin/Notifications.cfc
@@ -236,10 +236,26 @@ component extends="preside.system.base.AdminHandler" {
 
 // VIEWLETS
 	private string function notificationNavPromo( event, rc, prc, args={} ) {
-		args.notificationCount   = notificationService.getUnreadNotificationCount( userId = event.getAdminUserId() );
-		args.latestNotifications = notificationService.getUnreadTopics( userId = event.getAdminUserId() );
+		args.notificationCount   = notificationService.getUnreadNotificationCount( 
+			  userId  = event.getAdminUserId()
+			, maxRows = getSetting( "notificationCountLimit" ) + 1
+		);
 
 		return renderView( view="/admin/notifications/notificationNavPromo", args=args );
+	}
+
+	public string function getAjaxUnreadTopics( event, rc, prc, args={} ) {
+		
+		args.latestNotifications = notificationService.getUnreadTopics(
+			  userId = event.getAdminUserId()
+			, maxRows = getSetting( "notificationCountLimit" ) + 1
+		);
+		
+		return renderView( 
+			  view = "/admin/notifications/_notificationNavTopic"
+			, args = args
+		);
+
 	}
 
 // HELPERS

--- a/system/services/notifications/NotificationService.cfc
+++ b/system/services/notifications/NotificationService.cfc
@@ -118,7 +118,6 @@ component autodoc=true displayName="Notification Service" {
 	 */
 	public numeric function getUnreadNotificationCount(
 		  required string userId
-		, required numeric maxRows 
 	) autodoc=true {
 		var notificationCount = _getConsumerDao().selectData(
 			  filter          = { 

--- a/system/services/notifications/NotificationService.cfc
+++ b/system/services/notifications/NotificationService.cfc
@@ -121,8 +121,7 @@ component autodoc=true displayName="Notification Service" {
 		, required numeric maxRows 
 	) autodoc=true {
 		var notificationCount = _getConsumerDao().selectData(
-			  selectFields    = [ "read as notification" ]
-			, filter          = { 
+			  filter          = { 
 				  security_user = arguments.userId
 				, read          = false 
 			  }

--- a/system/services/notifications/NotificationService.cfc
+++ b/system/services/notifications/NotificationService.cfc
@@ -145,30 +145,27 @@ component autodoc=true displayName="Notification Service" {
 		
 		var unreadTopics = QueryNew( "topic, notification_count", "varchar, integer");
 
-		var notificationTopics =  _getConsumerDao().selectData(
+		var notificationTopics =  _getNotificationDao().selectData(
 			  selectFields = [ "admin_notification.topic" ]
-			, filter       = {
-				  "admin_notification_consumer.security_user" = arguments.userId
-				, "admin_notification_consumer.read"          = false
-			  }
 			, groupBy      = "admin_notification.topic"
 		);
-		  
-		for( notificationTopic in notificationTopics ) {
-			queryAddRow( unreadTopics );
 
+		for( notificationTopic in notificationTopics ) {
 			var queryResult =  _getConsumerDao().selectData(
 				  selectFields = [ "admin_notification.topic" ]
 				, filter       = {
-					"admin_notification_consumer.security_user" = arguments.userId
+					  "admin_notification_consumer.security_user" = arguments.userId
 					, "admin_notification_consumer.read"          = false
 					, "admin_notification.topic"                  = notificationTopic.topic
 				  }
 				, maxRows      = arguments.maxRows
 			);
 
-			querySetCell( unreadTopics, "topic", notificationTopic.topic );
-			querySetCell( unreadTopics, "notification_count", queryResult.recordCount() );
+			if( queryResult.recordCount() ) {
+				queryAddRow( unreadTopics );
+				querySetCell( unreadTopics, "topic", notificationTopic.topic );
+				querySetCell( unreadTopics, "notification_count", queryResult.recordCount() );
+			}
 		}
 		
 		return unreadTopics;

--- a/system/services/notifications/NotificationService.cfc
+++ b/system/services/notifications/NotificationService.cfc
@@ -120,17 +120,17 @@ component autodoc=true displayName="Notification Service" {
 		  required string userId
 		, required numeric maxRows 
 	) autodoc=true {
-		var queryResult = _getConsumerDao().selectData(
-			  selectFields = [ "read as notification" ]
-			, filter       = { 
+		var notificationCount = _getConsumerDao().selectData(
+			  selectFields    = [ "read as notification" ]
+			, filter          = { 
 				  security_user = arguments.userId
 				, read          = false 
 			  }
-			, useCache     = false
-			, maxRows      = arguments.maxRows
+			, useCache        = false
+			, recordCountOnly = true 
 		);
 
-		return queryResult.recordCount()?: "";
+		return notificationCount;
 	}
 
 	/**

--- a/system/views/admin/notifications/_notificationNavTopic.cfm
+++ b/system/views/admin/notifications/_notificationNavTopic.cfm
@@ -1,0 +1,19 @@
+<cfscript>
+	notifications = args.latestNotifications ?: QueryNew('');
+</cfscript>
+
+<cfoutput>
+	<cfloop query="notifications">
+		<li>
+			<a href="#event.buildAdminLink( linkTo="notifications", queryString="topic=#notifications.topic#" )#">
+				<div class="clearfix">
+					<span class="pull-left">
+						<i class="fa fa-fw #translateResource( 'notifications.#notifications.topic#:iconClass', 'fa-bell' )#"></i>
+						#translateResource( 'notifications.#notifications.topic#:title', notifications.topic )#
+					</span>
+					<span class="pull-right badge badge-info">#notifications.notification_count lt getSetting( "notificationCountLimit" )?notifications.notification_count:( getSetting( "notificationCountLimit" )&"+" ) #</span>
+				</div>
+			</a>
+		</li>
+	</cfloop>
+</cfoutput>

--- a/system/views/admin/notifications/notificationNavPromo.cfm
+++ b/system/views/admin/notifications/notificationNavPromo.cfm
@@ -2,22 +2,20 @@
 	event.include( "/js/admin/specific/notifications/" );
 
 	notificationCount      = args.notificationCount   ?: 0;
-	notificationCountLabel = notificationCount lt getSetting( "notificationCountLimit" )?notificationCount:( getSetting( "notificationCountLimit" )&"+")
-	notifications          = args.latestNotifications ?: QueryNew('');
 </cfscript>
 
 
 <cfoutput>
 	<a href="##" class="dropdown-toggle" id="notificationBar" data-href="#event.buildAdminLink( linkTo="notifications.getAjaxUnreadTopics" )#"  data-container="##notificationDropDown" data-toggle="preside-dropdown">
 		<i class="fa fa-bell-o<cfif notificationCount> icon-animated-bell</cfif>"></i>
-		<span class="badge <cfif notificationCount>badge-important</cfif>">#notificationCountLabel#</span>
+		<span class="badge <cfif notificationCount>badge-important</cfif>">#notificationCount#</span>
 	</a>
 
 	<ul class="dropdown-navbar dropdown-menu dropdown-caret dropdown-close" id="notificationDropDown">
 		<li class="dropdown-header">
 			<cfif notificationCount>
 				<i class="icon-warning-sign"></i>
-				#translateResource( uri="cms:notifications.navpromo.count", data=[ notificationCountLabel ] )#
+				#translateResource( uri="cms:notifications.navpromo.count", data=[ notificationCount ] )#
 			<cfelse>
 				<i class="icon-check"></i>
 				#translateResource( "cms:notifications.navpromo.no.new.notifications" )#

--- a/system/views/admin/notifications/notificationNavPromo.cfm
+++ b/system/views/admin/notifications/notificationNavPromo.cfm
@@ -1,40 +1,28 @@
 <cfscript>
-	notificationCount = args.notificationCount   ?: 0;
-	notifications     = args.latestNotifications ?: QueryNew('');
+	event.include( "/js/admin/specific/notifications/" );
+
+	notificationCount      = args.notificationCount   ?: 0;
+	notificationCountLabel = notificationCount lt getSetting( "notificationCountLimit" )?notificationCount:( getSetting( "notificationCountLimit" )&"+")
+	notifications          = args.latestNotifications ?: QueryNew('');
 </cfscript>
 
 
 <cfoutput>
-	<a href="##" class="dropdown-toggle" data-toggle="preside-dropdown">
+	<a href="##" class="dropdown-toggle" id="notificationBar" data-href="#event.buildAdminLink( linkTo="notifications.getAjaxUnreadTopics" )#"  data-container="##notificationDropDown" data-toggle="preside-dropdown">
 		<i class="fa fa-bell-o<cfif notificationCount> icon-animated-bell</cfif>"></i>
-		<span class="badge <cfif notificationCount>badge-important</cfif>">#notificationCount#</span>
+		<span class="badge <cfif notificationCount>badge-important</cfif>">#notificationCountLabel#</span>
 	</a>
 
-	<ul class="dropdown-navbar dropdown-menu dropdown-caret dropdown-close">
+	<ul class="dropdown-navbar dropdown-menu dropdown-caret dropdown-close" id="notificationDropDown">
 		<li class="dropdown-header">
 			<cfif notificationCount>
 				<i class="icon-warning-sign"></i>
-				#translateResource( uri="cms:notifications.navpromo.count", data=[ notificationCount ] )#
+				#translateResource( uri="cms:notifications.navpromo.count", data=[ notificationCountLabel ] )#
 			<cfelse>
 				<i class="icon-check"></i>
 				#translateResource( "cms:notifications.navpromo.no.new.notifications" )#
 			</cfif>
 		</li>
-
-		<cfloop query="notifications">
-			<li>
-				<a href="#event.buildAdminLink( linkTo="notifications", queryString="topic=#notifications.topic#" )#">
-					<div class="clearfix">
-						<span class="pull-left">
-							<i class="fa fa-fw #translateResource( 'notifications.#notifications.topic#:iconClass', 'fa-bell' )#"></i>
-							#translateResource( 'notifications.#notifications.topic#:title', notifications.topic )#
-						</span>
-						<span class="pull-right badge badge-info">#notifications.notification_count#</span>
-					</div>
-				</a>
-			</li>
-		</cfloop>
-
 		<li>
 			<a href="#event.buildAdminLink( linkTo="notifications" )#">
 				#translateResource( 'cms:notifications.navpromo.link.title' )#


### PR DESCRIPTION
- **Limit notification count**
- **Ajax fetch notification topic as suggested by** @john5onCheng 

Default notification limit in  _config.cfc_
> settings.notificationCountLimit      = 100;

During query the countLimit will be added by 1
`select index_field from tablename where condition limit 101`

At frontend it will display as per below 
```
if ( notification.count >100 ) { // if condition meet, then add "+" after count
 display (count&"+");  // output =  "100+"
} else {
 display (count); // output will be the count, "56"
}
```

**Test result ( tested with cache = false and fwReinitCaches = true ) **
- with 20k notification ( 2 notification topic // 10.9k + 9.1k    ) 
  
`getUnreadNotificationCount`
> Total query execution time 
Before : 43.40 ms
 Now    :    1.06 ms

`getUnreadTopics`
> Total query execution time 
Before : 116.00 ms 
Now    :     4.28 ms  
