### PR TITLE
PRESIDECMS-1869: Remove label for form id to fix issue with site tree…

### DIFF
--- a/system/i18n/cms_de.properties
+++ b/system/i18n/cms_de.properties
@@ -813,7 +813,6 @@ ckeditor.linkpicker.anchor.placeholder=W\u00E4hlen Sie einen Anker
 ckeditor.linkpicker.basic.tab=Basiseigenschaften
 ckeditor.linkpicker.advanced.tab=Erweiterte Eigenschaften
 ckeditor.linkpicker.type.sitetreelink=Link im Seitenbaum
-ckeditor.linkpicker.type.sitetreelink.fieldset.id=Seitenbaum
 ckeditor.linkpicker.type.url=URL
 ckeditor.linkpicker.type.email=E-Mail
 ckeditor.linkpicker.type.emailvariable=Email Variable


### PR DESCRIPTION
/system/views/admin/linkPicker/_linkTypeMenu.cfm uses the i18n value of cms:ckeditor.linkpicker.type.sitetree.fieldset.id to generate a form fieldset id. cms_de.properties translated this value instead of leaving it alone causing the form to not display the site tree page selection.