### PR TITLE
Update viewRecord.cfm

### DIFF
--- a/system/views/admin/datahelpers/viewRecord.cfm
+++ b/system/views/admin/datahelpers/viewRecord.cfm
@@ -13,12 +13,12 @@
 	#preRenderRecord#
 
 	<div class="row">
-		<div class="col-md-6">
+		<div class="col-lg-12">
 			#preRenderRecordLeftCol#
 			#leftCol#
 			#postRenderRecordLeftCol#
 		</div>
-		<div class="col-md-6">
+		<div class="col-lg-12">
 			#preRenderRecordRightCol#
 			#rightCol#
 			#postRenderRecordRightCol#


### PR DESCRIPTION
if you have relations in your objects and therefore you have datamanager grid fields in your admin record view, you end up with an ugly view record layout just for the sake to have the system properties in the right col. 
The cols are 6/6 at the moment, the datamanager grid fields don't fit in 6 cold most of the time and so they overflow.
My proposal is to show the system information at the end of the admin record view and show the important information first.