### PR TITLE
Feature presidecms 1534 parent folder require selected quickadd

### DIFF
--- a/system/forms/preside-objects/asset_folder/admin.quickadd.xml
+++ b/system/forms/preside-objects/asset_folder/admin.quickadd.xml
@@ -7,7 +7,7 @@ This form is used for adding asset folders in a quick add popover
 <form>
 	<tab id="basic" sortorder="10" title="preside-objects.asset_folder:basic.tab.title">
 		<fieldset id="basic" sortorder="10">
-			<field sortorder="10" binding="asset_folder.parent_folder" control="assetFolderPicker" />
+			<field sortorder="10" binding="asset_folder.parent_folder" control="assetFolderPicker" required="true" />
 			<field sortorder="20" binding="asset_folder.label" />
 		</fieldset>
 	</tab>


### PR DESCRIPTION
Add `required="true"` attribute to asset folder quick add form.
![PRESIDECMS-1534_parent_folder_require_selected_quickadd screenshot](https://user-images.githubusercontent.com/50225529/61344788-249e9480-a885-11e9-9b81-8074aae11ac0.png)
