### PR TITLE
PRESIDECMS-2009 Rules Engine Auto filter label updates

### DIFF
--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyCount.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyCount.cfc
@@ -111,9 +111,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentPropertyName = ""
 	) {
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri     = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );
-		var relatedToTranslated  = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 		var possesses            = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )
@@ -135,9 +134,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string parentPropertyName = ""
 	){
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri     = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );
-		var relatedToTranslated  = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated  = translateObjectProperty( objectName, propertyName );
 		var possesses            = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyHas.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyHas.cfc
@@ -94,9 +94,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentPropertyName = ""
 	) {
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri     = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );
-		var relatedToTranslated  = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated  = translateObjectProperty( objectName, propertyName );
 		var possesses            = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )
@@ -118,9 +117,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string parentPropertyName = ""
 	){
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri     = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );
-		var relatedToTranslated  = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated  = translateObjectProperty( objectName, propertyName );
 
 		if ( Len( Trim( parentPropertyName ) ) ) {
 			var parentPropNameTranslated = super._getExpressionPrefix( argumentCollection=arguments );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyMatch.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyMatch.cfc
@@ -88,9 +88,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentPropertyName = ""
 	) {
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri     = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );
-		var relatedToTranslated  = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated  = translateObjectProperty( objectName, propertyName );
 		var possesses            = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )
@@ -112,10 +111,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string parentPropertyName = ""
 	){
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri     = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );
-		var relatedToTranslated  = translateResource( relatedToBaseUri & "title", relatedTo );
-
+		var relatedToTranslated  = translateObjectProperty( objectName, propertyName );
 
 		if ( Len( Trim( parentPropertyName ) ) ) {
 			var parentPropNameTranslated = super._getExpressionPrefix( argumentCollection=arguments );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyCount.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyCount.cfc
@@ -119,8 +119,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentPropertyName = ""
 	) {
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( relatedTo );
-		var relatedToTranslated = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 		var possesses           = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )
@@ -143,8 +142,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string parentPropertyName = ""
 	){
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( relatedTo );
-		var relatedToTranslated = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 		var possesses           = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )

--- a/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyHas.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyHas.cfc
@@ -95,8 +95,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentPropertyName = ""
 	) {
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( relatedTo );
-		var relatedToTranslated = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 		var possesses           = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )
@@ -118,8 +117,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string parentObjectName   = ""
 		,          string parentPropertyName = ""
 	){
-		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( relatedTo );
-		var relatedToTranslated = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 
 		if ( Len( Trim( parentPropertyName ) ) ) {
 			var parentPropNameTranslated = super._getExpressionPrefix( argumentCollection=arguments );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyMatch.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyMatch.cfc
@@ -89,8 +89,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentPropertyName = ""
 	) {
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
-		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( relatedTo );
-		var relatedToTranslated = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 		var possesses           = translateResource(
 			  uri          = objectBaseUri & "field.#propertyName#.possesses.truthy"
 			, defaultValue = translateResource( "rules.dynamicExpressions:boolean.possesses" )
@@ -112,8 +111,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  parentObjectName   = ""
 		,          string  parentPropertyName = ""
 	){
-		var relatedToBaseUri          = presideObjectService.getResourceBundleUriRoot( relatedTo );
-		var relatedToTranslated       = translateResource( relatedToBaseUri & "title", relatedTo );
+		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 
 		if ( Len( Trim( parentPropertyName ) ) ) {
 			var parentPropNameTranslated = super._getExpressionPrefix( argumentCollection=arguments );


### PR DESCRIPTION
Using i18n property labels instead of target object labels for many-to-many and one-to-many auto filter expressions.
This is useful for all objects which have multiple relations to the same object or a relation to itself.