### PR TITLE
used common filename if timestamp must be used

### DIFF
--- a/system/handlers/ScheduledExportHelpers.cfc
+++ b/system/handlers/ScheduledExportHelpers.cfc
@@ -60,7 +60,7 @@ component {
 				var exportedFile = dataExportService.exportData( argumentCollection=configArgs );
 
 				if ( !isEmpty( exportedFile ) ) {
-					var filePath = "#savedExportDetail.file_name# #dateTimeFormat( now() )#.#exporterDetail.fileExtension#";
+					var filePath = "#savedExportDetail.file_name# #DateTimeFormat( Now(), "yyyymmdd_HHnn" )#.#exporterDetail.fileExtension#";
 
 					exportStorageProvider.putObject( object=fileReadBinary( exportedFile ), path=filePath );
 					scheduledExportService.saveFilePathToHistoryExport( filepath=filePath, historyExportId=historyId );


### PR DESCRIPTION
I had problems with saved export files. 
The resulting file path was "uploads/scheduled-export/companies_vps 22-Feb-2021 10:14:13.xlsx". It does not work because of the colon in the file name.

Problem detected on preside 10.12. but it still the source code status in 10.14.
