### PR TITLE
Fix: Formbuilder export icon missing.

### DIFF
--- a/system/views/admin/formbuilder/_statusControls.cfm
+++ b/system/views/admin/formbuilder/_statusControls.cfm
@@ -61,7 +61,7 @@
 				<a href="#event.buildAdminLink( linkto='formbuilder.exportSubmissions', queryString='formid=' & formId )#" title="#HtmlEditFormat( translateResource( 'formbuilder:excel.download.link' ) )#">
 					<span class="fa-stack fa-lg green">
 						<i class="fa fa-circle fa-stack-2x"></i>
-						<i class="fa fa-cloud-download fa-stack-1x fa-inverse"></i>
+						<i class="fa fa-cloud-download fa-stack-1x"></i>
 					</span>
 				</a>
 			</label>


### PR DESCRIPTION
minor tweak on formbuilder layout where export icon is not visible due to `fa-inverse` class on a white background