### PR TITLE
PRESIDECMS-1798 Read UTF-8 from i18n files

### DIFF
--- a/system/services/i18n/ResourceBundleService.cfc
+++ b/system/services/i18n/ResourceBundleService.cfc
@@ -218,7 +218,7 @@ component singleton=true {
 
 	private struct function _propertiesFileToStruct( required string propertiesFile ) output=false {
 		var fis          = CreateObject("java","java.io.FileInputStream").init( arguments.propertiesFile );
-		var fir 		 = CreateObject( "java", "java.io.InputStreamReader" ).init( fis, "UTF-8" );
+		var fir          = CreateObject("java","java.io.InputStreamReader").init( fis, "UTF-8" );
 		var prb          = CreateObject("java","java.util.PropertyResourceBundle").init( fir );
 		var keys         = prb.getKeys();
 		var key          = "";

--- a/system/services/i18n/ResourceBundleService.cfc
+++ b/system/services/i18n/ResourceBundleService.cfc
@@ -218,7 +218,8 @@ component singleton=true {
 
 	private struct function _propertiesFileToStruct( required string propertiesFile ) output=false {
 		var fis          = CreateObject("java","java.io.FileInputStream").init( arguments.propertiesFile );
-		var prb          = CreateObject("java","java.util.PropertyResourceBundle").init( fis );
+		var fir 		 = CreateObject( "java", "java.io.InputStreamReader" ).init( fis, "UTF-8" );
+		var prb          = CreateObject("java","java.util.PropertyResourceBundle").init( fir );
 		var keys         = prb.getKeys();
 		var key          = "";
 		var returnStruct = {};


### PR DESCRIPTION
support utf-8 character for .properties files
you can write utf-8 format : 

"Đạt đẹp trai" 

instead of convert to 

"\u0110\u1EA1t \u0111\u1EB9p trai".

I think it will save a lot of time for countries using the UTF-8 format

It works well with the old converted utf-8 format