### PR TITLE
PRESIDECMS-1680 send test email to custom email template with anonymous as recipient

### DIFF
--- a/system/handlers/admin/emailCenter/CustomTemplates.cfc
+++ b/system/handlers/admin/emailCenter/CustomTemplates.cfc
@@ -804,7 +804,13 @@ component extends="preside.system.base.AdminHandler" {
 
 	private string function _getTestSendFormName( event, rc, prc ) {
 		var filterObject  = emailRecipientTypeService.getFilterObjectForRecipientType( prc.template.recipient_type );
-		var labelRenderer = presideObjectService.getObjectAttribute( filterObject, "labelRenderer" );
+
+		if ( !isEmpty( filterObject ) ) {
+			var labelRenderer = presideObjectService.getObjectAttribute( filterObject, "labelRenderer" );
+		} else {
+			var labelRenderer = "";
+		}
+
 		var orderBy       = "label";
 		var cacheBuster   = createuuid();
 		var preFetchUrl   = event.buildAdminLink(


### PR DESCRIPTION
The error was coming from `presideObjectService.getObjectAttribute`.
Added !isEmpty() check for `filterObject` to prevent this.

Thanks
Brayden