### PR TITLE
PRESIDECMS-1442 asset manager view show last uploaded

### DIFF
--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -891,7 +891,7 @@ component extends="preside.system.base.AdminHandler" {
 			, searchQuery = datatableHelper.getSearchQuery()
 			, folder      = rc.folder ?: ""
 		);
-		var gridFields = [ "title", "datemodified" ];
+		var gridFields = [ "title", "datemodified", "datecreated" ];
 		var renderedOptions = [];
 		var checkboxCol     = []
 

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -471,7 +471,7 @@ component displayName="AssetManager Service" {
 	public struct function getAssetsForGridListing(
 		  numeric startRow    = 1
 		, numeric maxRows     = 10
-		, string  orderBy     = ""
+		, string  orderBy     = "datecreated ASC"
 		, string  searchQuery = ""
 		, string  folder      = ""
 		, boolean trashed     = false
@@ -485,7 +485,7 @@ component displayName="AssetManager Service" {
 			  startRow     = arguments.startRow
 			, maxRows      = arguments.maxRows
 			, orderBy      = arguments.orderBy
-			, selectFields = [ "id", "asset_folder", "#titleField# as title", "asset_type", "datemodified" ]
+			, selectFields = [ "id", "asset_folder", "#titleField# as title", "asset_type", "datemodified", "datecreated" ]
 		};
 
 		if ( Len( Trim( arguments.searchQuery ) ) ) {

--- a/system/views/admin/assetmanager/listingTable.cfm
+++ b/system/views/admin/assetmanager/listingTable.cfm
@@ -22,6 +22,7 @@
 					</th>
 					<th data-field="title">#translateResource( "preside-objects.asset:title.singular" )#</th>
 					<th data-width="240px" data-field="datemodified">#translateResource( "preside-objects.asset:field.datemodified.title" )#</th>
+					<th data-width="240px" data-field="datecreated">#translateResource( "preside-objects.asset:field.datecreated.title" )#</th>
 					<th data-width="100px">#translateResource( "cms:assetmanager.browser.table.actions.header" )#</th>
 				</tr>
 			</thead>


### PR DESCRIPTION
The listing table for Asset Manager now has a column for 'First uploaded' and orders the asset records by `datecreated` by default.