### PR TITLE
Feature presidecms 2042 sitetree page clone form missing tab title

### DIFF
--- a/system/i18n/preside-objects/page.properties
+++ b/system/i18n/preside-objects/page.properties
@@ -4,6 +4,7 @@ description=Site tree pages are pages that are navigatable within your website
 addRecord.prompt=Enter the basic page information, below. You will be able to configure advanced options once the page has been created.
 
 tab.main.title=Standard fields
+tab.clone.title=Standard fields
 tab.meta.title=Metadata and Search
 tab.dates.title=Date controls
 tab.navigation.title=Navigation


### PR DESCRIPTION
https://presidecms.atlassian.net/browse/PRESIDECMS-2042

tab.clone.title was missing. Have added this into page.properties as 'Standard fields'.

![image](https://user-images.githubusercontent.com/50322115/103620774-0f349300-4f6f-11eb-864b-e6d88f514165.png)
