### PR TITLE
Feature presidecms 1838 issue on rendering email widgets

### DIFF
--- a/system/handlers/renderers/content/RichEditor.cfc
+++ b/system/handlers/renderers/content/RichEditor.cfc
@@ -18,4 +18,9 @@ component {
 		return renderView( view="renderers/content/richeditor/adminView", args=args );
 	}
 
+	public string function email( event, rc, prc, args={} ){
+		args.data = args.data ?: "";
+		args.data = contentRendererService.renderEmbeddedWidgets( richContent=args.data, context="email" );
+		return default( argumentCollection=arguments );
+	}
 }


### PR DESCRIPTION
Added "email" context which can be used to render email widgets instead of using prc.template.
Thanks to @choontat-pixl8  for the approach.

Previously using prc.template has bug where the prc doesn't detected during sending the email.
```
var template  = prc.template ?: {};
if ( emailLayoutService.layoutExists( template.layout ?: "" ) ) {
     return renderView( view="widgets/button/email", args=args );
}
return renderView( view="widgets/button/index", arrgs=args );
```

With email context which have been tested to be working. 
The way it will be used in widgets are like like below.
```
var context  = args.context ?: "";
var viewPath = "widgets/button/#context#";
if ( !getController().viewExists( viewPath ) ) {
   viewPath = "widgets/button/index";
}
return renderView( view=viewPath, args=args );
```


