### PR TITLE
PRESIDE-1958 float comparison to decimal(12,4)

### DIFF
--- a/system/services/formbuilder/FormBuilderFilterService.cfc
+++ b/system/services/formbuilder/FormBuilderFilterService.cfc
@@ -883,7 +883,7 @@ component {
 						break;
 					case "free"   :
 						responseField="float_response";
-						cast         ="float";
+						cast         ="decimal(12,4)";
 						break;
 					case "price"  :
 						responseField="float_response";


### PR DESCRIPTION
Please confirm that decimal(12,4) is ok to use for float_response comparison in filters before merging

NB: float comparison hit precision problems on UAT (oddly worked locally)