### PR TITLE
Add alias to pseudo-column in dataExists method

### DIFF
--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -964,7 +964,7 @@ component displayName="Preside Object Service" {
 		return selectData(
 			  argumentCollection = arguments
 			, useCache           = false
-			, selectFields       = [ "1" ]
+			, selectFields       = [ "1 as record" ]
 			, recordCountOnly    = true
 		) > 0;
 	}


### PR DESCRIPTION
using "1" in the sql select list breaks the query for recordcount-only query in MSSQL. Using an Alias for the select field solves it.