### PR TITLE
PRESIDECMS-1697 emai centre scheduling settings issue

### DIFF
--- a/support/tests/integration/api/email/EmailTemplateServiceTest.cfc
+++ b/support/tests/integration/api/email/EmailTemplateServiceTest.cfc
@@ -655,7 +655,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 
 				for( var r in mockResult ) { expected = r; }
 
-				mockTemplateDao.$( "selectData" ).$args( id=template, allowDraftVersions=false, fromversionTable=false, specificVersion=0 ).$results( mockResult );
+				mockTemplateDao.$( "selectData" ).$args( id=template, allowDraftVersions=false, fromversionTable=false, specificVersion=0, useCache=false ).$results( mockResult );
 
 				expect( service.getTemplate( template ) ).toBe( expected );
 			} );
@@ -668,7 +668,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 
 				for( var r in mockResult ) { expected = r; }
 
-				mockTemplateDao.$( "selectData" ).$args( id=template, allowDraftVersions=true, fromversionTable=true, specificVersion=0 ).$results( mockResult );
+				mockTemplateDao.$( "selectData" ).$args( id=template, allowDraftVersions=true, fromversionTable=true, specificVersion=0, useCache=false ).$results( mockResult );
 
 				expect( service.getTemplate( id=template, allowDrafts=true ) ).toBe( expected );
 			} );
@@ -687,6 +687,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					, allowDraftVersions = false
 					, fromversionTable   = true
 					, specificVersion    = version
+					, useCache           = false
 				).$results( mockResult );
 
 				expect( service.getTemplate( id=template, version=version ) ).toBe( expected );
@@ -705,7 +706,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					, service_provider = mockBlueprint.service_provider
 				};
 
-				mockTemplateDao.$( "selectData" ).$args( id=template, allowDraftVersions=false, fromversionTable=false, specificVersion=0 ).$results( mockResult );
+				mockTemplateDao.$( "selectData" ).$args( id=template, allowDraftVersions=false, fromversionTable=false, specificVersion=0, useCache=false ).$results( mockResult );
 				mockBlueprintDao.$( "selectData" ).$args( id=mockResult.email_blueprint ).$results( mockBlueprint );
 
 				expect( service.getTemplate( template ) ).toBe( expected );

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -444,6 +444,7 @@ component {
 			, allowDraftVersions = arguments.allowDrafts
 			, fromversionTable   = arguments.fromVersionTable
 			, specificVersion    = arguments.version
+			, useCache           = false
 		);
 
 		for( var t in template ) {


### PR DESCRIPTION
Because the getTemplate() method wasn't returning the most up-to-date version of the template this was causing issues when modifying the settings. So updated to always select the data from the database directly rather than cache.