### PR TITLE
remove the variable that does not exist

### DIFF
--- a/system/handlers/rules/expressions/UserLastVisitedPage.cfc
+++ b/system/handlers/rules/expressions/UserLastVisitedPage.cfc
@@ -17,10 +17,6 @@ component {
 		  required string  page
 		,          struct  _pastTime
 	) {
-		if ( ListLen( action, "." ) != 2 ) {
-			return false;
-		}
-
 		var lastPerformedDate = websiteUserActionService.getLastPerformedDate(
 			  type        = "request"
 			, action      = "pagevisit"


### PR DESCRIPTION
there is some code that doesnt belong to UserLastVisitedPage.cfc's evaluateExpression method