### PR TITLE
PRESIDECMS-2116 avoid unnecessary exceptions

### DIFF
--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -3649,21 +3649,15 @@ component displayName="Preside Object Service" {
 	}
 
 	private boolean function _getUseCacheDefault( required string objectName ) {
-		try {
-			return request[ "_defaultUseCache#arguments.objectName#" ];
-		} catch( any e ) {
+		if ( !StructKeyExists( request, "_defaultUseCache#arguments.objectName#" ) )
 			request[ "_defaultUseCache#arguments.objectName#" ] = _objectUsesCaching( arguments.objectName ) && $getRequestContext().getUseQueryCache();
-		}
 
 		return request[ "_defaultUseCache#arguments.objectName#" ];
 	}
 
 	private boolean function _getDefaultAllowDraftVersions() {
-		try {
-			return request._defaultAllowDraftVersions;
-		} catch( any e ) {
+		if ( !StructKeyExists( request , "_defaultAllowDraftVersions" ) )
 			request._defaultAllowDraftVersions = $getRequestContext().showNonLiveContent();
-		}
 
 		return request._defaultAllowDraftVersions;
 	}

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -3649,15 +3649,16 @@ component displayName="Preside Object Service" {
 	}
 
 	private boolean function _getUseCacheDefault( required string objectName ) {
-		if ( !StructKeyExists( request, "_defaultUseCache#arguments.objectName#" ) )
+		if ( !StructKeyExists( request, "_defaultUseCache#arguments.objectName#" ) ) {
 			request[ "_defaultUseCache#arguments.objectName#" ] = _objectUsesCaching( arguments.objectName ) && $getRequestContext().getUseQueryCache();
-
+		}
 		return request[ "_defaultUseCache#arguments.objectName#" ];
 	}
 
 	private boolean function _getDefaultAllowDraftVersions() {
-		if ( !StructKeyExists( request , "_defaultAllowDraftVersions" ) )
+		if ( !StructKeyExists( request , "_defaultAllowDraftVersions" ) ) {
 			request._defaultAllowDraftVersions = $getRequestContext().showNonLiveContent();
+		}
 
 		return request._defaultAllowDraftVersions;
 	}


### PR DESCRIPTION
Both `_getUseCacheDefault()` and `_getDefaultAllowDraftVersions` in `PresideObjectService` use try/catch to see whether or not this has already been calculated for the request. A simple `StructKeyExists()` should suffice here and perform better.

https://presidecms.atlassian.net/browse/PRESIDECMS-2116