### PR TITLE
PRESIDECMS-1755 sort extensions function loop infinitely

### DIFF
--- a/system/services/devtools/ExtensionManagerService.cfc
+++ b/system/services/devtools/ExtensionManagerService.cfc
@@ -99,9 +99,8 @@ component {
 						var extC = extensions[ n ];
 
 						if ( extA.dependsOn.findNoCase( extC.id ) ) {
-							var tmp = extC;
-							extensions[ n ] = extA;
-							extensions[ i ] = tmp;
+							arrayDeleteAt(extensions, n);
+							arrayInsertAt(extensions, i, extC);
 							swapped = true;
 							break;
 						}


### PR DESCRIPTION
Updated _sortExtensions function logic when sorting dependant extensions to move the extensions they are depending on that lies behind them up to a position above them instead of swapping their position.