### PR TITLE
PRESIDECMS-2119 preside email css inliner tool injects media query styles

### DIFF
--- a/system/services/email/EmailStyleInliner.cfc
+++ b/system/services/email/EmailStyleInliner.cfc
@@ -51,7 +51,7 @@ component {
 		var styles        = [];
 
 		for( var styleElement in styleElements ) {
-			var elementStyleRules = styleElement.getAllElements().get( 0 ).data().replaceAll( "\n", "" ).replaceAll( "\/\*.*?\*\/", "" ).trim();
+			var elementStyleRules = styleElement.getAllElements().get( 0 ).data().replaceAll( "\n", "" ).replaceAll( "\/\*.*?\*\/", "" ).reReplaceNoCase( "\@media.*?\{(.*?\})?\}", "", "all" ).trim();
 			var tokenizer         = CreateObject( "java", "java.util.StringTokenizer" ).init( elementStyleRules, ruleDelims );
 
 			while( tokenizer.countTokens() > 1 ) {

--- a/system/services/email/EmailStyleInliner.cfc
+++ b/system/services/email/EmailStyleInliner.cfc
@@ -51,7 +51,7 @@ component {
 		var styles        = [];
 
 		for( var styleElement in styleElements ) {
-			var elementStyleRules = styleElement.getAllElements().get( 0 ).data().replaceAll( "\n", "" ).replaceAll( "\/\*.*?\*\/", "" ).reReplaceNoCase( "\@media.*?\{(.*?\})?\}", "", "all" ).trim();
+			var elementStyleRules = styleElement.getAllElements().get( 0 ).data().replaceAll( "\n", "" ).replaceAll( "\/\*.*?\*\/", "" ).reReplaceNoCase( "\@media.*?\{(.*?\})?\s*?\}", "", "all" ).trim();
 			var tokenizer         = CreateObject( "java", "java.util.StringTokenizer" ).init( elementStyleRules, ruleDelims );
 
 			while( tokenizer.countTokens() > 1 ) {


### PR DESCRIPTION
I used the regex replace all to remove all media query clauses.

Regexp: `\@media.*?\{(.*?\})?\s*?\}`
- Finding strings starting with `@media` up to the first occurrence of '{' and until the occurrence of consecutive '}'. Consecutive '}' means it is the end of the media query clause.
- The first '}' was put inside a group, `(.*?\})?`, to capture the scenario of empty media query, eg. `@media { }`