### PR TITLE
Feature presidecms 1598 asset folder recursion prevention

### DIFF
--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -870,9 +870,10 @@ component extends="preside.system.base.AdminHandler" {
 
 	function getFoldersForAjaxSelectControl( event, rc, prc ) {
 		var records = assetManagerService.getFoldersForSelectList(
-			  maxRows      = rc.maxRows ?: 100
-			, searchQuery  = rc.q       ?: ""
-			, ids          = ListToArray( rc.values ?: "" )
+			  maxRows            = rc.maxRows ?: 100
+			, searchQuery        = rc.q       ?: ""
+			, ids                = ListToArray( rc.values ?: "" )
+			, currentFolderLabel = rc.currentFolderLabel ?: ""
 		);
 
 		event.renderData( type="json", data=records );

--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -870,10 +870,10 @@ component extends="preside.system.base.AdminHandler" {
 
 	function getFoldersForAjaxSelectControl( event, rc, prc ) {
 		var records = assetManagerService.getFoldersForSelectList(
-			  maxRows            = rc.maxRows ?: 100
-			, searchQuery        = rc.q       ?: ""
-			, ids                = ListToArray( rc.values ?: "" )
-			, currentFolderLabel = rc.currentFolderLabel ?: ""
+			  maxRows         = rc.maxRows ?: 100
+			, searchQuery     = rc.q       ?: ""
+			, ids             = ListToArray( rc.values ?: "" )
+			, currentFolderId = rc.currentFolderId ?: ""
 		);
 
 		event.renderData( type="json", data=records );

--- a/system/handlers/formcontrols/AssetFolderPicker.cfc
+++ b/system/handlers/formcontrols/AssetFolderPicker.cfc
@@ -9,11 +9,11 @@ component {
 
 		args.prefetchUrl = event.buildAdminLink(
 			  linkTo      = "assetManager.getFoldersForAjaxSelectControl"
-			, querystring = "maxRows=100&prefetchCacheBuster=#prefetchCacheBuster#"
+			, querystring = "maxRows=100&prefetchCacheBuster=#prefetchCacheBuster#&currentFolderLabel=#args.savedData.LABEL ?: ""#"
 		);
 		args.remoteUrl = args.remoteUrl ?: event.buildAdminLink(
 			  linkTo      = "assetManager.getFoldersForAjaxSelectControl"
-			, querystring = "q=%QUERY"
+			, querystring = "currentFolderLabel=#args.savedData.LABEL ?: ""#&q=%QUERY"
 		);
 
 		return renderView( view="formcontrols/objectPicker/index", args=args );

--- a/system/handlers/formcontrols/AssetFolderPicker.cfc
+++ b/system/handlers/formcontrols/AssetFolderPicker.cfc
@@ -9,11 +9,11 @@ component {
 
 		args.prefetchUrl = event.buildAdminLink(
 			  linkTo      = "assetManager.getFoldersForAjaxSelectControl"
-			, querystring = "maxRows=100&prefetchCacheBuster=#prefetchCacheBuster#&currentFolderLabel=#args.savedData.LABEL ?: ""#"
+			, querystring = "maxRows=100&prefetchCacheBuster=#prefetchCacheBuster#&currentFolderId=#args.savedData.ID ?: ""#"
 		);
 		args.remoteUrl = args.remoteUrl ?: event.buildAdminLink(
 			  linkTo      = "assetManager.getFoldersForAjaxSelectControl"
-			, querystring = "currentFolderLabel=#args.savedData.LABEL ?: ""#&q=%QUERY"
+			, querystring = "currentFolderId=#args.savedData.ID ?: ""#&q=%QUERY"
 		);
 
 		return renderView( view="formcontrols/objectPicker/index", args=args );

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -330,7 +330,7 @@ component displayName="AssetManager Service" {
 		, string  parentFolder         = ""
 		, array   foldersForSelectList = []
 		, array   noPermissionFolders
-		, string  currentFolderLabel   = ""
+		, string  currentFolderId      = ""
 	) {
 		var folderPassesCriteria = function( id, label ){
 			return ( !ids.len() || ids.findNoCase( arguments.id ) ) && ( !Len( Trim( searchQuery ) ) || arguments.label.findNoCase( searchQuery ) );
@@ -371,7 +371,7 @@ component displayName="AssetManager Service" {
 		for ( var folder in folders ) {
 			var label = parentString & folder.label;
 
-			if ( folderPassesCriteria( folder.id, label ) && ! listContainsNoCase( label, currentFolderLabel ) ) {
+			if ( folderPassesCriteria( folder.id, label ) && ( folder.id neq arguments.currentFolderId ) && ( arguments.parentFolder neq arguments.currentFolderId ) ) {
 				foldersForSelectList.append( {
 					  text = label
 					, value = folder.id

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -330,6 +330,7 @@ component displayName="AssetManager Service" {
 		, string  parentFolder         = ""
 		, array   foldersForSelectList = []
 		, array   noPermissionFolders
+		, string  currentFolderLabel   = ""
 	) {
 		var folderPassesCriteria = function( id, label ){
 			return ( !ids.len() || ids.findNoCase( arguments.id ) ) && ( !Len( Trim( searchQuery ) ) || arguments.label.findNoCase( searchQuery ) );
@@ -370,7 +371,7 @@ component displayName="AssetManager Service" {
 		for ( var folder in folders ) {
 			var label = parentString & folder.label;
 
-			if ( folderPassesCriteria( folder.id, label ) ) {
+			if ( folderPassesCriteria( folder.id, label ) && ! listContainsNoCase( label, currentFolderLabel ) ) {
 				foldersForSelectList.append( {
 					  text = label
 					, value = folder.id


### PR DESCRIPTION
Check with folder ID instead of folder label, and prevent the folder and its child available in the parent folder selection.