### PR TITLE
Datamanager export permission customisation

### DIFF
--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -64,7 +64,7 @@ component extends="preside.system.base.AdminHandler" {
 				, isMultilingual      = IsTrue( prc.isMultilingual  ?: "" )
 				, draftsEnabled       = IsTrue( prc.draftsEnabled   ?: "" )
 				, canDelete           = IsTrue( prc.canDelete       ?: "" )
-				, allowDataExport     = IsTrue( prc.allowDataExport ?: "" )
+				, allowDataExport     = structKeyExists( prc, "allowDataExport" ) ? IsTrue( prc.allowDataExport ?: "" ) : true
 			}
 		);
 	}

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -61,9 +61,10 @@ component extends="preside.system.base.AdminHandler" {
 				, gridFields          = prc.gridFields          ?: _getObjectFieldsForGrid( objectName )
 				, hiddenGridFields    = prc.hiddenGridFields    ?: []
 				, batchEditableFields = prc.batchEditableFields ?: []
-				, isMultilingual      = IsTrue( prc.isMultilingual ?: "" )
-				, draftsEnabled       = IsTrue( prc.draftsEnabled  ?: "" )
-				, canDelete           = IsTrue( prc.canDelete      ?: "" )
+				, isMultilingual      = IsTrue( prc.isMultilingual  ?: "" )
+				, draftsEnabled       = IsTrue( prc.draftsEnabled   ?: "" )
+				, canDelete           = IsTrue( prc.canDelete       ?: "" )
+				, allowDataExport     = IsTrue( prc.allowDataExport ?: "" )
 			}
 		);
 	}
@@ -108,7 +109,7 @@ component extends="preside.system.base.AdminHandler" {
 				args.append( {
 					  useMultiActions = args.multiActions.len()
 					, multiActionUrl  = event.buildAdminLink( objectName=objectName, operation="multiRecordAction" )
-					, allowDataExport = args.allowDataExport ?: true
+					, allowDataExport = IsTrue( args.allowDataExport ?: _checkPermission( argumentCollection=arguments, object=objectName, key="read", throwOnError=false ) )
 				} );
 			}
 

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -61,9 +61,9 @@ component extends="preside.system.base.AdminHandler" {
 				, gridFields          = prc.gridFields          ?: _getObjectFieldsForGrid( objectName )
 				, hiddenGridFields    = prc.hiddenGridFields    ?: []
 				, batchEditableFields = prc.batchEditableFields ?: []
-				, isMultilingual      = IsTrue( prc.isMultilingual  ?: "" )
-				, draftsEnabled       = IsTrue( prc.draftsEnabled   ?: "" )
-				, canDelete           = IsTrue( prc.canDelete       ?: "" )
+				, isMultilingual      = IsTrue( prc.isMultilingual ?: "" )
+				, draftsEnabled       = IsTrue( prc.draftsEnabled  ?: "" )
+				, canDelete           = IsTrue( prc.canDelete      ?: "" )
 			}
 		);
 	}

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -64,7 +64,6 @@ component extends="preside.system.base.AdminHandler" {
 				, isMultilingual      = IsTrue( prc.isMultilingual  ?: "" )
 				, draftsEnabled       = IsTrue( prc.draftsEnabled   ?: "" )
 				, canDelete           = IsTrue( prc.canDelete       ?: "" )
-				, allowDataExport     = structKeyExists( prc, "allowDataExport" ) ? IsTrue( prc.allowDataExport ?: "" ) : true
 			}
 		);
 	}
@@ -106,10 +105,18 @@ component extends="preside.system.base.AdminHandler" {
 					, defaultHandler = "admin.datamanager._listingMultiActions"
 					, args           = args
 				);
+				
+				var allowDataExport = false;
+				
+				if ( dataManagerService.isDataExportEnabled( objectName ) ) {
+					var permissionKey = dataManagerService.getDataExportPermissionKey( objectName );
+					allowDataExport   = _checkPermission( argumentCollection=arguments, object=objectName, key=permissionKey, throwOnError=false );
+				}
+				
 				args.append( {
 					  useMultiActions = args.multiActions.len()
 					, multiActionUrl  = event.buildAdminLink( objectName=objectName, operation="multiRecordAction" )
-					, allowDataExport = IsTrue( args.allowDataExport ?: _checkPermission( argumentCollection=arguments, object=objectName, key="read", throwOnError=false ) )
+					, allowDataExport = allowDataExport
 				} );
 			}
 

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -757,6 +757,21 @@ component {
 
 		return filter;
 	}
+	
+	public boolean function isDataExportEnabled( required string objectName ) {
+	
+		if ( !$isFeatureEnabled( "dataexport" ) ) {
+			return false;
+		}
+
+		var exportEnabled = _getPresideObjectService().getObjectAttribute( objectName=arguments.objectName, attributeName="dataManagerExportEnabled", defaultValue=true );
+
+		return IsBoolean( exportEnabled ) && exportEnabled;
+	}
+	
+	public string function getDataExportPermissionKey( required string objectName ) {
+		return _getPresideObjectService().getObjectAttribute( objectName=arguments.objectName, attributeName="dataManagerExportPermissionKey", defaultValue="read" );
+	}
 
 // PRIVATE HELPERS
 	private array function _prepareGridFieldsForSqlSelect( required array gridFields, required string objectName, boolean versionTable=false, boolean draftsEnabled=areDraftsEnabledForObject( arguments.objectName ) ) {


### PR DESCRIPTION
added params to allow data manager customisations for the allowDataExport flag. This is useful if a custom website wants to distinguish export and read permissions.
I did not want to introduce an export permission in the core as this would break a lot of existing applications. This way now gives 2 possibilities to use a custom export permission, either by evaluating a permission in preRenderListing or by customising checkPermission.