### PR TITLE
Feature presidecms 1401 wrap the asset name to avoid layout break

### DIFF
--- a/system/assets/css/admin/specific/assetmanager/index/listingTable.less
+++ b/system/assets/css/admin/specific/assetmanager/index/listingTable.less
@@ -21,15 +21,26 @@
 						display          : inline-block;
 					}
 
+					.asset-title {
+						display: inline-block;
+						width  : 80%;
+					}
+
 					.asset-preview {
 						width   : 60px;
 						display : inline-block;
+						float   : left;
 
 						img {
 							max-width  : 48px;
 							max-height : 32px;
 						}
 					}
+				}
+
+				.asset-name {
+					word-wrap: break-word;
+					max-width: 250px;
 				}
 
 				&:first-child td {

--- a/system/assets/css/admin/specific/assetmanager/index/listingTable.less
+++ b/system/assets/css/admin/specific/assetmanager/index/listingTable.less
@@ -24,16 +24,20 @@
 					.asset-title {
 						display: inline-block;
 						width  : 80%;
+						height : 100%;
 					}
 
 					.asset-preview {
 						width   : 60px;
-						display : inline-block;
+						height  : 100%;
+						display : flex;
 						float   : left;
 
 						img {
 							max-width  : 48px;
 							max-height : 32px;
+							display    : inline-block;
+							margin     : auto 0;
 						}
 					}
 				}
@@ -41,6 +45,7 @@
 				.asset-name {
 					word-wrap: break-word;
 					max-width: 250px;
+					height   : 100%;
 				}
 
 				&:first-child td {

--- a/system/assets/js/admin/specific/assetmanager/index/assetBrowser.js
+++ b/system/assets/js/admin/specific/assetmanager/index/assetBrowser.js
@@ -131,13 +131,17 @@
 		mData     : "_checkbox",
 		sWidth    : "5em"
 	} );
-	for( i=1; i < $tableHeaders.length-1; i++ ){
-		colConfig.push( {
-			  mData     : $( $tableHeaders.get(i) ).data( 'field' )
-			, sWidth    : $( $tableHeaders.get(i) ).data( 'width' ) || 'auto'
-			, bSortable : true
-		} );
-	}
+	colConfig.push( {
+		  mData     : $( $tableHeaders.get(1) ).data( 'field' )
+		, sWidth    : $( $tableHeaders.get(1) ).data( 'width' ) || 'auto'
+		, bSortable : true
+		, sClass    : "asset-name"
+	} );
+	colConfig.push( {
+		  mData     : $( $tableHeaders.get(2) ).data( 'field' )
+		, sWidth    : $( $tableHeaders.get(2) ).data( 'width' ) || 'auto'
+		, bSortable : true
+	} );
 	colConfig.push( {
 		sClass    : "center",
 		bSortable : false,

--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -901,7 +901,7 @@ component extends="preside.system.base.AdminHandler" {
 			for( var field in gridFields ){
 				records[ field ][ records.currentRow ] = renderField( "asset", field, record[ field ], [ "adminDataTable", "admin" ] );
 				if ( field == "title" ) {
-					records[ field ][ records.currentRow ] = '<span class="asset-preview">' & renderAsset( assetId=record.id, context="pickericon" ) & "</span> " & records[ field ][ records.currentRow ];
+					records[ field ][ records.currentRow ] = '<span class="asset-preview">' & renderAsset( assetId=record.id, context="pickericon" ) & "</span> <span class='asset-title'>" & records[ field ][ records.currentRow ] & "</span>";
 				}
 			}
 
@@ -941,9 +941,9 @@ component extends="preside.system.base.AdminHandler" {
 				if ( field == "title" ) {
 					var type = assetManagerService.getAssetType( name=record.asset_type );
 					if ( ( type.groupName ?: "" ) == "image" ) {
-						records[ field ][ records.currentRow ] = '<span class="asset-preview"><img class="lazy" src="#event.buildLink( assetId=record.id, trashed=true )#"></span> ' & records[ field ][ records.currentRow ];
+						records[ field ][ records.currentRow ] = '<span class="asset-preview"><img class="lazy" src="#event.buildLink( assetId=record.id, trashed=true )#"></span> <span class="asset-title">' & records[ field ][ records.currentRow ] & "</span>";
 					} else {
-						records[ field ][ records.currentRow ] = '<span class="asset-preview">' & renderAsset( assetId=record.id, context="pickerIcon" ) & '</span> ' & records[ field ][ records.currentRow ];
+						records[ field ][ records.currentRow ] = '<span class="asset-preview">' & renderAsset( assetId=record.id, context="pickerIcon" ) & '</span> <span class="asset-title">' & records[ field ][ records.currentRow ] & "</span>";
 					}
 				}
 			}


### PR DESCRIPTION
Add `asset-name` class to style the asset name column.
Add `asset-title` class to style the preview and title.

Please refer to screenshot for the outcome.
![Screenshot 2019-07-30 at 10 29 49 AM](https://user-images.githubusercontent.com/50225529/62096676-09854900-b2b7-11e9-85c6-cf37de500dcd.png)

Thank you
Brayden