### PR TITLE
PRESIDECMS-2020 fix saving condition saved as filter bug

### DIFF
--- a/system/handlers/admin/datamanager/rules_engine_condition.cfc
+++ b/system/handlers/admin/datamanager/rules_engine_condition.cfc
@@ -449,6 +449,8 @@ component extends="preside.system.base.AdminHandler" {
 		if ( ( rc.convertAction ?: "" ) == "filter" && Len( rc.filter_object ?: "" ) ) {
 			formData.context = "";
 			formData.filter_object = rc.filter_object;
+		} else {
+			structDelete( formData, "filter_object" );
 		}
 
 		switch ( args.formData.filter_sharing_scope ?: "" ) {


### PR DESCRIPTION
remove `filter_object` from formData if is not convert to filter when editing rule condition.