### PR TITLE
PRESIDECMS-2183 Force download option when adding asset type link

### DIFF
--- a/system/forms/preside-objects/link/admin.edit.xml
+++ b/system/forms/preside-objects/link/admin.edit.xml
@@ -30,7 +30,8 @@ This form is used edit a link
 		</fieldset>
 
 		<fieldset id="asset" sortorder="50" class="link-type-group">
-			<field sortorder="10" binding="link.asset" />
+			<field sortorder="10" binding="link.asset"    />
+			<field sortorder="20" binding="link.download" />
 		</fieldset>
 	</tab>
 

--- a/system/forms/preside-objects/link/admin.quickadd.xml
+++ b/system/forms/preside-objects/link/admin.quickadd.xml
@@ -30,7 +30,8 @@ This form is used for the quick add link modal
 		</fieldset>
 
 		<fieldset id="asset" sortorder="50">
-			<field sortorder="10" binding="link.asset" />
+			<field sortorder="10" binding="link.asset"    />
+			<field sortorder="20" binding="link.download" />
 		</fieldset>
 
 		<fieldset id="anchor" sortorder="60">

--- a/system/forms/preside-objects/link/admin.quickedit.xml
+++ b/system/forms/preside-objects/link/admin.quickedit.xml
@@ -30,7 +30,8 @@ This form is used for editing links through the link picker form control
 		</fieldset>
 
 		<fieldset id="asset" sortorder="50">
-			<field sortorder="10" binding="link.asset" />
+			<field sortorder="10" binding="link.asset"    />
+			<field sortorder="20" binding="link.download" />
 		</fieldset>
 
 		<fieldset id="anchor" sortorder="60">

--- a/system/handlers/renderers/Link.cfc
+++ b/system/handlers/renderers/Link.cfc
@@ -16,6 +16,9 @@ component {
 		args.href  = linksService.getLinkUrl( link.id );
 		args.title = args.title ?: Trim( link.title );
 		args.referrer_policy = args.referrer_policy ?: Trim( link.referrer_policy );
+		if ( link.type == "asset" ) {
+			args.download = isTrue( link.download );
+		}
 
 		if ( !Len( Trim( args.body ?: "" ) ) ) {
 			if ( Len( Trim( link.image ) ) ) {

--- a/system/i18n/preside-objects/link.properties
+++ b/system/i18n/preside-objects/link.properties
@@ -31,6 +31,8 @@ field.text.title=Link text
 field.text.help=The text that appears in place of the link. Leave this blank to have it set automatically based on the type of link.
 field.image.title=Image
 field.image.help=Choose or upload an image if you wish to just have an image instead of text for the link. NOTE: the image will not be cropped in any way so ensure that the image you use is the correct size.
+field.download.title=Download
+field.download.help=Enabling this will force download when the asset link is clicked
 
 targets.self=Normal
 targets.blank=New window or tab

--- a/system/preside-objects/core/link.cfc
+++ b/system/preside-objects/core/link.cfc
@@ -17,6 +17,7 @@ component extends="preside.system.base.SystemPresideObject" displayname="Link" {
 	property name="nofollow"          type="boolean" dbtype="boolean"                 required=false default=false;
 	property name="referrer_policy"   type="string"  dbtype="varchar" enum="linkReferrerPolicy"  required=false default="";
 	property name="text"              type="string"  dbtype="varchar" maxlength="400" required=false;
+	property name="download"          type="boolean" dbtype="boolean"                 required="false" default="false";
 
 	property name="external_protocol" adminviewgroup="external" type="string"  dbtype="varchar" maxlength="10"  required=false default="http://" enum="linkProtocol";
 	property name="external_address"  adminviewgroup="external" type="string"  dbtype="varchar" maxlength="255" required=false;

--- a/system/views/renderers/link/default.cfm
+++ b/system/views/renderers/link/default.cfm
@@ -12,6 +12,7 @@
 	param name="args.ariaLabelledby"  type="string"  default="";
 	param name="args.ariaDescribedby" type="string"  default="";
 	param name="args.ariaHidden"      type="boolean" default=false;
+	param name="args.download"        type="boolean" default=false;
 
 	anchorTag = 'href="#args.href#"';
 
@@ -47,6 +48,9 @@
 	}
 	if ( args.ariaHidden ) {
 		anchorTag &= ' aria-hidden="true"';
+	}
+	if ( isTrue( args.download ) ) {
+		anchorTag &= ' download';
 	}
 </cfscript>
 


### PR DESCRIPTION
• Added download option when adding asset type link
• When enabled, the download attribute will be added to the html "a" tag