### PR TITLE
Feature presidecms 1347 cancel link for managed page types

### DIFF
--- a/system/handlers/admin/SiteTree.cfc
+++ b/system/handlers/admin/SiteTree.cfc
@@ -180,6 +180,12 @@ component extends="preside.system.base.AdminHandler" {
 		prc.mainFormName  = "preside-objects.page.add";
 		prc.mergeFormName = _getPageTypeFormName( pageType, "add" );
 
+		if ( _isManagedPage( parentPageId, rc.page_type ) ) {
+			prc.cancelLink = event.buildAdminLink( linkto="sitetree.managedChildren", querystring="parent=#parentPageId#&pageType=#rc.page_type#" );
+		} else {
+			prc.cancelLink = event.buildAdminLink( linkTo="sitetree" );
+		}
+
 		_pageCrumbtrail( argumentCollection=arguments, pageId=parentPageId, pageTitle=prc.parentPage.title );
 		event.addAdminBreadCrumb(
 			  title = translateResource( uri="cms:sitetree.addPage.title" )

--- a/system/views/admin/sitetree/addPage.cfm
+++ b/system/views/admin/sitetree/addPage.cfm
@@ -15,6 +15,7 @@
 
 	canPublish   = IsTrue( prc.canPublish   ?: "" );
 	canSaveDraft = IsTrue( prc.canSaveDraft ?: "" );
+	cancelLink   = Len( Tirm( prc.cancelLink ?: "" ) ) ? prc.cancelLink : event.buildAdminLink( linkTo="sitetree" );
 </cfscript>
 
 <cfoutput>
@@ -48,7 +49,7 @@
 			)#
 
 			<div class="col-md-offset-2">
-				<a href="#event.buildAdminLink( linkTo="sitetree" )#" class="btn btn-default" data-global-key="c">
+				<a href="#cancelLink#" class="btn btn-default" data-global-key="c">
 					<i class="fa fa-reply bigger-110"></i>
 					#translateResource( "cms:sitetree.cancel.btn" )#
 				</a>

--- a/system/views/admin/sitetree/editPage.cfm
+++ b/system/views/admin/sitetree/editPage.cfm
@@ -189,7 +189,7 @@
 		)#
 		<div class="form-actions row">
 			<div class="col-md-offset-2">
-				<a href="#event.buildAdminLink( linkTo="sitetree" )#" class="btn btn-default" data-global-key="c">
+				<a href="#backToTreeLink#" class="btn btn-default" data-global-key="c">
 					<i class="fa fa-reply bigger-110"></i>
 					#translateResource( "cms:sitetree.cancel.btn" )#
 				</a>


### PR DESCRIPTION
Hi,

This pull request is used to ensure admin will always get back to the list for manage pagetypes when clicking cancel in add page and edit page.

Thank you,
Kok Ann