### PR TITLE
PRESIDECMS-2014: Support higher ASCII and HTML encoded entities also when click tracking

### DIFF
--- a/system/services/email/EmailLoggingService.cfc
+++ b/system/services/email/EmailLoggingService.cfc
@@ -523,7 +523,11 @@ component {
 			}
 		}
 
-		return doc.toString();
+		if ( $isFeatureEnabled( "emailStyleInlinerAscii" ) ) {
+			doc.outputSettings().charset( "ASCII" );
+		}
+
+		return doc.html();
 	}
 
 	/**

--- a/tests/integration/api/email/EmailLoggingServiceTest.cfc
+++ b/tests/integration/api/email/EmailLoggingServiceTest.cfc
@@ -587,6 +587,7 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 		service.$( "$getPresideObject" ).$args( "email_template_send_log" ).$results( mockLogDao );
 		service.$( "$getPresideObject" ).$args( "email_template_send_log_activity" ).$results( mockLogActivityDao );
 		service.$( "$isFeatureEnabled" ).$args( "emailLinkShortener" ).$results( false );
+		service.$( "$isFeatureEnabled" ).$args( "emailStyleInlinerAscii" ).$results( false );
 		service.$( "$announceInterception" );
 
 		nowish  = Now();


### PR DESCRIPTION
The styleinliner already supported the feature emailStyleInlinerAscii - but the click tracking not.
In addition the click tracking used to use there jsoup doc.toString() method which eliminates html encoded entities.

The result is that emails with click tracking enabled look and behave differently if either higher ascii chars or html encoded entities are used.

The code changes proposed here will solve this and make sure that the general email content is the same, both with and without click tracking enabled.