### PR TITLE
Feature presidecms 1683 anonymous user tracking is not working when full page caching is enabled

### DIFF
--- a/system/interceptors/PageCachingInterceptor.cfc
+++ b/system/interceptors/PageCachingInterceptor.cfc
@@ -4,6 +4,7 @@ component extends="coldbox.system.Interceptor" {
 	property name="delayedViewletRendererService" inject="delayedInjector:delayedViewletRendererService";
 	property name="delayedStickerRendererService" inject="delayedInjector:delayedStickerRendererService";
 	property name="loginService"                  inject="delayedInjector:websiteLoginService";
+	property name="websiteUserActionService"      inject="delayedInjector:websiteUserActionService";
 
 // PUBLIC
 	public void function configure() {}
@@ -18,6 +19,15 @@ component extends="coldbox.system.Interceptor" {
 				event.checkPageAccess();
 				var viewletsRendered = delayedViewletRendererService.renderDelayedViewlets( cached.body ?: "" );
 				var contentType      = cached.contentType ?: "";
+
+				var pageId = getPresideObject( "page" ).selectData( selectFields=[ "id" ] ,filter={ _hierarchy_slug=prc.slug } ).id;
+				websiteUserActionService.recordAction(
+					  action     = "pagevisit"
+					, type       = "request"
+					, identifier = pageId
+					, userId     = getLoggedInUserId()
+				);
+
 				content reset=true;
 				if ( len( contentType ) ) {
 					content type=contentType;


### PR DESCRIPTION
Added `websiteUserActionService.recordAction(...)` in PageCachingInterceptor. When local cached is found it still recordAction for page visit.

Thanks
Brayden