### PR TITLE
PRESIDECMS-1723 assetmanager prehandler update

### DIFF
--- a/system/handlers/admin/AssetManager.cfc
+++ b/system/handlers/admin/AssetManager.cfc
@@ -38,6 +38,9 @@ component extends="preside.system.base.AdminHandler" {
 		}
 
 		prc.rootFolderId = assetManagerService.getRootFolderId();
+		if ( Len( Trim( rc.asset_folder ?: "" ) ) ) {
+			rc.folder = rc.asset_folder;
+		}
 		if ( !Len( Trim( rc.folder ?: "" ) ) ) {
 			rc.folder = prc.rootFolderId;
 		}


### PR DESCRIPTION
The action `uploadAssetAction` have rc.asset_folder and did not have rc.folder. When checking for permission, it will always check for root folder permission instead of the folder that an admin is trying to upload the asset to (rc.asset_folder). I have added a check so that it checks if rc.asset_folder is present, if it is present, then it will set it to rc.folder. Then the logic will check if rc.folder is present, else set it to root folder.