### PR TITLE
PRESIDECMS-1927: Rule expressions - User last submitted form builder form - variable action does not exist

### DIFF
--- a/system/handlers/rules/expressions/UserDownloadedAssetANumberOfTimes.cfc
+++ b/system/handlers/rules/expressions/UserDownloadedAssetANumberOfTimes.cfc
@@ -1,5 +1,5 @@
 /**
- * Expression handler for "User has visited a page a number of times"
+ * Expression handler for "User has downloaded an asset a number of times"
  *
  * @feature websiteUsers
  * @expressionContexts user

--- a/system/handlers/rules/expressions/UserLastDownloadedAsset.cfc
+++ b/system/handlers/rules/expressions/UserLastDownloadedAsset.cfc
@@ -1,5 +1,5 @@
 /**
- * Expression handler for "User has performed some action within the last x days"
+ * Expression handler for "User has downloaded an asset within the last x days"
  *
  * @feature websiteUsers
  * @expressionContexts user
@@ -17,10 +17,6 @@ component {
 		  required string  asset
 		,          struct  _pastTime
 	) {
-		if ( ListLen( action, "." ) != 2 ) {
-			return false;
-		}
-
 		var lastPerformedDate = websiteUserActionService.getLastPerformedDate(
 			  type        = "asset"
 			, action      = "download"

--- a/system/handlers/rules/expressions/UserLastSubmittedFormBuilderForm.cfc
+++ b/system/handlers/rules/expressions/UserLastSubmittedFormBuilderForm.cfc
@@ -18,10 +18,6 @@ component {
 		  required string  fbform
 		,          struct  _pastTime
 	) {
-		if ( ListLen( action, "." ) != 2 ) {
-			return false;
-		}
-
 		var lastPerformedDate = websiteUserActionService.getLastPerformedDate(
 			  type        = "formbuilder"
 			, action      = "submitform"

--- a/system/handlers/rules/expressions/UserLastVisitedPage.cfc
+++ b/system/handlers/rules/expressions/UserLastVisitedPage.cfc
@@ -1,5 +1,5 @@
 /**
- * Expression handler for "User has performed some action within the last x days"
+ * Expression handler for "User has visited a page the last x days"
  *
  * @feature websiteUsers
  * @expressionContexts user
@@ -17,10 +17,6 @@ component {
 		  required string  page
 		,          struct  _pastTime
 	) {
-		if ( ListLen( action, "." ) != 2 ) {
-			return false;
-		}
-
 		var lastPerformedDate = websiteUserActionService.getLastPerformedDate(
 			  type        = "request"
 			, action      = "pagevisit"

--- a/system/handlers/rules/expressions/UserSubmittedFormBuilderForms.cfc
+++ b/system/handlers/rules/expressions/UserSubmittedFormBuilderForms.cfc
@@ -1,5 +1,5 @@
 /**
- * Expression handler for "User has visited any/all of the following pages"
+ * Expression handler for "User has submitted any/all of the following form builder forms"
  *
  * @feature websiteUsers
  * @expressionContexts user


### PR DESCRIPTION
1. Remove checking "action" in some rules - expressions not needed.
2. Correct Rules - Expressions description