### PR TITLE
PRESIDECMS-1821

### DIFF
--- a/system/assets/ckeditorExtensions/config.js
+++ b/system/assets/ckeditorExtensions/config.js
@@ -14,29 +14,8 @@
 CKEDITOR.editorConfig = function( config ) {
 	// activate our plugins
 	config.extraPlugins = "autogrow,widgets,imagepicker,attachmentpicker,presidelink,codesnippet";
-	config.codeSnippet_theme = "atelier-dune.dark";
-	// the skin we are using
-	config.skin = "bootstrapck";
 
 	// configuring the auto imported styles from editor stylesheet (see stylesheetparser plugin)
 	config.stylesSet = [];
 	config.stylesheetParser_validSelectors = /^(h[1-6]|p|span|pre|li|ul|ol|dl|dt|dd|small|i|b|em|strong|table)\.\w+/;
-
-	// Set the most common block elements.
-	config.format_tags = 'p;h1;h2;h3;h4;h5;h6;pre;div';
-
-	// auto grow config
-	config.autoGrow_onStartup = true;
-
-	// email obfuscation for link plugin
-	config.emailProtection = 'encode';
-
-	config.scayt_sLang = "en_GB";
-
-	// To Remove the CKeditor IFrame plugin by default
-	config.removePlugins = 'iframe';
-
-	// Paste from word
-	config.pasteFromWordPromptCleanup = true;
-	config.disallowedContent = 'font;*[align];*{line-height};*{margin*};';
 };

--- a/system/assets/js/admin/presidecore/preside.richeditor.js
+++ b/system/assets/js/admin/presidecore/preside.richeditor.js
@@ -17,8 +17,8 @@ PresideRichEditor = ( function( $ ){
 		  , stylesheets           = $elementToReplace.data( "stylesheets" )
 		  , enterMode             = $elementToReplace.data( "enterMode" )
 		  , autoParagraph         = $elementToReplace.data( "autoParagraph" ) !== undefined ? $elementToReplace.data( "autoParagraph" ) : cfrequest.ckeditorAutoParagraph
-		  , extraAllowedContent   = cfrequest.ckeditorExtraAllowedContent   || ""
-		  , pasteFromWordDisallow = cfrequest.ckeditorPasteFromWordDisallow || []
+		  , defaultConfigs        = cfrequest.ckeditorDefaultConfigs || {}
+		  , pasteFromWordDisallow = []
 		  , editor;
 
 		if ( toolbar && toolbar.length ) {
@@ -55,7 +55,12 @@ PresideRichEditor = ( function( $ ){
 		config.autoParagraph       = autoParagraph;
 		config.widgetCategories    = widgetCategories;
 		config.linkPickerCategory  = linkPickerCategory;
-		config.extraAllowedContent = extraAllowedContent;
+
+		for( var defaultConfig in defaultConfigs ) {
+			config[defaultConfig] = defaultConfigs[defaultConfig];
+		}
+
+		pasteFromWordDisallow = config.pasteFromWordDisallow;
 
 		CKEDITOR.on( "instanceReady", function( event ) {
 			event.editor.initialdata = event.editor.getData();

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -350,13 +350,24 @@ component {
 				, minHeight             = 0
 				, maxHeight             = 300
 				, autoParagraph         = false
-				, configFile            = "/ckeditorExtensions/config.js?v=VERSION_NUMBER"
-				, extraAllowedContent   = "img dl dt dd"
-				, pasteFromWordDisallow = [
-					  "span"  // Strip all span elements
-					, "*(*)"  // Strip all classes
-					, "*{*}"  // Strip all inline-styles
-				  ]
+				, configFile            = "/ckeditorExtensions/config.js?v=10.11.38+0006339"
+				, defaultConfigs        = {
+					  pasteFromWordPromptCleanup      = true
+					, codeSnippet_theme               = "atelier-dune.dark"
+					, skin                            = "bootstrapck"
+					, format_tags                     = 'p;h1;h2;h3;h4;h5;h6;pre;div'
+					, autoGrow_onStartup              = true
+					, emailProtection                 = 'encode'
+					, removePlugins                   = 'iframe'
+					, disallowedContent               = 'font;*[align];*{line-height};*{margin*};'
+					, scayt_sLang                     = "en_GB"
+					, pasteFromWordDisallow           = [
+						  "span"  // Strip all span elements
+						, "*(*)"  // Strip all classes
+						, "*{*}"  // Strip all inline-styles
+					]
+					, extraAllowedContent   = "img dl dt dd"
+				}
 			  }
 			, linkPicker = _getRicheditorLinkPickerConfig()
 			, toolbars   = _getCkEditorToolbarConfig()

--- a/system/views/admin/layout/ckEditorJs.cfm
+++ b/system/views/admin/layout/ckEditorJs.cfm
@@ -18,7 +18,6 @@
 		, ckeditorDefaultMinHeight      = ckeditorSettings.defaults.minHeight             ?: "auto"
 		, ckeditorDefaultMaxHeight      = ckeditorSettings.defaults.maxHeight             ?: 300
 		, ckeditorAutoParagraph         = ckeditorSettings.defaults.autoParagraph         ?: true
-		, ckeditorExtraAllowedContent   = ckeditorSettings.defaults.extraAllowedContent   ?: ""
-		, ckeditorPasteFromWordDisallow = ckeditorSettings.defaults.pasteFromWordDisallow ?: []
+		, ckeditorDefaultConfigs        = ckeditorSettings.defaults.defaultConfigs        ?: {}
 	} );
 </cfscript>


### PR DESCRIPTION
Move CKeditor JS config to config.cfc

NOTE:
I have the problem to move `config.stylesheetParser_validSelectors` to Config.cfc

Wrapping up the string with double quote will break

config.stylesheetParser_validSelectors = /^(h[1-6]|p|span|pre|li|ul|ol|dl|dt|dd|small|i|b|em|strong|table)\.\w+/;

Could you help to see if moving this to config.cfc is possible?
