### PR TITLE
Feature presidecms 1588 fix datetimepicker relative to formcontrol

### DIFF
--- a/system/assets/js/admin/presidecore/preside.datepicker.js
+++ b/system/assets/js/admin/presidecore/preside.datepicker.js
@@ -67,7 +67,8 @@
 				}
 
 				$relativeField.on( "changeDate", function( e ){
-					var newDate = new Date( e.date );
+					var newDate   = new Date( e.date );
+					    fieldDate = datetimePicker.date();
 
 					switch( relativeOperator ) {
 						case "lt":

--- a/system/assets/js/admin/presidecore/preside.datetimepicker.js
+++ b/system/assets/js/admin/presidecore/preside.datetimepicker.js
@@ -81,7 +81,8 @@
 				}
 
 				$relativeField.on( "dp.change", function( e ){
-					var newDate = new Date( e.date );
+					var newDate   = new Date( e.date );
+					    fieldDate = datetimePicker.date();
 
 					switch( relativeOperator ) {
 						case "lt":


### PR DESCRIPTION
For cases like PRESIDECMS-1588 where two datetimepickers are relative to each other.
```
property name="datefrom" type="date"   dbtype="datetime" relativeToField="dateto" relativeOperator="lte" required="true";
property name="dateto"   type="date"   dbtype="datetime" relativeToField="datefrom" relativeOperator="gte";
```

The issue is when the relativeField was being changed, it had a check if the current datetimepicker's value (`var fieldDate = datetimePicker.date()`) was `null`. If it was, it'd clear the form control. The variable holding the datetimepicker's value was actually never updated despite being changed and hence constantly was evaluated as `null` which explains the disappearing dates in the issue.

Fix was to update the variable directly in the `onchange` function.

Should be noted that if the 2 datetimepicker object attributes weren't relativeTo each other, the issue never occurs without side effects (e.g. changing constraints, having to modify code, etc.)

```
property name="datefrom" type="date"   dbtype="datetime" required=true;
property name="dateto"   type="date"   dbtype="datetime" relativeToField="datefrom" relativeOperator="gte";
```