### PR TITLE
PRESIDECMS-1911 permissions on advanced filter builder usage

### DIFF
--- a/system/assets/js/admin/specific/datamanager/object/listingTable.js
+++ b/system/assets/js/admin/specific/datamanager/object/listingTable.js
@@ -39,6 +39,7 @@
 			  , noActions           = typeof tableSettings.noActions       === "undefined" ? ( typeof cfrequest.noActions       === "undefined" ? false: cfrequest.noActions       ) : tableSettings.noActions
 			  , useMultiActions     = typeof tableSettings.useMultiActions === "undefined" ? ( typeof cfrequest.useMultiActions === "undefined" ? true : cfrequest.useMultiActions ) : tableSettings.useMultiActions
 			  , $filterDiv          = $( '#' + tableId + '-filter' )
+			  , allowManageFilter   = $filterDiv.data( 'filter-allow' ) === true
 			  , $favouritesDiv      = $( '#' + tableId + '-favourites' )
 			  , enabledContextHotkeys, refreshFavourites
 			  , lastAjaxResult;
@@ -351,16 +352,20 @@
 				$filterDiv.on( "change", function( e ){
 					datatable.fnDraw();
 
-					$filterDiv.find( ".save-filter-btn" ).prop( "disabled", !$filterDiv.find( "[name=filter]" ).val().length );
+					if ( allowManageFilter ) {
+						$filterDiv.find( ".save-filter-btn" ).prop( "disabled", !$filterDiv.find( "[name=filter]" ).val().length );
+					}
 				} );
 
