### PR TITLE
PRESIDECMS-1903 control batch delete edit allowed operations

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -285,7 +285,7 @@ component {
 			  cms                    = [ "access" ]
 			, sitetree               = [ "navigate", "read", "add", "edit", "activate", "publish", "savedraft", "trash", "viewtrash", "emptytrash", "restore", "delete", "manageContextPerms", "viewversions", "sort", "translate", "clearcaches", "clone" ]
 			, sites                  = [ "navigate", "manage", "translate" ]
-			, datamanager            = [ "navigate", "read", "add", "edit", "delete", "manageContextPerms", "viewversions", "translate", "publish", "savedraft", "clone" ]
+			, datamanager            = [ "navigate", "read", "add", "edit","batchedit", "delete", "batchdelete", "manageContextPerms", "viewversions", "translate", "publish", "savedraft", "clone" ]
 			, usermanager            = [ "navigate", "read", "add", "edit", "delete" ]
 			, groupmanager           = [ "navigate", "read", "add", "edit", "delete" ]
 			, passwordPolicyManager  = [ "manage" ]

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -147,7 +147,8 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	private array function _getListingMultiActions( event, rc, prc, args={} ) {
-		var objectName = args.objectName ?: "";
+		var objectName  = args.objectName ?: "";
+		var batchDelete = presideObjectService.getObjectAttribute( objectName=objectName, attributeName="batchDelete", defaultValue=true );
 
 		args.actions             = [];
 		args.batchEditableFields = [];
@@ -162,7 +163,7 @@ component extends="preside.system.base.AdminHandler" {
 			args.actions.append( renderView( view="/admin/datamanager/_batchEditMultiActionButton", args=args ) );
 		}
 
-		if ( IsTrue( args.canDelete ?: ( prc.canDelete ?: "" ) ) ) {
+		if ( IsTrue( args.canDelete ?: ( prc.canDelete ?: "" ) ) and isTrue( batchDelete ?: true ) ) {
 			args.actions.append({
 				  class     = "btn-danger"
 				, label     = translateResource( uri="cms:datamanager.deleteSelected.title" )

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -3461,6 +3461,7 @@ component extends="preside.system.base.AdminHandler" {
 			prc.canView               = _checkPermission( argumentCollection=arguments, key="read"              , throwOnError=false );
 			prc.canAdd                = _checkPermission( argumentCollection=arguments, key="add"               , throwOnError=false );
 			prc.canedit               = _checkPermission( argumentCollection=arguments, key="edit"              , throwOnError=false );
+			prc.canBatchEdit          = _checkPermission( argumentCollection=arguments, key="batchedit"         , throwOnError=false );
 			prc.canDelete             = _checkPermission( argumentCollection=arguments, key="delete"            , throwOnError=false );
 			prc.canBatchDelete        = _checkPermission( argumentCollection=arguments, key="batchdelete"       , throwOnError=false );
 			prc.canManagePerms        = _checkPermission( argumentCollection=arguments, key="manageContextPerms", throwOnError=false );
@@ -3469,7 +3470,7 @@ component extends="preside.system.base.AdminHandler" {
 			prc.canSort               = datamanagerService.isSortable( prc.objectName ) && prc.canEdit;
 			prc.gridFields            = _getObjectFieldsForGrid( prc.objectName );
 			prc.hiddenGridFields      = _getObjectHiddenFieldsForGrid( prc.objectName );
-			prc.batchEditableFields   = dataManagerService.listBatchEditableFields( prc.objectName );
+			prc.batchEditableFields   = isTrue( prc.canBatchEdit ) ? dataManagerService.listBatchEditableFields( prc.objectName ) : [];
 			prc.isMultilingual        = multilingualPresideObjectService.isMultilingual( prc.objectName );
 			prc.canTranslate          = prc.isMultilingual && _checkPermission( argumentCollection=arguments, key="translate", throwOnError=false );
 			prc.useVersioning         = datamanagerService.isOperationAllowed( prc.objectName, "viewversions" ) && presideObjectService.objectIsVersioned( prc.objectName );

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -147,8 +147,7 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	private array function _getListingMultiActions( event, rc, prc, args={} ) {
-		var objectName  = args.objectName ?: "";
-		var batchDelete = presideObjectService.getObjectAttribute( objectName=objectName, attributeName="batchDelete", defaultValue=true );
+		var objectName = args.objectName ?: "";
 
 		args.actions             = [];
 		args.batchEditableFields = [];
@@ -163,7 +162,7 @@ component extends="preside.system.base.AdminHandler" {
 			args.actions.append( renderView( view="/admin/datamanager/_batchEditMultiActionButton", args=args ) );
 		}
 
-		if ( IsTrue( args.canDelete ?: ( prc.canDelete ?: "" ) ) and isTrue( batchDelete ?: true ) ) {
+		if ( IsTrue( args.canDelete ?: ( prc.canDelete ?: "" ) ) ) {
 			args.actions.append({
 				  class     = "btn-danger"
 				, label     = translateResource( uri="cms:datamanager.deleteSelected.title" )

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -64,6 +64,7 @@ component extends="preside.system.base.AdminHandler" {
 				, isMultilingual      = IsTrue( prc.isMultilingual ?: "" )
 				, draftsEnabled       = IsTrue( prc.draftsEnabled  ?: "" )
 				, canDelete           = IsTrue( prc.canDelete      ?: "" )
+				, canBatchDelete      = IsTrue( prc.canBatchDelete ?: "" )
 			}
 		);
 	}
@@ -162,7 +163,7 @@ component extends="preside.system.base.AdminHandler" {
 			args.actions.append( renderView( view="/admin/datamanager/_batchEditMultiActionButton", args=args ) );
 		}
 
-		if ( IsTrue( args.canDelete ?: ( prc.canDelete ?: "" ) ) ) {
+		if ( IsTrue( args.canDelete ?: ( prc.canDelete ?: "" ) ) && IsTrue( args.canBatchDelete ?: ( prc.canBatchDelete ?: "" ) ) ) {
 			args.actions.append({
 				  class     = "btn-danger"
 				, label     = translateResource( uri="cms:datamanager.deleteSelected.title" )
@@ -2705,7 +2706,7 @@ component extends="preside.system.base.AdminHandler" {
 			} );
 		}
 
-		var operations      = [ "read", "add", "edit", "delete", "viewversions", "translate", "clone" ];
+		var operations      = [ "read", "add", "edit", "batchedit", "delete", "batchdelete", "viewversions", "translate", "clone" ];
 		var draftOperations = [ "addRecord", "addRecordAction", "editRecord", "editRecordAction", "translateRecord", "translateRecordAction" ];
 		var permitted       = true;
 
@@ -3461,6 +3462,7 @@ component extends="preside.system.base.AdminHandler" {
 			prc.canAdd                = _checkPermission( argumentCollection=arguments, key="add"               , throwOnError=false );
 			prc.canedit               = _checkPermission( argumentCollection=arguments, key="edit"              , throwOnError=false );
 			prc.canDelete             = _checkPermission( argumentCollection=arguments, key="delete"            , throwOnError=false );
+			prc.canBatchDelete        = _checkPermission( argumentCollection=arguments, key="batchdelete"       , throwOnError=false );
 			prc.canManagePerms        = _checkPermission( argumentCollection=arguments, key="manageContextPerms", throwOnError=false );
 			prc.canViewVersions       = _checkPermission( argumentCollection=arguments, key="viewversions"      , throwOnError=false );
 			prc.canClone              = _checkPermission( argumentCollection=arguments, key="clone"             , throwOnError=false );

--- a/system/i18n/permissions.properties
+++ b/system/i18n/permissions.properties
@@ -10,11 +10,17 @@ datamanager.add.description=Users can add records
 datamanager.edit.title=Edit
 datamanager.edit.description=Users can edit records
 
+datamanager.batchedit.title=Batch edit
+datamanager.batchedit.description=Users can batch edit records
+
 datamanager.translate.title=Translate
 datamanager.translate.description=Users can translate records
 
 datamanager.delete.title=Delete
 datamanager.delete.description=Users can delete records
+
+datamanager.batchdelete.title=Batch delete
+datamanager.batchdelete.description=Users can batch delete records
 
 datamanager.manageContextPerms.title=Manage permissions
 datamanager.manageContextPerms.description=Users can manage permissions access permissions

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -167,7 +167,9 @@ component {
 	}
 
 	public array function listBatchEditableFields( required string objectName ) {
-		if ( !isOperationAllowed( arguments.objectName, "edit" ) ) {
+		var objectBatchEditable = _getPresideObjectService().getObjectAttribute( objectName=objectName, attributeName="batchEditable", defaultValue=true );
+
+		if ( !isOperationAllowed( arguments.objectName, "edit" ) || ( isBoolean( objectBatchEditable ) && !objectBatchEditable ) ) {
 			return [];
 		}
 
@@ -757,9 +759,9 @@ component {
 
 		return filter;
 	}
-	
+
 	public boolean function isDataExportEnabled( required string objectName ) {
-	
+
 		if ( !$isFeatureEnabled( "dataexport" ) ) {
 			return false;
 		}
@@ -768,7 +770,7 @@ component {
 
 		return IsBoolean( exportEnabled ) && exportEnabled;
 	}
-	
+
 	public string function getDataExportPermissionKey( required string objectName ) {
 		return _getPresideObjectService().getObjectAttribute( objectName=arguments.objectName, attributeName="dataManagerExportPermissionKey", defaultValue="read" );
 	}

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -167,7 +167,7 @@ component {
 	}
 
 	public array function listBatchEditableFields( required string objectName ) {
-		if ( !isOperationAllowed( arguments.objectName, "edit" ) ) {
+		 if ( !isOperationAllowed( arguments.objectName, "edit" ) || !isOperationAllowed( arguments.objectName, "batchedit" ) ) {
 			return [];
 		}
 
@@ -242,7 +242,7 @@ component {
 	}
 
 	public string function getDefaultOperationsForObject( required string objectName ) {
-		var defaults = [ "read", "add", "edit", "delete" ];
+		var defaults = [ "read", "add", "edit", "batchedit", "delete", "batchdelete" ];
 
 		if ( _getPresideObjectService().objectIsVersioned( arguments.objectName ) ) {
 			defaults.append( "viewversions" );

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -167,9 +167,7 @@ component {
 	}
 
 	public array function listBatchEditableFields( required string objectName ) {
-		var objectBatchEditable = _getPresideObjectService().getObjectAttribute( objectName=objectName, attributeName="batchEditable", defaultValue=true );
-
-		if ( !isOperationAllowed( arguments.objectName, "edit" ) || ( isBoolean( objectBatchEditable ) && !objectBatchEditable ) ) {
+		if ( !isOperationAllowed( arguments.objectName, "edit" ) ) {
 			return [];
 		}
 


### PR DESCRIPTION
- add object attribute _batchEditable_ to have object level control, default to true
- add object attribute _batchDelete_ to have record delete but restricted batch delete, default to true