### PR TITLE
use useVersioning instead of canViewversioning

### DIFF
--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -1793,7 +1793,7 @@ component extends="preside.system.base.AdminHandler" {
 							, title      = deleteRecordTitle.replace( "{recordlabel}", ( record[ prc.labelField ] ?: "" ), "all" )
 						} );
 					}
-					if ( canViewVersions ) {
+					if ( useVersioning ) {
 						actions.append( {
 							  link       = viewHistoryLink.replace( "{id}", record.id )
 							, icon       = "fa-history"


### PR DESCRIPTION
Use the variable **useVersioning** to disable the view History link from the listing grid when the object has the `@versioned false`
The previous variable **canViewVersions** only check the permission but if the object have the version disabled and the permission set to true the link appears in the list grid and when you click on it you get an error. Using the useVerioning as a check it checks both the @versioned flag and the permission