### PR TITLE
PRESIDECMS-2016 saved export saved filters field not showing on edit form

### DIFF
--- a/system/handlers/admin/datamanager/saved_export.cfc
+++ b/system/handlers/admin/datamanager/saved_export.cfc
@@ -159,6 +159,10 @@ component {
 		);
 	}
 
+	private void function preRenderEditRecordForm( event, rc, prc, args={} ) {
+		rc.filterObject = args.record.object_name ?: "";
+	}
+
 // HELPERS
 	private string function _decorateLabelForListing( required string recordId ) {
 		var detail     = presideObjectService.selectData( objectName="saved_export", id=arguments.recordId );


### PR DESCRIPTION
Added **preRenderEditRecordForm** to Saved export datamanager to define rc.filterObject in order for the **saved_filters** field to show on the edit saved export admin form.