### PR TITLE
Presidecms 1598 asset folder recursion

### DIFF
--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -870,9 +870,10 @@ component extends="preside.system.base.AdminHandler" {
 
 	function getFoldersForAjaxSelectControl( event, rc, prc ) {
 		var records = assetManagerService.getFoldersForSelectList(
-			  maxRows      = rc.maxRows ?: 100
-			, searchQuery  = rc.q       ?: ""
-			, ids          = ListToArray( rc.values ?: "" )
+			  maxRows             = rc.maxRows ?: 100
+			, searchQuery         = rc.q       ?: ""
+			, ids                 = ListToArray( rc.values ?: "" )
+			, excludeDescendants  = rc.excludeDescendants  ?: ""
 		);
 
 		event.renderData( type="json", data=records );

--- a/system/handlers/formcontrols/AssetFolderPicker.cfc
+++ b/system/handlers/formcontrols/AssetFolderPicker.cfc
@@ -4,16 +4,17 @@ component {
 
 	public string function index( event, rc, prc, args={} ) {
 		var prefetchCacheBuster = assetManagerService.getAssetFolderPrefetchCachebusterForAjaxSelect();
+		var excludeDescendants  = args.excludeDescendants ?: "";
 
-		args.object  = "asset_folder";
+		args.object = "asset_folder";
 
 		args.prefetchUrl = event.buildAdminLink(
 			  linkTo      = "assetManager.getFoldersForAjaxSelectControl"
-			, querystring = "maxRows=100&prefetchCacheBuster=#prefetchCacheBuster#"
+			, querystring = "maxRows=100&prefetchCacheBuster=#prefetchCacheBuster#&excludeDescendants=#excludeDescendants#"
 		);
 		args.remoteUrl = args.remoteUrl ?: event.buildAdminLink(
 			  linkTo      = "assetManager.getFoldersForAjaxSelectControl"
-			, querystring = "q=%QUERY"
+			, querystring = "excludeDescendants=#excludeDescendants#&q=%QUERY"
 		);
 
 		return renderView( view="formcontrols/objectPicker/index", args=args );

--- a/system/preside-objects/assetManager/asset_folder.cfc
+++ b/system/preside-objects/assetManager/asset_folder.cfc
@@ -21,6 +21,7 @@ component output="false" extends="preside.system.base.SystemPresideObject" displ
 	property name="original_label"       type="string"  dbtype="varchar" maxLength=200 required=false;
 
 	property name="parent_folder"    relationship="many-to-one" relatedTo="asset_folder"           required=false uniqueindexes="folderName|1" ondelete="cascade-if-no-cycle-check" onupdate="cascade-if-no-cycle-check";
+	property name="child_folders"    relationship="one-to-many" relatedTo="asset_folder"           required=false relationshipKey="parent_folder";
 	property name="storage_location" relationship="many-to-one" relatedTo="asset_storage_location" required=false;
 	property name="access_condition" relationship="many-to-one" relatedto="rules_engine_condition" required=false control="conditionPicker" ruleContext="webrequest";
 

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -124,11 +124,14 @@ component displayName="AssetManager Service" {
 			ancestorArray.append( folder );
 		}
 
-		while( Len( Trim( folder.parent_folder ) ) && ancestorArray.indexOf( folder ) < 0 ) {
-			folder = getFolder( id=folder.parent_folder )
-
-			if( folder.recordCount ) {
-				ancestorArray.append( folder )
+		while( folder.recordCount ) {
+			if ( not Len( Trim( folder.parent_folder ) ) ) {
+				break;
+			}
+			folder = getFolder( id=folder.parent_folder );
+			if( ancestorArray.indexOf(folder) >= 0 ) break;
+			if ( folder.recordCount ) {
+				ancestorArray.append( folder );
 			}
 		}
 

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -321,10 +321,10 @@ component displayName="AssetManager Service" {
 	}
 
 	public any function getFoldersForSelectList(
-		  numeric maxRows              = 1000
-		, string  searchQuery          = ""
-		, array   ids                  = []
-		, string  excludeDescendants   = []
+		  numeric maxRows            = 1000
+		, string  searchQuery        = ""
+		, array   ids                = []
+		, array   excludeDescendants = []
 		, string  parentFolder
 		, array   noPermissionFolders
 	) {

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -120,7 +120,7 @@ component displayName="AssetManager Service" {
 		var ancestors     = QueryNew( folder.columnList );
 		var ancestorArray = [];
 
-		if ( arguments.includeChildFolder ){
+		if ( arguments.includeChildFolder ) {
 			ancestorArray.append( folder );
 		}
 
@@ -132,7 +132,7 @@ component displayName="AssetManager Service" {
 			}
 		}
 
-		for( var i=1; i <= ancestorArray.len(); i++ ){
+		for( var i=1; i <= ancestorArray.len(); i++ ) {
 			for( folder in ancestorArray[i] ) {
 				QueryAddRow( ancestors, folder );
 			}
@@ -320,72 +320,87 @@ component displayName="AssetManager Service" {
 		return true;
 	}
 
-	public array function getFoldersForSelectList(
+	public any function getFoldersForSelectList(
 		  numeric maxRows              = 1000
 		, string  searchQuery          = ""
 		, array   ids                  = []
-		, string  parentString         = "/ "
-		, string  parentFolder         = ""
-		, array   foldersForSelectList = []
+		, string  excludeDescendants   = []
+		, string  parentFolder
 		, array   noPermissionFolders
 	) {
-		var folderPassesCriteria = function( id, label ){
-			return ( !ids.len() || ids.findNoCase( arguments.id ) ) && ( !Len( Trim( searchQuery ) ) || arguments.label.findNoCase( searchQuery ) );
-		};
-
-		if ( arguments.parentFolder == "" && !arguments.foldersForSelectList.len() ) {
-			var rootFolderName = $translateResource( "cms:assetmanager.root.folder", "" );
-			var rootFolderId   = getRootFolderId();
-
-			if ( folderPassesCriteria( rootFolderId, rootFolderName ) ) {
-				arguments.foldersForSelectList.append({
-					  text  = rootFolderName
-					, value = rootFolderId
-				});
-			}
-		}
-
-		var noPermissionFolders = arguments.noPermissionFolders ?: _userNoPermissionAssetFolders();
-		var filter              = "( asset_folder.is_trashed = :is_trashed and ( asset_folder.hidden = :asset_folder.hidden or asset_folder.hidden is null ) and asset_folder.parent_folder = :parent_folder )";
-		var params              = {
+		var rootFolderId         = getRootFolderId();
+		var foldersForSelectList = [];
+		var noPermissionFolders  = arguments.noPermissionFolders ?: _userNoPermissionAssetFolders();
+		var filter               = "( asset_folder.is_trashed = :is_trashed and ( asset_folder.hidden = :asset_folder.hidden or asset_folder.hidden is null ) )";
+		var params               = {
 			  is_trashed            = false
 			, "asset_folder.hidden" = false
-			, parent_folder         = Len( Trim( arguments.parentFolder ) ) ? arguments.parentFolder : getRootFolderId()
 		}
 
-		if( arrayLen( noPermissionFolders ) ){
+		if( arrayLen( noPermissionFolders ) ) {
 			filter &= " and ( asset_folder.id not in (:asset_folder.id) )";
 			params[ "asset_folder.id" ] = noPermissionFolders;
 		}
 
-		var folders             = _getFolderDao().selectData(
-			  selectFields = [ "id", "label" ]
+		var folders = _getFolderDao().selectData(
+			  selectFields = [ "id", "label", "child_folders.id AS child_id" ]
 			, orderBy      = "label"
 			, filter       = filter
 			, filterParams = params
 		);
 
-		for ( var folder in folders ) {
-			var label = parentString & folder.label;
+		// DATA PRE-PROCESSING
+		// Converting it into a struct with the folder ID as key for easy access.
+		var folderStruct = structNew( "ordered" );
 
-			if ( folderPassesCriteria( folder.id, label ) ) {
-				foldersForSelectList.append( {
-					  text = label
-					, value = folder.id
-				} );
+		for( row in folders ) {
+			if( row.id == rootFolderId ) {
+				row.label = $translateResource( "cms:assetmanager.root.folder", "" );
+			}
+			if( !structKeyExists( folderStruct, row.id ) ) {
+				folderStruct[row.id] = { label=row.label, children=[] };
+			}
+			if( !Len( row.child_id) ) {
+				continue;
+			}
+			folderStruct[row.id].children.prepend(row.child_id);
+		}
+
+		// DFS traversal down the trie.
+		var parentFolderId = arguments.parentFolder ?: rootFolderId
+		var folderQueue    = [ parentFolderId ];
+		var visitedNodes   = [];
+		var folderPassesCriteria = function( id, label ) {
+			return ( !ids.len() || ids.findNoCase( arguments.id ) ) && ( !Len( Trim( searchQuery ) ) || arguments.label.findNoCase( searchQuery ) );
+		};
+
+		while( !folderQueue.isEmpty() ) {
+			if( len(foldersForSelectList) >= arguments.maxRows ) break;
+
+			var currentFolderId = folderQueue[1];
+			var currentFolder   = folderStruct[currentFolderId];
+
+			if( arguments.excludeDescendants.indexOf( currentFolderId ) >= 0 ) {
+				folderQueue.deleteAt(1);
+				continue;
+			};
+
+			if( !folderPassesCriteria( currentFolderId, currentFolder.label ) || visitedNodes.indexOf( currentFolderId ) >= 0 ) {
+				folderQueue.deleteAt(1);
+				continue;
 			}
 
-			if ( foldersForSelectList.len() >= maxRows ) {
-				break;
+			foldersForSelectList.append( { text=currentFolder.label, value=currentFolderId } );
+
+			for( child in currentFolder.children ) {
+				var parentLabel = ( currentFolderId == rootFolderId ) ? "" : currentFolder.label;
+
+				folderStruct[child].label = trim( parentLabel & " / " & folderStruct[child].label );
+				folderQueue.prepend( child );
 			}
 
-			foldersForSelectList = getFoldersForSelectList(
-				  argumentCollection   = arguments
-				, parentString         = parentString & folder.label & " / "
-				, parentFolder         = folder.id
-				, foldersForSelectList = foldersForSelectList
-				, noPermissionFolders  = noPermissionFolders
-			);
+			folderQueue.deleteAt( len( currentFolder.children ) + 1 );
+			visitedNodes.append(currentFolderId);
 		}
 
 		return foldersForSelectList;

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -124,13 +124,11 @@ component displayName="AssetManager Service" {
 			ancestorArray.append( folder );
 		}
 
-		while( folder.recordCount ){
-			if ( not Len( Trim( folder.parent_folder ) ) ) {
-				break;
-			}
-			folder = getFolder( id=folder.parent_folder );
-			if ( folder.recordCount ) {
-				ancestorArray.append( folder );
+		while( Len( Trim( folder.parent_folder ) ) && ancestorArray.indexOf( folder ) < 0 ) {
+			folder = getFolder( id=folder.parent_folder )
+
+			if( folder.recordCount ) {
+				ancestorArray.append( folder )
 			}
 		}
 

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -327,7 +327,7 @@ component displayName="AssetManager Service" {
 		  numeric maxRows            = 1000
 		, string  searchQuery        = ""
 		, array   ids                = []
-		, array   excludeDescendants = []
+		, string  excludeDescendants = ""
 		, string  parentFolder
 		, array   noPermissionFolders
 	) {
@@ -383,7 +383,7 @@ component displayName="AssetManager Service" {
 			var currentFolderId = folderQueue[1];
 			var currentFolder   = folderStruct[currentFolderId];
 
-			if( arguments.excludeDescendants.indexOf( currentFolderId ) >= 0 ) {
+			if( currentFolderId == arguments.excludeDescendants ) {
 				folderQueue.deleteAt(1);
 				continue;
 			};

--- a/system/views/admin/assetmanager/editFolder.cfm
+++ b/system/views/admin/assetmanager/editFolder.cfm
@@ -13,11 +13,12 @@
 
 <cfoutput>
 	#renderView( view="/admin/datamanager/_editRecordForm", args={
-		  object           = "asset_folder"
-		, id               = rc.folder      ?: ""
-		, record           = prc.record ?: {}
-		, editRecordAction = event.buildAdminLink( linkTo='assetmanager.editFolderAction', queryString='folder=#( rc.folder ? : "" )#' )
-		, cancelAction     = event.buildAdminLink( linkTo='assetmanager.index' )
-		, mergeWithFormName= isRootFolder ? "preside-objects.asset_folder.admin.edit.root" : ""
+		  object            = "asset_folder"
+		, id                = rc.folder  ?: ""
+		, record            = prc.record ?: {}
+		, editRecordAction  = event.buildAdminLink( linkTo='assetmanager.editFolderAction', queryString='folder=#( rc.folder ? : "" )#' )
+		, cancelAction      = event.buildAdminLink( linkTo='assetmanager.index' )
+		, mergeWithFormName = isRootFolder ? "preside-objects.asset_folder.admin.edit.root" : ""
+		, additionalArgs    = { fields = { parent_folder = { excludeDescendants = rc.folder ?: "" } } }
 	} )#
 </cfoutput>


### PR DESCRIPTION
Adds an extra one-line check in `AssetManagerService.getFolderAncestors` to check if a folder has already been 'visited' to prevent infinite loops.

Refactor `AssetManagerService.getFoldersForSelectList` to include an extra argument, `excludeDescendants` which takes in a string folder ID and excludes said folder from appearing in the select list.

- Is now iterative via an array acting as a queue instead of recursive.
- Takes an extra argument, `excludeDescendants` which is a folder ID string.
- Will skip said folder when traversing down the tree effectively cutting off the sub-tree.
- Uses `selectData` only once then converts the records into a struct with folderIds as keys.
- Currently depends on selectData's `orderBy` and some special prepending and deleting to get the results in proper order.
- As an extra precaution, checks again if a certain folder has already been 'visited' to avoid duplicates.

Also adds a `one-to-many child_folders` property to the asset_folder object related to parent_folder to make it easier to access a folder's descendants rather than constantly selecting and filtering out folders.

Only sets an `excludeDescendant` when editing folders. Done with an `additionalArgs` passed into the `renderView` of `_editRecordForm` in `views/admin/assetmanager/editFolder.cfm`