### PR TITLE
Feature presidecms 1368 default filters

### DIFF
--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -192,14 +192,18 @@ component displayName="Preside Object Service" {
 		,          array   bypassTenants           = []
 		,          array   ignoreDefaultFilters    = []
 	) autodoc=true {
-		var defaultFilters = listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) );
-		if( !defaultFilters.isEmpty() ){
-			if( !arguments.ignoreDefaultFilters.isEmpty() ){
-				arguments.ignoreDefaultFilters.each( function(element){
-					defaultFilters.delete(element);
-				});
+		var adminRequest = $getRequestContext().isAdminRequest();
+		
+		if ( !adminRequest ){
+			var defaultFilters = listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) );
+			if( !defaultFilters.isEmpty() ){
+				if( !arguments.ignoreDefaultFilters.isEmpty() ){
+					arguments.ignoreDefaultFilters.each( function(element){
+						defaultFilters.delete(element);
+					});
+				}
+				arguments.savedFilters.append( defaultFilters, true );
 			}
-			arguments.savedFilters.append( defaultFilters, true );
 		}
 
 		var args = _cleanupPropertyAliases( argumentCollection=Duplicate( arguments ) );

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -190,7 +190,18 @@ component displayName="Preside Object Service" {
 		,          boolean distinct                = false
 		,          struct  tenantIds               = {}
 		,          array   bypassTenants           = []
+		,          array   ignoreDefaultFilters    = []
 	) autodoc=true {
+		var defaultFilters = listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) );
+		if( !defaultFilters.isEmpty() ){
+			if( !arguments.ignoreDefaultFilters.isEmpty() ){
+				arguments.ignoreDefaultFilters.each( function(element){
+					defaultFilters.delete(element);
+				});
+			}
+			arguments.savedFilters.append( defaultFilters, true );
+		}
+
 		var args = _cleanupPropertyAliases( argumentCollection=Duplicate( arguments ) );
 		var interceptorResult = _announceInterception( "preSelectObjectData", args );
 		if ( IsBoolean( interceptorResult.abort ?: "" ) && interceptorResult.abort ) {

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -2952,20 +2952,19 @@ component displayName="Preside Object Service" {
 	}
 
 	private array function _getDefaultFilters( required string objectName, required array ignoreDefaultFilters ){
-		var adminRequest = $getRequestContext().isAdminRequest();
+
 		var defaultFilters = [];
 
-		if ( !adminRequest ){
-			defaultFilters.append( listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) ), true );
+		defaultFilters.append( listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) ), true );
 
-			if( !defaultFilters.isEmpty() ){
-				if( !arguments.ignoreDefaultFilters.isEmpty() ){
-					arguments.ignoreDefaultFilters.each( function(element){
-						defaultFilters.delete(element);
-					});
-				}
+		if( !defaultFilters.isEmpty() ){
+			if( !arguments.ignoreDefaultFilters.isEmpty() ){
+				arguments.ignoreDefaultFilters.each( function(element){
+					defaultFilters.delete(element);
+				});
 			}
 		}
+
 
 		return defaultFilters;
 	}

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -192,19 +192,8 @@ component displayName="Preside Object Service" {
 		,          array   bypassTenants           = []
 		,          array   ignoreDefaultFilters    = []
 	) autodoc=true {
-		var adminRequest = $getRequestContext().isAdminRequest();
-		
-		if ( !adminRequest ){
-			var defaultFilters = listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) );
-			if( !defaultFilters.isEmpty() ){
-				if( !arguments.ignoreDefaultFilters.isEmpty() ){
-					arguments.ignoreDefaultFilters.each( function(element){
-						defaultFilters.delete(element);
-					});
-				}
-				arguments.savedFilters.append( defaultFilters, true );
-			}
-		}
+
+		arguments.savedFilters.append( _getDefaultFilters( arguments.objectName, arguments.ignoreDefaultFilters ), true );
 
 		var args = _cleanupPropertyAliases( argumentCollection=Duplicate( arguments ) );
 		var interceptorResult = _announceInterception( "preSelectObjectData", args );
@@ -2960,6 +2949,25 @@ component displayName="Preside Object Service" {
 		}
 
 		return expanded;
+	}
+
+	private array function _getDefaultFilters( required string objectName, required array ignoreDefaultFilters ){
+		var adminRequest = $getRequestContext().isAdminRequest();
+		var defaultFilters = [];
+
+		if ( !adminRequest ){
+			defaultFilters.append( listToArray( getObjectAttribute( arguments.objectName, "defaultFilters", "" ) ), true );
+
+			if( !defaultFilters.isEmpty() ){
+				if( !arguments.ignoreDefaultFilters.isEmpty() ){
+					arguments.ignoreDefaultFilters.each( function(element){
+						defaultFilters.delete(element);
+					});
+				}
+			}
+		}
+
+		return defaultFilters;
 	}
 
 	private struct function _prepareFilter(


### PR DESCRIPTION
The default filters can be defined in the `Config.cfc` like how saved filters are defined.
Example: 
<pre><code>settings.filters = {
      publishedStuff = { filter = "stuff.published=true" }
    , approvedStuff = { filter = "stuff.approved=true" }
};</code></pre>

To use the saved filters as a default filter, it must be defined in the `Object.cfc`.
<pre><code>/**
 * @datamanagerGridFields label,approved,published
 * @defaultFilters publishedStuff,approvedStuff
 */
component dataManagerGroup="Lookup" {
	property name="approved" type="boolean" dbtype="boolean";
	property name="published" type="boolean" dbtype="boolean";
}</code></pre>

So whenever, `selectData()` is called, it will automatically filter the query using the default filters.

These default filters can be ignored by specifying which filter to be ignored.
<pre><code>args.stuff = presideObjectService.selectData(
      objectName = "stuff"
    , selectFields = [
          "label"
        , "approved"
	, "published"
    ]
    , ignoreDefaultFilters = [ "publishedStuff" ]
);</code></pre>

How it works is by just appending the default filters( the ones that are not ignored ) to the `arguments.savedFilters` in the `PresideObjectService.cfc`. I had also added a condition in `_getDefaultFilters()` private function to check if the current request is an admin request because without it, default filters will be applied to the data manager as well.

