### PR TITLE
PRESIDECMS-1827 Fix for Scheduled future email task did not calculate / save the next send date

### DIFF
--- a/support/tests/integration/api/email/EmailTemplateServiceTest.cfc
+++ b/support/tests/integration/api/email/EmailTemplateServiceTest.cfc
@@ -310,7 +310,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				expect( service.$callLog().saveTemplate[1].template.schedule_next_send_date ?: "" ).toBe( nextSendDate );
 			} );
 
-			it( "should set the schedule_next_send_date field when the schedule type is 'repeat' and next_send_date later than newly calculated send date", function(){
+			it( "should the schedule_next_send_date field when the schedule type is 'repeat' with newly calculated send date", function(){
 				var service      = _getService();
 				var templateId   = CreateUUId();
 				var nowish       = Now();
@@ -337,19 +337,20 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 
 			} );
 
-			it( "should not set the schedule_next_send_date field when the schedule type is 'repeat' and next_send_date is in the future and earlier than newly calculated send date", function(){
+			it( "should set the next send date to start date when start date is in the future", function(){
 				var service      = _getService();
 				var templateId   = CreateUUId();
 				var nowish       = Now();
-				var nextSendDate = DateAdd( "d", 3, nowish );
+				var nextSendDate = DateAdd( "ww", 4, nowish );
+				var startDate    = DateAdd( "ww", 1, nowish );
 				var template = {
 					  sending_method          = "scheduled"
 					, schedule_type           = "repeat"
 					, schedule_measure        = 3
 					, schedule_unit           = "day"
-					, schedule_start_date     = ""
+					, schedule_start_date     = startDate
 					, schedule_end_date       = ""
-					, schedule_next_send_date = DateAdd( "d", 2, nowish )
+					, schedule_next_send_date = nextSendDate
 				};
 
 				service.$( "getTemplate" ).$args( id=templateId, allowDrafts=true, fromVersionTable=false ).$results( template );
@@ -360,34 +361,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 
 				expect( service.$callLog().saveTemplate.len() ).toBe( 1 );
 				expect( service.$callLog().saveTemplate[1].id ?: "" ).toBe( templateId );
-				expect( service.$callLog().saveTemplate[1].template.keyExists( "schedule_next_send_date" ) ).toBe( false );
-
-			} );
-
-			it( "should set the schedule_next_send_date to empty when schedule start date is in the future", function(){
-				var service      = _getService();
-				var templateId   = CreateUUId();
-				var nowish       = Now();
-				var nextSendDate = DateAdd( "d", 3, nowish );
-				var template = {
-					  sending_method          = "scheduled"
-					, schedule_type           = "repeat"
-					, schedule_measure        = 3
-					, schedule_unit           = "day"
-					, schedule_start_date     = DateAdd( "ww", 1, nowish )
-					, schedule_end_date       = ""
-					, schedule_next_send_date = DateAdd( "ww", 4, nowish )
-				};
-
-				service.$( "getTemplate" ).$args( id=templateId, allowDrafts=true, fromVersionTable=false ).$results( template );
-				service.$( "saveTemplate", templateId );
-				service.$( "_getNow", nowish );
-
-				service.updateScheduledSendFields( templateId );
-
-				expect( service.$callLog().saveTemplate.len() ).toBe( 1 );
-				expect( service.$callLog().saveTemplate[1].id ?: "" ).toBe( templateId );
-				expect( service.$callLog().saveTemplate[1].template.schedule_next_send_date ?: "" ).toBe( "" );
+				expect( service.$callLog().saveTemplate[1].template.schedule_next_send_date ?: "" ).toBe( startDate );
 			} );
 
 			it( "should set the schedule_next_send_date to empty when schedule end date is in the past", function(){

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -647,10 +647,8 @@ component {
 					}
 
 					if ( IsDate( template.schedule_end_date ) && updatedData.schedule_next_send_date >= template.schedule_end_date ){
-						updatedData.delete( "schedule_next_send_date" );
+						updatedData.schedule_next_send_date = "";
 					}
-				} else {
-					updatedData.delete( "schedule_next_send_date" );
 				}
 
 				updatedData.schedule_date = "";

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -649,6 +649,8 @@ component {
 					if ( IsDate( template.schedule_end_date ) && updatedData.schedule_next_send_date >= template.schedule_end_date ){
 						updatedData.delete( "schedule_next_send_date" );
 					}
+				} else {
+					updatedData.delete( "schedule_next_send_date" );
 				}
 
 				updatedData.schedule_date = "";
@@ -1305,7 +1307,7 @@ component {
 		var nowish = _getNow();
 		var cfunit = _timeUnitToCfMapping[ arguments.unit ];
 
-		if ( IsDate( arguments.startDate ) ) {		
+		if ( IsDate( arguments.startDate ) ) {
 			var nextDate         = arguments.startDate;
 
 			while( nextDate <= nowish ) {

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -636,15 +636,17 @@ component {
 
 		if ( template.sending_method == "scheduled" ) {
 			if ( template.schedule_type == "repeat" ) {
-				var nowish = _getNow();
-				var expired = ( IsDate( template.schedule_start_date ) && template.schedule_start_date > nowish ) || ( IsDate( template.schedule_end_date ) && template.schedule_end_date < nowish );
+				var nowish  = _getNow();
+				var expired = ( IsDate( template.schedule_end_date ) && template.schedule_end_date < nowish );
 
-				if ( !expired ) {
-					var newSendDate = _calculateNextSendDate( template.schedule_measure, template.schedule_unit, template.schedule_start_date );
-
-					if ( !IsDate( template.schedule_next_send_date ) || template.schedule_next_send_date <= nowish || template.schedule_next_send_date > newSendDate ) {
-						updatedData.schedule_next_send_date = newSendDate;
+				if( !expired ){
+					if( ( IsDate( template.schedule_start_date ) && template.schedule_start_date > nowish ) ){
+						updatedData.schedule_next_send_date = template.schedule_start_date;
 					} else {
+						updatedData.schedule_next_send_date = _calculateNextSendDate( template.schedule_measure, template.schedule_unit, template.schedule_start_date );
+					}
+
+					if ( IsDate( template.schedule_end_date ) && updatedData.schedule_next_send_date >= template.schedule_end_date ){
 						updatedData.delete( "schedule_next_send_date" );
 					}
 				}
@@ -1303,12 +1305,11 @@ component {
 		var nowish = _getNow();
 		var cfunit = _timeUnitToCfMapping[ arguments.unit ];
 
-		if ( IsDate( arguments.startDate ) ) {
-			var measureFromStart = DateDiff( cfunit, arguments.startDate, nowish ) + arguments.measure;
-			var nextDate         = DateAdd( cfunit, measureFromStart, arguments.startDate );
+		if ( IsDate( arguments.startDate ) ) {		
+			var nextDate         = arguments.startDate;
 
 			while( nextDate <= nowish ) {
-				nextDate = DateAdd( cfunit, 1, nextDate );
+				nextDate = DateAdd( cfunit, arguments.measure, nextDate );
 			}
 
 			return nextDate;


### PR DESCRIPTION
1.) Test with no start / end date
> Send on next date time and repeat after the next send and no ending.

2.) Test with start date only
> Send on start date time and repeat after the next send and no ending.

3.) Test with end date only
> Send on next date time and repeat after the next send. When next date is  greater or equal to end date set next date to null.

4.) Test with start / end date
> Send on start date time and repeat after the next send. When next date is greater or equal to end date set next date to null.