### PR TITLE
PRESIDECMS-2093 Added feature for datamanager grid to get paged results and total count in single query

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -453,7 +453,6 @@ component {
 			, assetQueueHeartBeat      = { enabled=true , siteTemplates=[ "*" ] }
 			, assetQueue               = { enabled=false , siteTemplates=[ "*" ] }
 			, queryCachePerObject      = { enabled=false, siteTemplates=[ "*" ] }
-			, enhancedGridRecordcount  = { enabled=false, siteTemplates=[ "*" ] }
 			, sslInternalHttpCalls     = { enabled=_luceeGreaterThanFour(), siteTemplates=[ "*" ] }
 			, sslInternalHttpCalls     = { enabled=_luceeGreaterThanFour(), siteTemplates=[ "*" ] }
 			, presideSessionManagement = { enabled=_usePresideSessionManagement(), siteTemplates=[ "*" ] }

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -453,6 +453,7 @@ component {
 			, assetQueueHeartBeat      = { enabled=true , siteTemplates=[ "*" ] }
 			, assetQueue               = { enabled=false , siteTemplates=[ "*" ] }
 			, queryCachePerObject      = { enabled=false, siteTemplates=[ "*" ] }
+			, enhancedGridRecordcount  = { enabled=false, siteTemplates=[ "*" ] }
 			, sslInternalHttpCalls     = { enabled=_luceeGreaterThanFour(), siteTemplates=[ "*" ] }
 			, sslInternalHttpCalls     = { enabled=_luceeGreaterThanFour(), siteTemplates=[ "*" ] }
 			, presideSessionManagement = { enabled=_usePresideSessionManagement(), siteTemplates=[ "*" ] }

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -442,18 +442,18 @@ component {
 				args.filterParams[ param.name ] = args.filterParams[ param.name ] ?: param;
 			}
 		}
-		
-		var enhancedGridRecordcount = $isFeatureEnabled( "enhancedGridRecordcount" );
-		
-		if ( enhancedGridRecordcount ) {
-			args.selectFields.append( "count(*) over() as _total_recordcount" );
+
+		var dbAdapter = _getPresideObjectService().getDbAdapterForObject( arguments.objectName );
+
+		if ( dbAdapter.supportsCountOverWindowFunction() ) {
+			args.selectFields.append( "#dbAdapter.getCountOverWindowFunctionSql()# as _total_recordcount" );
 		}
 
 		result.records = _getPresideObjectService().selectData( argumentCollection=args );
 
 		if ( arguments.startRow == 1 && result.records.recordCount < arguments.maxRows ) {
 			result.totalRecords = result.records.recordCount;
-		} else if ( enhancedGridRecordcount ) {
+		} else if ( dbAdapter.supportsCountOverWindowFunction() ) {
 			result.totalRecords = result.records.recordCount ? result.records._total_recordcount : 0;
 		} else {
 			result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args, recordCountOnly=true, maxRows=0 );

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -442,11 +442,19 @@ component {
 				args.filterParams[ param.name ] = args.filterParams[ param.name ] ?: param;
 			}
 		}
+		
+		var enhancedGridRecordcount = $isFeatureEnabled( "enhancedGridRecordcount" );
+		
+		if ( enhancedGridRecordcount ) {
+			args.selectFields.append( "count(*) over() as _total_recordcount" );
+		}
 
 		result.records = _getPresideObjectService().selectData( argumentCollection=args );
 
 		if ( arguments.startRow == 1 && result.records.recordCount < arguments.maxRows ) {
 			result.totalRecords = result.records.recordCount;
+		} else if ( enhancedGridRecordcount ) {
+			result.totalRecords = result.records.recordCount ? result.records._total_recordcount : 0;
 		} else {
 			result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args, recordCountOnly=true, maxRows=0 );
 		}

--- a/system/services/database/adapters/BaseAdapter.cfc
+++ b/system/services/database/adapters/BaseAdapter.cfc
@@ -472,6 +472,14 @@ component {
 		return false;
 	}
 
+	public boolean function supportsCountOverWindowFunction() {
+		return false;
+	}
+
+	public string function getCountOverWindowFunctionSql() {
+		return "null";
+	}
+
 	public string function getRenameColumnSql( required string tableName, required string oldColumnName, required string newColumnName ) {
 		return "getRenameColumnSql() not implemented. Must be implemented by extended adapters.";
 	}

--- a/system/services/database/adapters/MySqlAdapter.cfc
+++ b/system/services/database/adapters/MySqlAdapter.cfc
@@ -248,4 +248,12 @@ component extends="BaseAdapter" {
 		        where           u.table_schema = :databasename
 		        and             u.referenced_column_name is not null";
 	}
+
+	public boolean function supportsCountOverWindowFunction() {
+		return true;
+	}
+
+	public string function getCountOverWindowFunctionSql() {
+		return "count(*) over()";
+	}
 }


### PR DESCRIPTION
* feature disabled by default
* if enabled avoiding second query to obtain total record count in datamanager grid listings
* using sql window function (available in recent mysql/mariadb versions as well as SQL Server. tested with MariaDB)
* especially useful if dealing with large tables but should be in general faster than using 2 queries