### PR TITLE
add failTask in Adhoc Task Progress Reporter class

### DIFF
--- a/system/services/taskmanager/AdHocTaskProgressReporter.cfc
+++ b/system/services/taskmanager/AdHocTaskProgressReporter.cfc
@@ -78,6 +78,22 @@ component {
 		return !task.recordCount || task.status != "running";
 	}
 
+	/**
+	 * Marks a task as failed
+	 *
+	 * @autodoc    true
+	 * @taskId     ID of the task to mark as failed
+	 * @error      Error that prompted task failure
+	 * @forceRetry If true, will ignore retry config and automatically queue for retry
+	 */
+	public void function failTask( required string taskId, struct error={}, boolean forceRetry=false ) {
+		_getAdhocTaskManagerService().failTask(
+			  taskId 			= arguments.taskId
+			, error    		= arguments.error
+			, forceRetry 	= arguments.forceRetry
+		);
+	}
+
 
 // GETTERS AND SETTERS
 	private any function _getAdhocTaskManagerService() {


### PR DESCRIPTION
Public the failTaks method to be able to mark a task as failure status from the progress variable param