### PR TITLE
PRESIDECMS-1908 ability to omit field labels for fields in single record view

### DIFF
--- a/system/handlers/admin/DataHelpers.cfc
+++ b/system/handlers/admin/DataHelpers.cfc
@@ -81,6 +81,7 @@ component extends="preside.system.base.adminHandler" {
 				, recordId      = recordId
 				, value         = prc.record[ propertyName ] ?: ""
 				, rendered      = renderedValue
+				, displayTitle  = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="displayPropertyTitle", defaultValue=true )
 			} );
 		}
 

--- a/system/views/admin/datahelpers/displayGroup.cfm
+++ b/system/views/admin/datahelpers/displayGroup.cfm
@@ -22,7 +22,9 @@
  						<tbody>
 							<cfloop array="#renderedProps#" item="prop" index="i">
 								<tr>
-									<th>#prop.propertyTitle#:</th>
+									<cfif isTrue( prop.displayTitle ?: true )>
+										<th>#prop.propertyTitle#:</th>
+									</cfif>
 									<td>#prop.rendered#</td>
 								</tr>
 							</cfloop>


### PR DESCRIPTION
add new _ displayPropertyTitle_ property attribute to control visibility of property title, default is true.