### PR TITLE
PRESIDECMS-1957 fix many to many of draft objects not shown in record view

### DIFF
--- a/system/handlers/admin/DataHelpers.cfc
+++ b/system/handlers/admin/DataHelpers.cfc
@@ -163,10 +163,10 @@ component extends="preside.system.base.adminHandler" {
 	 *
 	 */
 	public void function getRecordsForRelatedRecordsDatatable( event, rc, prc ) {
-		var objectName       = rc.objectName       ?: "";
-		var propertyName     = rc.propertyName     ?: "";
-		var recordId         = rc.recordId         ?: "";
-		var fromVersionTable = rc.fromVersionTable ?: false;
+		var objectName       = rc.objectName   ?: "";
+		var propertyName     = rc.propertyName ?: "";
+		var recordId         = rc.recordId     ?: "";
+		var fromVersionTable = isTrue( rc.fromVersionTable ?: "" );
 		var gridFields       = adminDataViewsService.listGridFieldsForRelationshipPropertyTable( objectName, propertyName ).toList();
 		var relatedObject    = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="relatedTo" );
 		var relatedIdField   = presideObjectService.getIdField( objectName=relatedObject );
@@ -176,7 +176,7 @@ component extends="preside.system.base.adminHandler" {
 			, id                  = recordId
 			, selectFields        = [ "#propertyName#.#relatedIdField# as id" ]
 			, getSqlAndParamsOnly = true
-			, fromVersionTable    = booleanFormat( fromVersionTable )
+			, fromVersionTable    = fromVersionTable
 		);
 		var subQueryAlias = "relatedRecordsFilter";
 		var params        = {};

--- a/system/handlers/admin/DataHelpers.cfc
+++ b/system/handlers/admin/DataHelpers.cfc
@@ -107,13 +107,15 @@ component extends="preside.system.base.adminHandler" {
 	 *
 	 */
 	private string function relatedRecordsDatatable( event, rc, prc, args={} ) {
-		var objectName    = args.objectName   ?: "";
-		var propertyName  = args.propertyName ?: "";
-		var recordId      = args.recordId     ?: "";
-		var queryString   = "objectName=#args.objectName#&propertyName=#args.propertyName#&recordId=#args.recordId#";
-		var datasourceUrl = event.buildAdminLink( linkto="dataHelpers.getRecordsForRelatedRecordsDatatable", queryString=queryString );
-		var relatedObject = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="relatedTo" );
-		var gridFields    = adminDataViewsService.listGridFieldsForRelationshipPropertyTable( objectName, propertyName );
+		var objectName       = args.objectName   ?: "";
+		var propertyName     = args.propertyName ?: "";
+		var recordId         = args.recordId     ?: "";
+		var record           = prc.record        ?: queryNew("");
+		var fromVersionTable = isTrue( prc.useVersioning ?: false ) && isTrue( record._version_has_drafts ?: "" );
+		var queryString      = "objectName=#args.objectName#&propertyName=#args.propertyName#&recordId=#args.recordId#&fromVersionTable=#fromVersionTable#";
+		var datasourceUrl    = event.buildAdminLink( linkto="dataHelpers.getRecordsForRelatedRecordsDatatable", queryString=queryString );
+		var relatedObject    = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="relatedTo" );
+		var gridFields       = adminDataViewsService.listGridFieldsForRelationshipPropertyTable( objectName, propertyName );
 
 		return renderView( view="/admin/datamanager/_objectDataTable", args={
 			  objectName        = relatedObject
@@ -161,18 +163,20 @@ component extends="preside.system.base.adminHandler" {
 	 *
 	 */
 	public void function getRecordsForRelatedRecordsDatatable( event, rc, prc ) {
-		var objectName     = rc.objectName   ?: "";
-		var propertyName   = rc.propertyName ?: "";
-		var recordId       = rc.recordId     ?: "";
-		var gridFields     = adminDataViewsService.listGridFieldsForRelationshipPropertyTable( objectName, propertyName ).toList();
-		var relatedObject  = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="relatedTo" );
-		var relatedIdField = presideObjectService.getIdField( objectName=relatedObject );
-		var extraFilters   = [];
-		var subquerySelect = presideObjectService.selectData(
+		var objectName       = rc.objectName       ?: "";
+		var propertyName     = rc.propertyName     ?: "";
+		var recordId         = rc.recordId         ?: "";
+		var fromVersionTable = rc.fromVersionTable ?: false;
+		var gridFields       = adminDataViewsService.listGridFieldsForRelationshipPropertyTable( objectName, propertyName ).toList();
+		var relatedObject    = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="relatedTo" );
+		var relatedIdField   = presideObjectService.getIdField( objectName=relatedObject );
+		var extraFilters     = [];
+		var subquerySelect   = presideObjectService.selectData(
 			  objectName          = objectName
 			, id                  = recordId
 			, selectFields        = [ "#propertyName#.#relatedIdField# as id" ]
 			, getSqlAndParamsOnly = true
+			, fromVersionTable    = booleanFormat( fromVersionTable )
 		);
 		var subQueryAlias = "relatedRecordsFilter";
 		var params        = {};

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -246,15 +246,29 @@ component displayName="Preside Object Service" {
 		args.joins       = _getJoinsFromJoinTargets( argumentCollection=args );
 
 		if ( args.fromVersionTable && objectIsVersioned( args.objectName ) ) {
-			args.result = _selectFromVersionTables(
+			var versionTablePrep = _prepareSelectFromVersionTables(
 				  argumentCollection = args
 				, filter             = args.preparedFilter.filter
 				, params             = args.preparedFilter.params
 				, originalTableName  = args.objMeta.tableName
 				, distinct           = args.distinct
 			);
-			if ( arguments.recordCountOnly ) {
-				args.result = Val( args.result.record_count ?: "" );
+
+			if ( arguments.getSqlAndParamsOnly ) {
+				return {
+					  sql    = versionTablePrep.sql
+					, params = arguments.formatSqlParams ? _formatParams( versionTablePrep.params ) : versionTablePrep.params
+				};
+			} else {
+				args.result = _runSql(
+					  sql    = versionTablePrep.sql
+					, dsn    = versionTablePrep.dsn
+					, params = versionTablePrep.params
+				);
+
+				if ( arguments.recordCountOnly ) {
+					args.result = Val( args.result.record_count ?: "" );
+				}
 			}
 		} else {
 			var sql = args.adapter.getSelectSql(
@@ -2893,7 +2907,7 @@ component displayName="Preside Object Service" {
 		return interceptArguments.tableJoins;
 	}
 
-	private query function _selectFromVersionTables(
+	private struct function _prepareSelectFromVersionTables(
 		  required string  objectName
 		, required string  originalTableName
 		, required array   joins
@@ -2965,7 +2979,11 @@ component displayName="Preside Object Service" {
 			sql = adapter.getCountSql( sql );
 		}
 
-		return _runSql( sql=sql, dsn=versionObj.dsn, params=arguments.params );
+		return {
+			  sql    = sql
+			, dsn    = versionObj.dsn
+			, params = arguments.params
+		};
 	}
 
 	private array function _alterJoinsToUseVersionTables(


### PR DESCRIPTION
- update `_selectFromVersionTables` (return query) private function to `_prepareSelectFromVersionTables` (return prepared struct) and run sql in selectData function instead.
- update `relatedRecordsDatatable` function to check use versioning and record has draft to query from version table.