### PR TITLE
PRESIDECMS-1940 preside objects sorting problem with drafts

### DIFF
--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -333,8 +333,9 @@ component {
 		var idField        = _getPresideObjectService().getIdField( arguments.objectName );
 		var selectDataArgs = StructCopy( arguments );
 
-		selectDataArgs.orderBy      = getSortField( arguments.objectName );
-		selectDataArgs.selectFields = [ "#arguments.objectName#.#idField# as id", "${labelfield} as label", selectDataArgs.orderBy ];
+		selectDataArgs.orderBy          = getSortField( arguments.objectName );
+		selectDataArgs.selectFields     = [ "#arguments.objectName#.#idField# as id", "${labelfield} as label", selectDataArgs.orderBy ];
+		selectDataArgs.fromVersionTable = _getPresideObjectService().objectUsesDrafts( objectName=arguments.objectName );
 
 		return _getPresideObjectService().selectData( argumentCollection=selectDataArgs );
 	}
@@ -345,8 +346,12 @@ component {
 
 		for( var i=1; i <= arguments.sortedIds.len(); i++ ) {
 			object.updateData(
-				  id   = arguments.sortedIds[ i ]
-				, data = { "#sortField#" = i }
+				  id      = arguments.sortedIds[ i ]
+				, data    = { "#sortField#" = i }
+				, isDraft = _getPresideObjectService().objectRecordHasDraft(
+					  objectName = arguments.objectName
+					, recordId   = arguments.sortedIds[ i ]
+				)
 			);
 		}
 	}

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -1693,6 +1693,29 @@ component displayName="Preside Object Service" {
 	}
 
 	/**
+	 * Returns whether or not the given record has draft
+	 *
+	 * @objectName.hint Name of the object you wish to check
+	 * @recordId.hint   ID of the object record you wish to check
+	 */
+	public boolean function objectRecordHasDraft(
+		  required string objectName
+		, required string recordId
+	) autodoc=true {
+		if ( objectUsesDrafts( objectName=arguments.objectName ) ) {
+			return dataExists(
+				  objectName = arguments.objectName
+				, filter     = {
+					  id                  = arguments.recordId
+					, _version_has_drafts = true
+				}
+			);
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns whether or not the given object is configured to create
 	 * versions on insert
 	 *


### PR DESCRIPTION
- add new `objectRecordHasDraft` function in Preside object service to check object record has draft or not, default to false if the object is not allow draft.
- get sort record data from version table if object is allow use draft.
- passing `isDraft` argument when update record sort order.