### PR TITLE
PRESIDECMS-1971 update formbuilder object action button logic

### DIFF
--- a/system/handlers/admin/FormBuilder.cfc
+++ b/system/handlers/admin/FormBuilder.cfc
@@ -30,8 +30,19 @@ component extends="preside.system.base.AdminHandler" {
 		prc.pageTitle    = translateResource( "formbuilder:page.title" );
 		prc.pageSubtitle = translateResource( "formbuilder:page.subtitle" );
 
-		prc.canAdd    = hasCmsPermission( permissionKey="formbuilder.addform" );
-		prc.canDelete = hasCmsPermission( permissionKey="formbuilder.deleteform" );
+		prc.canAdd     = hasCmsPermission( permissionKey="formbuilder.addform" );
+		prc.canDelete  = hasCmsPermission( permissionKey="formbuilder.deleteform" );
+		prc.avlButtons = [];
+
+		if ( isTrue( prc.canAdd ) ) {
+			prc.avlButtons.append( {
+				  link      = event.buildAdminLink( linkTo="formbuilder.addForm" )
+				, globalKey = "a"
+				, btnClass  = "btn-success btn-sm"
+				, iconClass = "fa-plus"
+				, btnLabel  = translateResource( "formbuilder:add.form.btn" )
+			} );
+		}
 	}
 
 	public void function addForm( event, rc, prc ) {

--- a/system/handlers/admin/FormBuilder.cfc
+++ b/system/handlers/admin/FormBuilder.cfc
@@ -30,19 +30,8 @@ component extends="preside.system.base.AdminHandler" {
 		prc.pageTitle    = translateResource( "formbuilder:page.title" );
 		prc.pageSubtitle = translateResource( "formbuilder:page.subtitle" );
 
-		prc.canAdd     = hasCmsPermission( permissionKey="formbuilder.addform" );
-		prc.canDelete  = hasCmsPermission( permissionKey="formbuilder.deleteform" );
-		prc.avlButtons = [];
-
-		if ( isTrue( prc.canAdd ) ) {
-			prc.avlButtons.append( {
-				  link      = event.buildAdminLink( linkTo="formbuilder.addForm" )
-				, globalKey = "a"
-				, btnClass  = "btn-success btn-sm"
-				, iconClass = "fa-plus"
-				, btnLabel  = translateResource( "formbuilder:add.form.btn" )
-			} );
-		}
+		prc.canAdd    = hasCmsPermission( permissionKey="formbuilder.addform" );
+		prc.canDelete = hasCmsPermission( permissionKey="formbuilder.deleteform" );
 	}
 
 	public void function addForm( event, rc, prc ) {

--- a/system/handlers/admin/datamanager/formbuilder_question.cfc
+++ b/system/handlers/admin/datamanager/formbuilder_question.cfc
@@ -55,6 +55,13 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 // DATA MANAGER CUSTOMIZATIONS
+	private void function rootBreadcrumb( event, rc, prc, args={} ) {
+		event.addAdminBreadCrumb(
+			  title = translateResource( uri="formBuilder:breadcrumb.title" )
+			, link  = event.buildAdminLink( linkTo="formbuilder.index" )
+		);
+	}
+
 	private boolean function checkPermission( event, rc, prc, args={} ) {
 		var objectName       = "formbuilder_question";
 		var allowedOps       = datamanagerService.getAllowedOperationsForObject( objectName );

--- a/system/views/admin/formbuilder/index.cfm
+++ b/system/views/admin/formbuilder/index.cfm
@@ -1,21 +1,19 @@
 <cfscript>
-	canAdd    = IsTrue( prc.canAdd ?: "" );
-	canDelete = IsTrue( prc.canDelete ?: "" );
-
-	showButtonGroup = canAdd;
+	canDelete  = IsTrue( prc.canDelete ?: "" );
+	avlButtons = prc.avlButtons ?: [];
 </cfscript>
 
 <cfoutput>
-	<cfif showButtonGroup>
+	<cfif isArray( avlButtons ) && !arrayIsEmpty( avlButtons )>
 		<div class="top-right-button-group">
-			<cfif canAdd>
-				<a class="pull-right inline" href="#event.buildAdminLink( linkTo="formbuilder.addForm" )#" data-global-key="a">
-					<button class="btn btn-success btn-sm">
-						<i class="fa fa-plus"></i>
-						#translateResource( "formbuilder:add.form.btn" )#
+			<cfloop array="#avlButtons#" item="btn">
+				<a class="pull-right inline" href="#btn.link#" data-global-key="#btn.globalKey ?: ""#">
+					<button class="btn #btn.btnClass#">
+						<i class="fa #btn.iconClass#"></i>
+						#btn.btnLabel#
 					</button>
 				</a>
-			</cfif>
+			</cfloop>
 		</div>
 	</cfif>
 

--- a/system/views/admin/formbuilder/index.cfm
+++ b/system/views/admin/formbuilder/index.cfm
@@ -1,19 +1,20 @@
 <cfscript>
-	canDelete  = IsTrue( prc.canDelete ?: "" );
-	avlButtons = prc.avlButtons ?: [];
+	canAdd    = IsTrue( prc.canAdd ?: "" );
+	canDelete = IsTrue( prc.canDelete ?: "" );
+	showButtonGroup = canAdd;
 </cfscript>
 
 <cfoutput>
-	<cfif isArray( avlButtons ) && !arrayIsEmpty( avlButtons )>
+	<cfif showButtonGroup>
 		<div class="top-right-button-group">
-			<cfloop array="#avlButtons#" item="btn">
-				<a class="pull-right inline" href="#btn.link#" data-global-key="#btn.globalKey ?: ""#">
-					<button class="btn #btn.btnClass#">
-						<i class="fa #btn.iconClass#"></i>
-						#btn.btnLabel#
+			<cfif canAdd>
+				<a class="pull-right inline" href="#event.buildAdminLink( linkTo="formbuilder.addForm" )#" data-global-key="a">
+					<button class="btn btn-success btn-sm">
+						<i class="fa fa-plus"></i>
+						#translateResource( "formbuilder:add.form.btn" )#
 					</button>
 				</a>
-			</cfloop>
+			</cfif>
 		</div>
 	</cfif>
 


### PR DESCRIPTION
- ~~move form builder canAdd logic check to handler and append to `prc.avlButton`, render actions from new `avlButton` in view.~~ Revert this
- add crumb trail for form builder's questions