### PR TITLE
Feature presidecms 1806 allowed types for link picker

### DIFF
--- a/system/handlers/admin/LinkPicker.cfc
+++ b/system/handlers/admin/LinkPicker.cfc
@@ -3,14 +3,31 @@ component extends="preside.system.base.AdminHandler" {
 	property name="presideObjectService" inject="presideObjectService";
 	property name="linkPickerConfig"     inject="coldbox:setting:ckeditor.linkPicker";
 
-	function index( event, rc, prc ) {
-		var configCat = rc.linkPickerCategory ?: "default";
-		if ( !StructKeyExists( linkPickerConfig, configCat ) ) {
-			configCat = "default";
+	public void function preHandler( event, action ) {
+		super.preHandler( argumentCollection=arguments );
+		
+		if( !isEmptyString( rc.allowedTypes ?:"" ) ) {
+			prc.linkTypes = listToArray( rc.allowedTypes );
+		}else {
+			var configCat = rc.linkPickerCategory ?: "default";
+			if ( !StructKeyExists( linkPickerConfig, configCat ) ) {
+				configCat = "default";
+			}
+			
+			var linkTypes = linkPickerConfig[ configCat ].types ?: [ "sitetreelink", "url", "email", "asset", "anchor" ];
+
+			switch ( action ) {
+				case "quickAddForm"  :
+				case "quickEditForm" :
+					linkTypes = [  "email", "sitetreelink", "url", "asset"  ];
+					break;
+			}
+
+			prc.linkTypes = linkTypes;
 		}
+	}
 
-		prc.linkTypes = linkPickerConfig[ configCat ].types ?: [ "sitetreelink", "url", "email", "asset", "anchor" ];
-
+	function index( event, rc, prc ) {
 		event.setLayout( "adminModalDialog" );
 		event.setView( "admin/linkPicker/index" );
 	}

--- a/system/handlers/formcontrols/LinkPicker.cfc
+++ b/system/handlers/formcontrols/LinkPicker.cfc
@@ -1,17 +1,19 @@
 component {
 
 	public string function index( event, rc, prc, args={} ) {
-		args.control   = "objectPicker";
-		args.object    = "link";
-		args.quickAdd  = args.quickAdd  ?: true;
-		args.quickEdit = args.quickEdit ?: true;
+		args.control     = "objectPicker";
+		args.object      = "link";
+		args.quickAdd    = args.quickAdd     ?: true;
+		args.quickEdit   = args.quickEdit    ?: true;
+		var allowedTypes = args.allowedTypes ?: "";
 
-		args.quickAddUrl         = event.buildAdminLink( linkTo="LinkPicker.quickAddForm" );
-		args.quickEditUrl        = event.buildAdminLink( linkTo="LinkPicker.quickEditForm", queryString="id=" );
+		args.quickAddUrl         = event.buildAdminLink( linkTo="LinkPicker.quickAddForm", queryString="allowedTypes=#allowedTypes#" );
+		args.quickEditUrl        = event.buildAdminLink( linkTo="LinkPicker.quickEditForm", queryString="allowedTypes=#allowedTypes#&id=" );
 		args.quickAddModalTitle  = "cms:linkpicker.quick.add.modal.title";
 		args.quickEditModalTitle = "cms:linkpicker.quick.edit.modal.title";
 
 		return renderViewlet( event="formcontrols.objectPicker.index", args=args );
+
 	}
 
 }

--- a/system/views/admin/linkPicker/quickAddForm.cfm
+++ b/system/views/admin/linkPicker/quickAddForm.cfm
@@ -1,9 +1,9 @@
 <cfscript>
-	linkType = rc.type ?: "sitetreelink";
+	linkTypes = prc.linkTypes ?: [];
+	linkType  = LCase( rc.type ?: ( linkTypes[ 1 ] ?: "" ) );
 
-	validLinkTypes = "email,url,sitetreelink,asset";
-	if ( !ListFindNoCase( validLinkTypes, linkType ) ) {
-		linkType = "sitetreelink";
+	if ( !ArrayFind( linkTypes, linkType ) ) {
+		linkType = linkTypes[ 1 ] ?: "";
 	}
 
 	formId = "link-picker-form";
@@ -16,7 +16,7 @@
 	<div class="row link-picker">
 		<div class="col-sm-2">
 			<div class="link-type-menu">
-				#renderView( view="admin/linkPicker/_linkTypeMenu", args={ selectedType=(rc.type ?: "sitetreelink" ), allowedTypes="email,url,sitetreelink,asset" } )#
+				#renderView( view="admin/linkPicker/_linkTypeMenu", args={ allowedTypes=linkTypes, selectedType=linkType } )#
 			</div>
 		</div>
 		<div class="col-sm-10">

--- a/system/views/admin/linkPicker/quickEditForm.cfm
+++ b/system/views/admin/linkPicker/quickEditForm.cfm
@@ -1,23 +1,19 @@
 <cfscript>
-	record = prc.record ?: {};
-	linkType = record.type ?: "sitetreelink";
+	record    = prc.record    ?: {};
+	linkTypes = prc.linkTypes ?: [];
+	linkType  = record.type   ?: ( linkTypes[ 1 ] ?: "sitetreelink" );
+
+	formId = "link-picker-form";
 
 	validationResult = rc.validationResult ?: "";
 	editRecordAction = event.buildAdminLink( linkTo='datamanager.quickEditRecordAction', queryString="object=link" );
-
-	validLinkTypes = "email,url,sitetreelink,asset";
-	if ( !ListFindNoCase( validLinkTypes, linkType ) ) {
-		linkType = "sitetreelink";
-	}
-
-	formId = "link-picker-form";
 </cfscript>
 
 <cfoutput>
 	<div class="row link-picker">
 		<div class="col-sm-2">
 			<div class="link-type-menu">
-				#renderView( view="admin/linkPicker/_linkTypeMenu", args={ selectedType=linkType, allowedTypes="email,url,sitetreelink,asset" } )#
+				#renderView( view="admin/linkPicker/_linkTypeMenu", args={ selectedType=linkType, allowedTypes=linkTypes } )#
 			</div>
 		</div>
 		<div class="col-sm-10">


### PR DESCRIPTION
- Added allowedTypes to  queryString for quickAdd & quickEdit url in formControl/linkPicker.cfc
- Add pre-handler in admin/linkPicker.cfc  for the linTypes logic to follow DRY concept instead of adding the logic in each function.
- Ammended linkPicker/quickAddForm.cfm & linkPicker/quickEditForm.cfm to be as similar as linkPicker/index.cfm on adapting the allowedTypes

More info for this PR.
https://presidecms.atlassian.net/browse/PRESIDECMS-1806

Example
`<field name="testLink" control="linkPicker" allowedTypes="sitetreelink,url"/>
`
https://www.screencast.com/t/CZmwhIPI4