-				setupQuickSaveFilterIframeModal( $filterDiv );
+				if ( allowManageFilter ) {
+					setupQuickSaveFilterIframeModal( $filterDiv );
 
-				if ( settings.oLoadedState !== null && typeof settings.oLoadedState.oFilter !== "undefined" ) {
-					if ( settings.oLoadedState.oFilter.filters.length || settings.oLoadedState.oFilter.filter.length ) {
-						prePopulateFilter( settings.oLoadedState.oFilter.filters, settings.oLoadedState.oFilter.filter );
-					} else if ( settings.oLoadedState.oFilter.favourites && settings.oLoadedState.oFilter.favourites.length ) {
-						setFavourites( settings.oLoadedState.oFilter.favourites );
+					if ( settings.oLoadedState !== null && typeof settings.oLoadedState.oFilter !== "undefined" ) {
+						if ( settings.oLoadedState.oFilter.filters.length || settings.oLoadedState.oFilter.filter.length ) {
+							prePopulateFilter( settings.oLoadedState.oFilter.filters, settings.oLoadedState.oFilter.filter );
+						} else if ( settings.oLoadedState.oFilter.favourites && settings.oLoadedState.oFilter.favourites.length ) {
+							setFavourites( settings.oLoadedState.oFilter.favourites );
+						}
 					}
 				}
 			};
@@ -541,7 +546,10 @@
 				var $searchContainer = $( dtSettings.aanFeatures.f[0] );
 
 				$filterDiv.fadeOut( 100, function(){
-					$filterDiv.find( "[name=filter]" ).data( "conditionBuilder" ).clear();
+					if ( allowManageFilter ) {
+						$filterDiv.find( "[name=filter]" ).data( "conditionBuilder" ).clear();
+					}
+
 					$filterDiv.find( "[name=filters]" ).data( "uberSelect").clear();
 					$filterDiv.find( "[name=filters]" ).val("");
 					refreshFavourites();

--- a/system/assets/js/admin/specific/datamanager/object/listingTable.js
+++ b/system/assets/js/admin/specific/datamanager/object/listingTable.js
@@ -39,7 +39,7 @@
 			  , noActions           = typeof tableSettings.noActions       === "undefined" ? ( typeof cfrequest.noActions       === "undefined" ? false: cfrequest.noActions       ) : tableSettings.noActions
 			  , useMultiActions     = typeof tableSettings.useMultiActions === "undefined" ? ( typeof cfrequest.useMultiActions === "undefined" ? true : cfrequest.useMultiActions ) : tableSettings.useMultiActions
 			  , $filterDiv          = $( '#' + tableId + '-filter' )
-			  , allowManageFilter   = $filterDiv.data( 'filter-allow' ) === true
+			  , allowManageFilter   = $filterDiv.data( 'allow-manage-filter' ) === true
 			  , $favouritesDiv      = $( '#' + tableId + '-favourites' )
 			  , enabledContextHotkeys, refreshFavourites
 			  , lastAjaxResult;

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -334,10 +334,11 @@ component {
 		settings.adminRoles = StructNew( "linked" );
 
 		settings.adminRoles.sysadmin           = [ "cms.access", "usermanager.*", "groupmanager.*", "systemConfiguration.*", "presideobject.security_user.*", "presideobject.security_group.*", "websiteBenefitsManager.*", "websiteUserManager.*", "sites.*", "presideobject.links.*", "notifications.*", "passwordPolicyManager.*", "urlRedirects.*", "systemInformation.*", "taskmanager.navigate", "taskmanager.viewlogs", "auditTrail.*", "rulesEngine.*", "emailCenter.*", "!emailCenter.queue.*" ];
-		settings.adminRoles.contentadmin       = [ "cms.access", "sites.*", "presideobject.site.*", "presideobject.link.*", "sitetree.*", "presideobject.page.*", "datamanager.*", "assetmanager.*", "presideobject.asset.*", "presideobject.asset_folder.*", "formbuilder.*", "!formbuilder.lockForm", "!formbuilder.activateForm", "!formbuilder.deleteForm", "rulesEngine.read", "emailCenter.*", "!emailCenter.queue.*" ];
-		settings.adminRoles.contenteditor      = [ "cms.access", "presideobject.link.*", "sites.navigate", "sitetree.*", "presideobject.page.*", "datamanager.*", "assetmanager.*", "presideobject.asset.*", "presideobject.asset_folder.*", "!*.delete", "!*.manageContextPerms", "!assetmanager.folders.add", "rulesEngine.read" ];
+		settings.adminRoles.contentadmin       = [ "cms.access", "sites.*", "presideobject.site.*", "presideobject.link.*", "sitetree.*", "presideobject.page.*", "datamanager.*", "assetmanager.*", "presideobject.asset.*", "presideobject.asset_folder.*", "formbuilder.*", "!formbuilder.lockForm", "!formbuilder.activateForm", "!formbuilder.deleteForm", "rulesEngine.read", "rulesEngine.navigate", "emailCenter.*", "!emailCenter.queue.*" ];
+		settings.adminRoles.contenteditor      = [ "cms.access", "presideobject.link.*", "sites.navigate", "sitetree.*", "presideobject.page.*", "datamanager.*", "assetmanager.*", "presideobject.asset.*", "presideobject.asset_folder.*", "!*.delete", "!*.manageContextPerms", "!assetmanager.folders.add", "rulesEngine.read", "rulesEngine.navigate" ];
 		settings.adminRoles.formbuildermanager = [ "cms.access", "formbuilder.*" ];
 		settings.adminRoles.emailcentremanager = [ "cms.access", "emailCenter.*", "!emailCenter.queue.*" ];
+		settings.adminRoles.rulesenginemanager = [ "cms.access", "rulesEngine.*" ];
 
 		settings.websitePermissions = {
 			  pages  = [ "access" ]

--- a/system/handlers/formcontrols/FilterPicker.cfc
+++ b/system/handlers/formcontrols/FilterPicker.cfc
@@ -37,6 +37,9 @@ component  {
 			);
 		}
 
+		args.hasQuickAddPermission  = booleanFormat( hasCmsPermission( "rulesEngine.add" )  );
+		args.hasQuickEditPermission = booleanFormat( hasCmsPermission( "rulesEngine.edit" ) );
+
 		return renderViewlet( event="formcontrols.objectPicker.index", args=args );
 	}
 }

--- a/system/i18n/cms.properties
+++ b/system/i18n/cms.properties
@@ -1254,6 +1254,10 @@ rulesEngine.edit.filter.page.title=Edit filter
 rulesEngine.edit.filter.page.subtitle={1}
 rulesEngine.edit.filter.breadcrumb.title=Edit filter, {1}
 
+rulesEngine.view.condition.page.title=View condition
+rulesEngine.view.condition.page.subtitle={1}
+rulesEngine.view.condition.breadcrumb.title=View condition, {1}
+
 rulesEngine.expression.search.placeholder=Type to search available expressions
 rulesEngine.configure.field.modal.title=Configure field
 

--- a/system/i18n/roles.properties
+++ b/system/i18n/roles.properties
@@ -15,3 +15,6 @@ emailcentremanager.description=Permissions to administer all aspects of the Emai
 
 auditTrailmanager.title=Audit log manager
 auditTrailmanager.description=Permissions to administer allow to see the audit log system
+
+rulesenginemanager.title=Rules engine manager
+rulesenginemanager.description=Permissions to administer all aspects of the Rules engine system

--- a/system/views/admin/datamanager/_objectDataTable.cfm
+++ b/system/views/admin/datamanager/_objectDataTable.cfm
@@ -76,7 +76,7 @@
 		</cfif>
 
 		<cfif args.allowFilter>
-			<div class="object-listing-table-filter hide" id="#tableId#-filter" data-filter-allow="#booleanFormat( allowManageFilter )#">
+			<div class="object-listing-table-filter hide" id="#tableId#-filter" data-allow-manage-filter="#booleanFormat( allowManageFilter )#">
 				<div class="row">
 					<div class="col-md-12">
 						<a class="pull-right back-to-basic-search" href="##">

--- a/system/views/admin/datamanager/_objectDataTable.cfm
+++ b/system/views/admin/datamanager/_objectDataTable.cfm
@@ -33,7 +33,8 @@
 	instanceId = LCase( Hash( CallStackGet( "string" ) ) );
 	tableId = args.id ?: "object-listing-table-#LCase( args.objectName )#-#instanceId#";
 
-	args.allowFilter = args.allowFilter && isFeatureEnabled( "rulesengine" );
+	args.allowFilter  = args.allowFilter && isFeatureEnabled( "rulesengine" );
+	allowManageFilter = args.allowFilter && hasCmsPermission( "rulesEngine.add" ) && hasCmsPermission( "rulesEngine.edit" );
 
 	if ( args.allowFilter ) {
 		saveFilterFormEndpoint = event.buildAdminLink(
@@ -75,7 +76,7 @@
 		</cfif>
 
 		<cfif args.allowFilter>
-			<div class="object-listing-table-filter hide" id="#tableId#-filter">
+			<div class="object-listing-table-filter hide" id="#tableId#-filter" data-filter-allow="#booleanFormat( allowManageFilter )#">
 				<div class="row">
 					<div class="col-md-12">
 						<a class="pull-right back-to-basic-search" href="##">
@@ -98,35 +99,39 @@
 							, showCount    = false
 						)#
 						<br><br>
-						<a href="##" data-toggle="collapse" data-target="##quick-filter-form" class="quick-filter-toggler">
-							<i class="fa fa-fw fa-caret-down"></i>#translateResource( "cms:rulesEngine.show.quick.filter" )#
-						</a>
+						<cfif allowManageFilter>
+							<a href="##" data-toggle="collapse" data-target="##quick-filter-form" class="quick-filter-toggler">
+								<i class="fa fa-fw fa-caret-down"></i>#translateResource( "cms:rulesEngine.show.quick.filter" )#
+							</a>
+						</cfif>
 					</div>
 				</div>
 
-				<div id="quick-filter-form-#instanceId#" class="in clearfix">
-					#renderFormControl(
-						  name        = "filter"
-						, id          = "filter-#instanceId#"
-						, type        = "rulesEngineFilterBuilder"
-						, context     = "admin"
-						, contextData = args.filterContextData
-						, object      = args.objectName
-						, label       = ""
-						, layout      = ""
-						, compact     = true
-						, showCount   = false
-					)#
+				<cfif allowManageFilter>
+					<div id="quick-filter-form-#instanceId#" class="in clearfix">
+						#renderFormControl(
+							  name        = "filter"
+							, id          = "filter-#instanceId#"
+							, type        = "rulesEngineFilterBuilder"
+							, context     = "admin"
+							, contextData = args.filterContextData
+							, object      = args.objectName
+							, label       = ""
+							, layout      = ""
+							, compact     = true
+							, showCount   = false
+						)#
 
-					<div class="form-actions">
-						<div class="pull-right">
-							<button class="btn btn-info btn-sm save-filter-btn" tabindex="#getNextTabIndex()#" disabled data-save-form-endpoint="#saveFilterFormEndpoint#" data-modal-dialog-full="#IsTrue( args.filterQuickAddFullModal ?: "" )#">
-								<i class="fa fa-fw fa-save"></i>
-								#translateResource( "cms:rulesEngine.quick.filter.save.btn" )#
-							</button>
+						<div class="form-actions">
+							<div class="pull-right">
+								<button class="btn btn-info btn-sm save-filter-btn" tabindex="#getNextTabIndex()#" disabled data-save-form-endpoint="#saveFilterFormEndpoint#" data-modal-dialog-full="#IsTrue( args.filterQuickAddFullModal ?: "" )#">
+									<i class="fa fa-fw fa-save"></i>
+									#translateResource( "cms:rulesEngine.quick.filter.save.btn" )#
+								</button>
+							</div>
 						</div>
 					</div>
-				</div>
+				</cfif>
 			</div>
 
 			<div class="object-listing-table-favourites hide" id="#tableId#-favourites">


### PR DESCRIPTION
1. hide rule engine builder in object listing view if permission not granted, but still able to access favourite and saved filter.
![Screenshot 2020-07-29 at 16 03 50](https://user-images.githubusercontent.com/50225529/88773828-3cf20080-d1b5-11ea-86e2-a5bbbda012a2.png)

2. add new _rules engine manage_ role to grant all aspect of control for rules engine feature.