### PR TITLE
Feature fix filter toggle

### DIFF
--- a/system/views/admin/datamanager/_objectDataTable.cfm
+++ b/system/views/admin/datamanager/_objectDataTable.cfm
@@ -98,7 +98,7 @@
 							, showCount    = false
 						)#
 						<br><br>
-						<a href="##" data-toggle="collapse" data-target="##quick-filter-form" class="quick-filter-toggler">
+						<a href="##" data-toggle="collapse" data-target="##quick-filter-form-#instanceId#" class="quick-filter-toggler">
 							<i class="fa fa-fw fa-caret-down"></i>#translateResource( "cms:rulesEngine.show.quick.filter" )#
 						</a>
 					</div>


### PR DESCRIPTION
small fix on the filter toggle on the data manager admin object listing page where instance id is missing from the target