### PR TITLE
Feature presidecms 1656 email overwrite domain

### DIFF
--- a/support/tests/integration/api/email/EmailServiceTest.cfc
+++ b/support/tests/integration/api/email/EmailServiceTest.cfc
@@ -310,6 +310,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		mockColdBox                = createMock( "preside.system.coldboxModifications.Controller" );
 		mockEmailTemplateService   = createMock( "preside.system.services.email.EmailTemplateService" );
 		mockServiceProviderService = createMock( "preside.system.services.email.EmailServiceProviderService" );
+		
+		mockTemplate = createStub();
+		
+		mockEmailTemplateService.$( "getTemplate" ).$results( mockTemplate );
+		mockEmailTemplateService.$( "$isFeatureEnabled" ).$args( "emailOverwriteDomain" ).$results( false );
+		mockEmailTemplateService.$( "enableDomainOverwriteForBuildLink" );
 
 		var service = createMock( object=new preside.system.services.email.EmailService(
 			  emailTemplateDirectories    = templateDirs

--- a/support/tests/integration/api/email/EmailTemplateServiceTest.cfc
+++ b/support/tests/integration/api/email/EmailTemplateServiceTest.cfc
@@ -1597,6 +1597,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		service.$( "$getPresideObject" ).$args( "email_blueprint" ).$results( mockBlueprintDao );
 		service.$( "$getPresideObject" ).$args( "email_template_view_online_content" ).$results( mockViewOnlineContentDao );
 		service.$( "$isFeatureEnabled" ).$args( "emailStyleInliner" ).$results( true );
+		service.$( "$isFeatureEnabled" ).$args( "emailOverwriteDomain" ).$results( false );
 		service.$( "$audit" );
 		service.$( "$getRequestContext", mockRequestContext );
 

--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -29,7 +29,13 @@ component extends="coldbox.system.web.context.RequestContextDecorator" {
 		var fetchSite = ( prc._forceDomainLookup ?: false ) || ( Len( Trim( arguments.siteId ) ) && arguments.siteId != getSiteId() );
 		var site      = fetchSite ? getModel( "siteService" ).getSite( arguments.siteId ) : getSite();
 		var protocol  = ( site.protocol ?: getProtocol() );
-		var siteUrl   = protocol & "://" & ( fetchSite ? ( site.domain ?: cgi.server_name ) : cgi.server_name );
+		var domain    = ( fetchSite ? ( site.domain ?: cgi.server_name ) : cgi.server_name );
+		
+		if ( overwriteDomainForBuildLink() ) {
+			domain = getOverwriteDomainForBuildLink();
+		}
+		
+		var siteUrl   = protocol & "://" & domain;
 
 		prc.delete( "_forceDomainLookup" );
 
@@ -115,9 +121,14 @@ component extends="coldbox.system.web.context.RequestContextDecorator" {
 			return this.getSiteUrl( site="", includePath=false, includeLanguageSlug=false );
 		}
 
+		var protocol = getProtocol() & "://";
+		var port     = !listFindNoCase( "80,443", cgi.SERVER_PORT ) ? ( ":" & cgi.SERVER_PORT ) : "";
+		
+		if ( overwriteDomainForBuildLink() ) {
+			return protocol & getOverwriteDomainForBuildLink() & port;
+		}
+		
 		var allowedDomains = getController().getSetting( "allowedDomains" );
-		var protocol       = getProtocol() & "://";
-		var port           = !listFindNoCase( "80,443", cgi.SERVER_PORT ) ? ( ":" & cgi.SERVER_PORT ) : "";
 
 		if ( IsArray( allowedDomains ) && allowedDomains.len() ) {
 			return protocol & allowedDomains[1] & port;
@@ -140,6 +151,24 @@ component extends="coldbox.system.web.context.RequestContextDecorator" {
 
 	public string function getCurrentPresideUrlPath() {
 		return getRequestContext().getValue( name="_presideUrlPath", private=true, defaultValue="/" );
+	}
+	
+	public boolean function overwriteDomainForBuildLink() {
+		return getRequestContext().valueExists( name="_overwriteDomainForBuildLink", private=true );
+	}
+	
+	public string function getOverwriteDomainForBuildLink() {
+		return getRequestContext().getValue( name="_overwriteDomainForBuildLink", defaultValue="", private=true );
+	}
+	
+	public void function setOverwriteDomainForBuildLink( required string domain ) {
+		if ( len( arguments.domain ) ) {
+			getRequestContext().setValue( name="_overwriteDomainForBuildLink", value=arguments.domain, private=true );
+		}
+	}
+	
+	public void function removeOverwriteDomainForBuildLink() {
+		getRequestContext().removeValue( name="_overwriteDomainForBuildLink", private=true );
 	}
 
 // REQUEST DATA

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -358,6 +358,7 @@ component {
 			, emailCenterResend       = { enabled=false, siteTemplates=[ "*" ] }
 			, emailStyleInliner       = { enabled=true , siteTemplates=[ "*" ] }
 			, emailLinkShortener      = { enabled=false, siteTemplates=[ "*" ] }
+			, emailOverwriteDomain    = { enabled=false, siteTemplates=[ "*" ] }
 			, customEmailTemplates    = { enabled=true , siteTemplates=[ "*" ] }
 			, apiManager              = { enabled=false, siteTemplates=[ "*" ] }
 			, restTokenAuth           = { enabled=false, siteTemplates=[ "*" ] }

--- a/system/forms/email/layout/default.xml
+++ b/system/forms/email/layout/default.xml
@@ -4,6 +4,7 @@
 		<fieldset id="default" sortorder="10">
 			<field name="signature_html" control="richeditor" widgetCategories="email" />
 			<field name="signature_text" control="textarea" />
+			<field name="overwrite_domain" feature="emailOverwriteDomain" />
 		</fieldset>
 	</tab>
 </form>

--- a/system/i18n/email/layout/default.properties
+++ b/system/i18n/email/layout/default.properties
@@ -6,3 +6,7 @@ field.signature_html.help=Try to keep signature HTML formatting to a minimum and
 
 field.signature_text.title=Signature (plain text)
 field.signature_text.placeholder=Should contain NO HTML. e.g. The Preside Team
+
+field.overwrite_domain.title=Overwrite Domain
+field.overwrite_domain.placeholder=e.g. newsletter.mycompany.com
+field.overwrite_domain.help=This will overwrite the domain being used within the mailing (Click and Open Tracking, View online, Regular links, etc.)

--- a/system/i18n/email/layout/default_de.properties
+++ b/system/i18n/email/layout/default_de.properties
@@ -4,3 +4,6 @@ field.signature_html.title=Signatur (html)
 field.signature_html.help=Versuchen Sie, die HTML-Formatierung der Signatur auf ein Minimum zu beschr\u00E4nken. Denken Sie daran mit verschiedenen E-Mail-Clients zu testen\!
 field.signature_text.title=Signatur (Nur Text)
 field.signature_text.placeholder=Sollte KEIN HTML enthalten, z.B. Das Preside Team
+field.overwrite_domain.title=Dom\u00e4ne \u00fcberschreiben
+field.overwrite_domain.placeholder=z.B. newsletter.firma.com
+field.overwrite_domain.help=Wenn hier eine Dom\u00e4ne eingetragen wird, werden jegliche URLs innerhalb der E-Mail damit \u00fcberschrieben (Click und Open Tracking, View Online, regul\u00e4re Links, usw.)

--- a/system/services/email/EmailService.cfc
+++ b/system/services/email/EmailService.cfc
@@ -69,7 +69,13 @@ component displayName="Email service" {
 		, boolean overwriteTemplateArgs = false
 		, boolean isTest                = false
 	) autodoc=true {
+	
 		var hasTemplate = Len( Trim( arguments.template ) );
+		
+		if ( hasTemplate ) {
+			_getEmailTemplateService().enableDomainOverwriteForBuildLink( template=_getEmailTemplateService().getTemplate( id=arguments.template ) );
+		}
+		
 		var sendArgs    = hasTemplate ? _mergeArgumentsWithTemplateHandlerResult( argumentCollection=arguments ) : arguments;
 		    sendArgs    = _addDefaultsForMissingArguments( sendArgs );
 
@@ -78,11 +84,17 @@ component displayName="Email service" {
 		sendArgs.args = arguments.args;
 		sendArgs.args.template = sendArgs.template = arguments.template;
 
-		return _getEmailServiceProviderService().sendWithProvider(
+		var result = _getEmailServiceProviderService().sendWithProvider(
 			  provider = _getEmailServiceProviderService().getProviderForTemplate( arguments.template )
 			, sendArgs = sendArgs
 			, logSend  = !arguments.isTest
 		);
+		
+		if ( hasTemplate ) {
+			_getEmailTemplateService().disableDomainOverwriteForBuildLink();
+		}
+		
+		return result;
 	}
 
 	/**

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -218,6 +218,8 @@ component {
 				, recipientType = messageTemplate.recipient_type
 			);
 		}
+		
+		enableDomainOverwriteForBuildLink( template=messageTemplate );
 
 		var message       = { subject = replaceParameterTokens( messageTemplate.subject, params, "text" ) };
 		var body          = replaceParameterTokens( $renderContent( renderer="richeditor", data=messageTemplate.html_body, context="email" ), params, "html" );
@@ -265,6 +267,8 @@ component {
 		if ( Len( Trim( previewRecipient ) ) ) {
 			_getEmailSendingContextService().clearContext();
 		}
+		
+		disableDomainOverwriteForBuildLink();
 
 		return message;
 	}
@@ -1222,7 +1226,33 @@ component {
 			, forceDeleteAll = !arguments.templateId.len()
 		);
 	}
-
+	
+	public void function enableDomainOverwriteForBuildLink( required struct template ) {
+		if ( !$isFeatureEnabled( "emailOverwriteDomain" ) ) {
+			return;
+		}
+		
+		if ( len( arguments.template.id ?: "" ) && len( arguments.template.layout ?: "" ) && len( arguments.template.email_blueprint ?: "" ) ) {
+			var layoutConfig = _getEmailLayoutService().getLayoutConfig(
+				  layout        = arguments.template.layout
+	            , emailTemplate = arguments.template.id
+	            , blueprint     = arguments.template.email_blueprint
+	            , merged        = true
+			);
+			
+			if ( len( layoutConfig.overwrite_domain ?: "" ) ) {
+				$getRequestContext().setOverwriteDomainForBuildLink( domain=layoutConfig.overwrite_domain );
+			}
+		}
+	}
+	
+	public void function disableDomainOverwriteForBuildLink() {
+		if ( !$isFeatureEnabled( "emailOverwriteDomain" ) ) {
+			return;
+		}
+		
+		$getRequestContext().removeOverwriteDomainForBuildLink();
+	}
 
 // PRIVATE HELPERS
 	private void function _ensureSystemTemplatesHaveDbEntries() {


### PR DESCRIPTION
Added the option to overwrite emails for buildLink. Implicitely other RequestContectDecorator functions need to use this as well, e.g. getSiteUrl - because of custom route handlers making use of those.

In addition there is a new email layout option for the default layout to set a custom domain that overwrite the default one within email center preview and during actual sending.