### PR TITLE
PRESIDECMS-1654 asset url is too long

### DIFF
--- a/system/preside-objects/assetManager/asset.cfc
+++ b/system/preside-objects/assetManager/asset.cfc
@@ -9,7 +9,7 @@ component extends="preside.system.base.SystemPresideObject" labelfield="title" d
 	property name="title"             type="string"  dbtype="varchar" maxLength=150     required=true   uniqueindexes="assetfolder|2";
 	property name="file_name"         type="string"  dbtype="varchar" maxLength=150     required=false  indexes="filename";
 	property name="storage_path"      type="string"  dbtype="varchar" maxLength=255     required=true   uniqueindexes="assetpath";
-	property name="asset_url"         type="string"  dbtype="varchar" maxLength=255     required=false  uniqueindexes="asseturl";
+	property name="asset_url"         type="string"  dbtype="varchar" maxLength=1024    required=false;
 	property name="description"       type="string"  dbtype="text"    maxLength=0       required=false;
 	property name="author"            type="string"  dbtype="varchar" maxLength=100     required=false;
 	property name="size"              type="numeric" dbtype="int"                       required=true;

--- a/system/preside-objects/assetManager/asset_derivative.cfc
+++ b/system/preside-objects/assetManager/asset_derivative.cfc
@@ -8,11 +8,11 @@ component extends="preside.system.base.SystemPresideObject" displayName="Asset d
 
 	property name="label" maxLength=200 required=true uniqueindexes="derivative|3";
 
-	property name="storage_path" type="string" dbtype="varchar" maxLength=255 required=true  uniqueindexes="assetpath";
-	property name="asset_url"    type="string" dbtype="varchar" maxLength=255 required=false uniqueindexes="asseturl";
-	property name="asset_type"   type="string" dbtype="varchar" maxLength=10  required=true;
-	property name="config"       type="string" dbtype="text"                  required=false;
-	property name="config_hash"  type="string" dbtype="varchar" maxLength=12  required=false uniqueindexes="derivative|4";
+	property name="storage_path" type="string" dbtype="varchar" maxLength=255  required=true  uniqueindexes="assetpath";
+	property name="asset_url"    type="string" dbtype="varchar" maxLength=1024 required=false;
+	property name="asset_type"   type="string" dbtype="varchar" maxLength=10   required=true;
+	property name="config"       type="string" dbtype="text"                   required=false;
+	property name="config_hash"  type="string" dbtype="varchar" maxLength=12   required=false uniqueindexes="derivative|4";
 
 	property name="is_trashed"   type="boolean" dbtype="boolean"               required=false default=false;
 	property name="trashed_path" type="string"  dbtype="varchar" maxLength=255 required=false;

--- a/system/preside-objects/assetManager/asset_version.cfc
+++ b/system/preside-objects/assetManager/asset_version.cfc
@@ -12,7 +12,7 @@ component extends="preside.system.base.SystemPresideObject" labelfield="title" d
 	property name="version_number"    type="numeric" dbtype="int"                       required=true  uniqueindexes="assetversion|2";
 
 	property name="storage_path"      type="string"  dbtype="varchar" maxLength=255     required=true  uniqueindexes="assetversionpath";
-	property name="asset_url"         type="string"  dbtype="varchar" maxLength=255     required=false uniqueindexes="assetversionurl";
+	property name="asset_url"         type="string"  dbtype="varchar" maxLength=1024    required=false;
 	property name="size"              type="numeric" dbtype="int"                       required=true;
 	property name="asset_type"        type="string"  dbtype="varchar" maxLength=10      required=true;
 	property name="raw_text_content"  type="string"  dbtype="longtext";


### PR DESCRIPTION
Extend `asset_url` field length to 1024 and remove unique indexes for `asset_url` fields.