### PR TITLE
PRESIDECMS-1937 new left right multi select panel form control

### DIFF
--- a/system/assets/css/admin/specific/multiSelectPanel/multiSelectPanel.less
+++ b/system/assets/css/admin/specific/multiSelectPanel/multiSelectPanel.less
@@ -1,0 +1,23 @@
+@import url( 'globals.less' );
+
+.multi-select-panel {
+	display: flex;
+
+	.action-buttons {
+		margin: auto;
+
+		.btn {
+			margin-bottom: 0.6em;
+		}
+	}
+
+	.sorting-buttons {
+		margin: auto;
+		text-align: right;
+
+		.sorting-link {
+			font-size: 2em;
+			margin-bottom: 0;
+		}
+	}
+}

--- a/system/assets/js/admin/specific/multiSelectPanel/multiSelectPanel.js
+++ b/system/assets/js/admin/specific/multiSelectPanel/multiSelectPanel.js
@@ -13,13 +13,13 @@
 	};
 
 	$mutliSelectPanel.each( function(event) {
-		var curPanelId     = $(this).attr('id') ;
-		var selectAllBtn   = $(this).find( '#select-all-btn' );
-		var selectBtn      = $(this).find( '#select-btn' );
-		var deselectAllBtn = $(this).find( '#deselect-all-btn' );
-		var deselectBtn    = $(this).find( '#deselect-btn' );
-		var sortUpBtn      = $(this).find( 'a#sort-up' );
-		var sortDownBtn    = $(this).find( 'a#sort-down' );
+		var curPanelId     = $(this).attr('id')
+		  , selectAllBtn   = $(this).find( '#select-all-btn' )
+		  , selectBtn      = $(this).find( '#select-btn' )
+		  , deselectAllBtn = $(this).find( '#deselect-all-btn' )
+		  , deselectBtn    = $(this).find( '#deselect-btn' )
+		  , sortUpBtn      = $(this).find( 'a#sort-up' )
+		  , sortDownBtn    = $(this).find( 'a#sort-down' );
 
 		// SORTING ACTIONS
 		sortUpBtn.on( 'click', function(event) {

--- a/system/assets/js/admin/specific/multiSelectPanel/multiSelectPanel.js
+++ b/system/assets/js/admin/specific/multiSelectPanel/multiSelectPanel.js
@@ -1,0 +1,78 @@
+( function( $ ){
+	var $mutliSelectPanel     = $( '.multi-select-panel' )
+	  , updateSelectedValues;
+
+	updateSelectedValues = function( selectId ) {
+		var selectedValues = [];
+
+		$( '#' + selectId + '_to option' ).each(function() {
+			selectedValues.push( $(this).val() );
+		});
+
+		$( 'input[type=hidden]#' + selectId ).val( selectedValues.toString() );
+	};
+
+	$mutliSelectPanel.each( function(event) {
+		var curPanelId     = $(this).attr('id') ;
+		var selectAllBtn   = $(this).find( '#select-all-btn' );
+		var selectBtn      = $(this).find( '#select-btn' );
+		var deselectAllBtn = $(this).find( '#deselect-all-btn' );
+		var deselectBtn    = $(this).find( '#deselect-btn' );
+		var sortUpBtn      = $(this).find( 'a#sort-up' );
+		var sortDownBtn    = $(this).find( 'a#sort-down' );
+
+		// SORTING ACTIONS
+		sortUpBtn.on( 'click', function(event) {
+			var moveUpSelected = $( '#' + curPanelId + '_to option:selected' );
+			var optionAtTop    = moveUpSelected.first().prev();
+
+			if ( optionAtTop.length > 0 ) {
+				moveUpSelected.detach().insertBefore( optionAtTop );
+			}
+
+			updateSelectedValues( curPanelId );
+		});
+		sortDownBtn.on( 'click', function(event) {
+			var moveDownSelected = $( '#' + curPanelId + '_to option:selected' );
+			var optionAtBottom   = moveDownSelected.last().next();
+
+			if ( optionAtBottom.length > 0 ) {
+				moveDownSelected.detach().insertAfter( optionAtBottom );
+			}
+
+			updateSelectedValues( curPanelId );
+		});
+
+		// SELECT ALL ACTION
+		selectAllBtn.on( 'click', function(event) {
+			event.preventDefault();
+
+			$( '#' + curPanelId + '_from option' ).remove().appendTo( '#' + curPanelId + '_to' );
+			updateSelectedValues( curPanelId );
+		});
+
+		// SELECT ACTION
+		selectBtn.on( 'click', function(event) {
+			event.preventDefault();
+
+			$( '#' + curPanelId + '_from option:selected' ).remove().appendTo( '#' + curPanelId + '_to' );
+			updateSelectedValues( curPanelId );
+		});
+
+		// DESELECT ALL ACTION
+		deselectAllBtn.on( 'click', function(event) {
+			event.preventDefault();
+
+			$( '#' + curPanelId + '_to option' ).remove().appendTo( '#' + curPanelId + '_from' );
+			updateSelectedValues( curPanelId );
+		});
+
+		// DESELECT ACTION
+		deselectBtn.on( 'click', function(event) {
+			event.preventDefault();
+
+			$( '#' + curPanelId + '_to option:selected' ).remove().appendTo( '#' + curPanelId + '_from' );
+			updateSelectedValues( curPanelId );
+		});
+	});
+} )( presideJQuery );

--- a/system/forms/dataExport/exportConfiguration.xml
+++ b/system/forms/dataExport/exportConfiguration.xml
@@ -8,7 +8,7 @@ This form is used for configuring fields, title and format of an object data exp
 	<tab id="default">
 		<fieldset id="default" sortorder="10">
 			<field name="filename"     control="hidden"                required="true" sortorder="10" />
-			<field name="exportFields" control="dataExportFieldPicker" required="true" sortorder="20" />
+			<field name="exportFields" control="dataExportPanelPicker" required="true" sortorder="20" />
 			<field name="exporter"     control="dataExporterPicker"    required="true" sortorder="30" />
 		</fieldset>
 	</tab>

--- a/system/forms/dataExport/saveExportConfiguration.xml
+++ b/system/forms/dataExport/saveExportConfiguration.xml
@@ -17,7 +17,7 @@
 	</tab>
 	<tab id="filters" sortorder="20">
 		<fieldset id="fields" sortorder="10">
-			<field name="exportFields" control="dataExportFieldPicker" required="true" sortorder="10" />
+			<field name="exportFields" control="dataExportPanelPicker" required="true" sortorder="10" />
 		</fieldset>
 		<fieldset id="filters" sortorder="20">
 			<field name="savedFilters" control="filterPicker" required="false" sortorder="10" multiple="true" />

--- a/system/forms/preside-objects/saved_export/admin.edit.xml
+++ b/system/forms/preside-objects/saved_export/admin.edit.xml
@@ -10,7 +10,7 @@
 	</tab>
 	<tab id="filters" sortorder="20">
 		<fieldset id="fields" sortorder="10">
-			<field binding="saved_export.fields" control="dataExportFieldPicker" required="true" sortorder="10" />
+			<field binding="saved_export.fields" control="dataExportPanelPicker" required="true" sortorder="10" />
 		</fieldset>
 		<fieldset id="filters" sortorder="20">
 			<field binding="saved_export.saved_filter" control="filterPicker" required="false" sortorder="10" multiple="true" />

--- a/system/handlers/formcontrols/DataExportPanelPicker.cfc
+++ b/system/handlers/formcontrols/DataExportPanelPicker.cfc
@@ -1,0 +1,15 @@
+component extends="preside.system.handlers.formcontrols.MultiSelectPanel" {
+	property name="dataExportService" inject="DataExportService";
+
+	public string function index( event, rc, prc, args={} ) {
+		args.useObjProperties = true;
+		args.sortable         = true;
+		args.object           = args.exportObject ?: ( prc.record.object_name ?: ( rc.object ?: "" ) );
+
+		if ( !isEmptyString( args.object ) ) {
+			args.defaultValue = Len( args.defaultValue ?: "" ) ? args.defaultValue : dataExportService.getDefaultExportFieldsForObject( args.object ).selectFields.toList();
+		}
+
+		return super.index( argumentCollection=arguments );
+	}
+}

--- a/system/handlers/formcontrols/MultiSelectPanel.cfc
+++ b/system/handlers/formcontrols/MultiSelectPanel.cfc
@@ -1,0 +1,71 @@
+component {
+	property name="presideObjectService" inject="PresideObjectService";
+
+	public string function index( event, rc, prc, args={} ) {
+		args.labels    = args.labels ?: [];
+		args.values    = args.values ?: [];
+		var savedValue = event.getValue( name=args.name, defaultValue=args.defaultValue ?: "" );
+		var objectName = args.object ?: "";
+
+		if ( !isEmptyString( objectName ) ) {
+			if ( isTrue( args.useObjProperties ?: "" ) ) {
+				args.labels = [];
+				args.values = [];
+				var props   = presideObjectService.getObjectProperties( objectName );
+
+				for ( var prop in props ) {
+					if ( !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" ) && !IsTrue( props[ prop ].excludeDataExport ?: "" ) ) {
+						args.values.append( prop );
+					}
+				}
+
+				if ( !isEmptyString( savedValue ) ) {
+					var savedValueArray = listToArray( savedValue );
+
+					args.values.each( function( item, index ) {
+						if ( isTrue( arrayFind( savedValueArray, item ) ) ) {
+							args.values.swap( arrayFind( savedValueArray, item ), index );
+						}
+					});
+				}
+
+				var baseI18nUri = presideObjectService.getResourceBundleUriRoot( objectName=objectName );
+				for( var prop in args.values ) {
+					args.labels.append( translateResource(
+						  uri          = baseI18nUri & "field.#prop#.title"
+						, defaultValue = translateResource( uri="cms:preside-objects.default.field.#prop#.title", defaultValue=prop )
+					) );
+				}
+
+				args.selectSize = ( arrayLen( args.values ) lt 10 ) ? arrayLen( args.values ) : 10;
+			} else {
+				var fParams = {};
+				var orderBy = [];
+
+				orderBy.append( args.objOrderBy ?: "" );
+
+				if ( !isEmptyString( savedValue ) ) {
+					orderBy.prepend( "FIELD( id, :ids )" );
+					fParams.ids = { value=savedValue, type="varchar", list=true };
+				}
+
+				var objRecords = presideObjectService.selectData(
+					  objectName   = objectName
+					, selectFields = listToArray( args.objSelectFields ?: "id,label" )
+					, savedFilters = listToArray( args.objSavedFilters ?: "" )
+					, filterParams = fParams
+					, orderBy      = arrayToList( orderBy )
+				);
+
+				if ( objRecords.recordcount ) {
+					args.values = valueArray( objRecords, args.objIdField    ?: "id" );
+					args.labels = valueArray( objRecords, args.objLabelField ?: presideObjectService.getLabelField( objectName ) );
+
+					args.selectSize = ( objRecords.recordcount lt 10 ) ? objRecords.recordcount : 10;
+				}
+			}
+		}
+
+		return renderView( view="/formcontrols/multiSelectPanel/index", args=args )
+	}
+}

--- a/system/i18n/formcontrols/multiSelectPanel.properties
+++ b/system/i18n/formcontrols/multiSelectPanel.properties
@@ -1,0 +1,17 @@
+availableOptions.label=Available option(s)
+selectedOptions.label=Selected option(s)
+
+sortUp.icon=fa-sort-up
+sortDown.icon=fa-sort-down
+
+btn.selectAll.label=Select All
+btn.selectAll.icon=fa-angle-double-left
+
+btn.select.label=Select
+btn.select.icon=fa-angle-left
+
+btn.deselectAll.label=Deselect All
+btn.deselectAll.icon=fa-angle-double-right
+
+btn.deselect.label=Deselect
+btn.deselect.icon=fa-angle-right

--- a/system/views/formcontrols/multiSelectPanel/_actionButtons.cfm
+++ b/system/views/formcontrols/multiSelectPanel/_actionButtons.cfm
@@ -1,0 +1,26 @@
+<cfscript>
+	enableSelectAll   = args.enableSelectAll   ?: true;
+	enableDeselectAll = args.enableDeselectAll ?: true;
+</cfscript>
+
+<cfoutput>
+	<cfif isTrue( enableSelectAll )>
+		<button id="select-all-btn" class="btn btn-sm btn-info width-100">
+			<i class="bigger-110 fa #translateResource( "formcontrols.multiSelectPanel:btn.selectAll.icon" )#"></i> #translateResource( "formcontrols.multiSelectPanel:btn.selectAll.label" )#
+		</button>
+	</cfif>
+
+	<button id="select-btn" class="btn btn-sm btn-info width-100">
+		<i class="bigger-110 fa #translateResource( "formcontrols.multiSelectPanel:btn.select.icon" )#"></i> #translateResource( "formcontrols.multiSelectPanel:btn.select.label" )#
+	</button>
+
+	<button id="deselect-btn" class="btn btn-sm btn-info width-100">
+		#translateResource( "formcontrols.multiSelectPanel:btn.deselect.label" )# <i class="bigger-110 fa #translateResource( "formcontrols.multiSelectPanel:btn.deselect.icon" )#"></i>
+	</button>
+
+	<cfif isTrue( enableDeselectAll )>
+		<button id="deselect-all-btn" class="btn btn-sm btn-info width-100">
+			#translateResource( "formcontrols.multiSelectPanel:btn.deselectAll.label" )# <i class="bigger-110 fa #translateResource( "formcontrols.multiSelectPanel:btn.deselectAll.icon" )#"></i>
+		</button>
+	</cfif>
+</cfoutput>

--- a/system/views/formcontrols/multiSelectPanel/_availableOptions.cfm
+++ b/system/views/formcontrols/multiSelectPanel/_availableOptions.cfm
@@ -1,0 +1,20 @@
+<cfoutput>
+	<p><small>#translateResource( "formcontrols.multiSelectPanel:availableOptions.label" )#</small></p>
+	<select class="#inputClass# #extraClasses# from"
+	        name="#inputName#_from"
+	        id="#inputId#_from"
+	        tabindex="#getNextTabIndex()#"
+	        multiple="multiple"
+	        size="#selectSize#"
+	>
+		<cfloop array="#values#" index="i" item="availableValue">
+			<cfset selected = ListFindNoCase( value, availableValue ) />
+
+			<cfif isFalse( selected )>
+				<option value="#HtmlEditFormat( availableValue )#">
+					#HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#
+				</option>
+			</cfif>
+		</cfloop>
+	</select>
+</cfoutput>

--- a/system/views/formcontrols/multiSelectPanel/_selectedOptions.cfm
+++ b/system/views/formcontrols/multiSelectPanel/_selectedOptions.cfm
@@ -1,0 +1,20 @@
+<cfoutput>
+	<p><small>#translateResource( "formcontrols.multiSelectPanel:selectedOptions.label" )#</small></p>
+	<select class="#inputClass# #extraClasses# to"
+	        name="#inputName#_to"
+	        id="#inputId#_to"
+	        tabindex="#getNextTabIndex()#"
+	        multiple="multiple"
+	        size="#selectSize#"
+	>
+		<cfloop array="#values#" index="i" item="selectedValue">
+			<cfset selected = ListFindNoCase( value, selectedValue ) />
+
+			<cfif isTrue( selected )>
+				<option value="#HtmlEditFormat( selectedValue )#">
+					#HtmlEditFormat( translateResource( labels[i] ?: "", labels[i] ?: "" ) )#
+				</option>
+			</cfif>
+		</cfloop>
+	</select>
+</cfoutput>

--- a/system/views/formcontrols/multiSelectPanel/_sortingPanel.cfm
+++ b/system/views/formcontrols/multiSelectPanel/_sortingPanel.cfm
@@ -1,0 +1,9 @@
+<cfoutput>
+	<p class="sorting-link">
+		<a id="sort-up" href="##"><i class="bigger-110 fa #translateResource( "formcontrols.multiSelectPanel:sortUp.icon" )#"></i></a>
+	</p>
+
+	<p class="sorting-link">
+		<a id="sort-down" href="##"><i class="bigger-110 fa #translateResource( "formcontrols.multiSelectPanel:sortDown.icon" )#"></i></a>
+	</p>
+</cfoutput>

--- a/system/views/formcontrols/multiSelectPanel/index.cfm
+++ b/system/views/formcontrols/multiSelectPanel/index.cfm
@@ -1,0 +1,50 @@
+<cfscript>
+	inputName    = args.name         ?: "";
+	inputId      = args.id           ?: "";
+	inputClass   = args.class        ?: "form-control";
+	extraClasses = args.extraClasses ?: "";
+	sortable     = args.sortable     ?: false;
+	selectSize   = args.selectSize   ?: "";
+	defaultValue = args.defaultValue ?: "";
+	values       = args.values       ?: "";
+	labels       = ( structKeyExists( args, "labels") && len( args.labels ) ) ? args.labels : args.values;
+
+	if ( IsSimpleValue( values ) ) { values = ListToArray( values ); }
+	if ( IsSimpleValue( labels ) ) { labels = ListToArray( labels ); }
+
+	value = event.getValue( name=inputName, defaultValue=defaultValue );
+	if ( not IsSimpleValue( value ) ) {
+		value = "";
+	}
+
+	value = HtmlEditFormat( value );
+
+	event.include( "/css/admin/specific/multiSelectPanel/" )
+	     .include( "/js/admin/specific/multiSelectPanel/"  );
+</cfscript>
+
+<cfoutput>
+	<cfif !isEmpty( values )>
+		<div class="row multi-select-panel" id="#inputId#">
+			<cfif isTrue( sortable )>
+				<div class="col-xs-1 sorting-buttons">
+					#renderView( view="/formcontrols/multiSelectPanel/_sortingPanel", args=args )#
+				</div>
+			</cfif>
+
+			<div class="col-xs-<cfif isTrue( sortable )>4<cfelse>5</cfif>">
+				#renderView( view="/formcontrols/multiSelectPanel/_selectedOptions", args=args )#
+			</div>
+
+			<div class="col-xs-2 action-buttons">
+				#renderView( view="/formcontrols/multiSelectPanel/_actionButtons", args=args )#
+			</div>
+
+			<div class="col-xs-5">
+				#renderView( view="/formcontrols/multiSelectPanel/_availableOptions", args=args )#
+			</div>
+		</div>
+
+		<input type="hidden" id="#inputId#" name="#inputName#" value="#value#" />
+	</cfif>
+</cfoutput>


### PR DESCRIPTION
Add new _MultiSelectPanel_ form control for left right multi select panel layout
![Screenshot 2020-08-19 at 10 09 04](https://user-images.githubusercontent.com/50225529/90586980-eeabac80-e20a-11ea-869c-d4698252d657.png)
- Able to explicitly provide values and labels for select options.
- Able to provide object and default will get records (default fields `id, label`) as options
- If object is provided, able to use object properties as options by set `useObjProperties` to true
- Sortable default to false (sorting panel will be hidden if not sortable)


Add new _dataExportPanelPicker_ form control to replace existing data export field picker control (extended from _MultiSelectPanel_ with `useObjProperties=true`, `args.sortable =true` and get object from request context)
![Screenshot 2020-08-19 at 11 00 42](https://user-images.githubusercontent.com/50225529/90587120-3f230a00-e20b-11ea-81d2-c2f4ad2f7519.png)
