### PR TITLE
PRESIDECMS-1950 parsedatetime in getPrefetchCachebusterForAjaxSelect

### DIFF
--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -660,7 +660,7 @@ component {
 			}
 		}
 
-		return Hash( max( lastModified, rendererCacheDate ) );
+		return Hash( max( parseDateTime(lastModified), rendererCacheDate ) );
 	}
 
 	public boolean function areDraftsEnabledForObject( required string objectName ) {


### PR DESCRIPTION
Fix issue when we are working with cbehcache after deserializing a date field from a query 