### PR TITLE
PRESIDECMS-1631 fix broken multilingual og url

### DIFF
--- a/system/views/general/_openGraphMeta.cfm
+++ b/system/views/general/_openGraphMeta.cfm
@@ -6,6 +6,7 @@
 	local.title        = Trim( event.getPageProperty( "title"              ) );
 	local.mainImage    = Trim( event.getPageProperty( "main_image"         ) );
 	local.ogType       = local.site.og_type ?: "website";
+	local.ogUrl        = event.getSiteUrl() & HtmlEditFormat( event.getCurrentUrl() );
 
 	local.title  = Len( local.browserTitle ) ? local.browserTitle : local.title;
 	local.teaser = Len( local.teaser       ) ? local.teaser       : local.description;
@@ -14,7 +15,7 @@
 <cfoutput>
 	<meta property="og:title" content="#XmlFormat( local.title )#" />
 	<meta property="og:type"  content="#local.ogType#" />
-	<meta property="og:url"   content="#event.getSiteUrl()##HtmlEditFormat( event.getCurrentUrl() )#" />
+	<meta property="og:url"   content="#reReplace( local.ogUrl, "/([a-z][a-z]/)(\1)+", "/\1")#" />
 	<cfif Len( local.teaser )>
 		<meta property="og:description" content="#HtmlEditFormat( local.teaser )#" />
 	</cfif>

--- a/system/views/general/_openGraphMeta.cfm
+++ b/system/views/general/_openGraphMeta.cfm
@@ -6,7 +6,6 @@
 	local.title        = Trim( event.getPageProperty( "title"              ) );
 	local.mainImage    = Trim( event.getPageProperty( "main_image"         ) );
 	local.ogType       = local.site.og_type ?: "website";
-	local.ogUrl        = event.getSiteUrl() & HtmlEditFormat( event.getCurrentUrl() );
 
 	local.title  = Len( local.browserTitle ) ? local.browserTitle : local.title;
 	local.teaser = Len( local.teaser       ) ? local.teaser       : local.description;
@@ -15,7 +14,7 @@
 <cfoutput>
 	<meta property="og:title" content="#XmlFormat( local.title )#" />
 	<meta property="og:type"  content="#local.ogType#" />
-	<meta property="og:url"   content="#reReplace( local.ogUrl, "/([a-z][a-z]/)(\1)+", "/\1")#" />
+	<meta property="og:url"   content="#event.getSiteUrl( includeLanguageSlug=false )##HtmlEditFormat( event.getCurrentUrl() )#" /> 
 	<cfif Len( local.teaser )>
 		<meta property="og:description" content="#HtmlEditFormat( local.teaser )#" />
 	</cfif>


### PR DESCRIPTION
Updates og:url in _openGraphMeta.cfm to remove duplicate languages in url.
RegEx: `reReplace( local.ogUrl, "/([a-z][a-z]/)(\1)+", "/\1")`

Notes for, if some reason, these cases happen:
1. Does not account for capital letters e.g. '/EN/' or '/dE/' or '/Fr/'.
2. In the case there are two doubles back to back, it will not match the
   2nd one. e.g. '/de/de/de/' -> '/de/' but '/de/de/en/en/' ->
   '/de/en/en/' however '/de/de/en/fr/fr/' still becomes '/de/en/fr/'.