### PR TITLE
Feature presidecms 1776 asset items overlapping asset name on asset manager

### DIFF
--- a/system/assets/css/admin/specific/assetmanager/index/listingTable.less
+++ b/system/assets/css/admin/specific/assetmanager/index/listingTable.less
@@ -26,7 +26,7 @@
 						display : inline-block;
 
 						img {
-							max-width  : 48px;
+							max-width  : 100%;
 							max-height : 32px;
 						}
 					}


### PR DESCRIPTION
Limit the css of asset image max-width to 100%, to avoid overlapping happened in smaller screen size.