### PR TITLE
PRESIDECMS-1992 Lucee Spreadsheet upgrade to latest release

### DIFF
--- a/box.json
+++ b/box.json
@@ -27,7 +27,7 @@
     ],
     "dependencies":{
         "sticker":"1.2.2",
-        "lucee-spreadsheet":"github:cfsimplicity/lucee-spreadsheet#v1.3.0",
+        "lucee-spreadsheet":"github:cfsimplicity/lucee-spreadsheet#v2.12.0",
         "presidecmseditor":"github:pixl8/Preside-Editor#4.11.3",
         "cbi18n":"1.3.1+56",
         "cbmessagebox":"2.2.0+10",


### PR DESCRIPTION
Upgrade to latest release version and have tested with:
1. Datamanager export
2. Formbuilder export

Special note: There is an existing error prior to Lucee Spreadsheet upgrade on Datamanager object export > ExcelMultiSheets - left as it is with the upgrade