### PR TITLE
Feature presidecms 2176 update last error dbtype

### DIFF
--- a/system/preside-objects/assetManager/asset_generation_queue.cfc
+++ b/system/preside-objects/assetManager/asset_generation_queue.cfc
@@ -17,5 +17,5 @@ component extends="preside.system.base.SystemPresideObject" displayName="Asset g
 	property name="retry_count"  type="numeric" dbtype="int"                  required=true default=0         indexes="retrycount";
 	property name="queue_status" type="string"  dbtype="varchar" maxlength=10 required=true default="pending" indexes="queuestatus" enum="assetQueueStatus";
 
-	property name="last_error" type="string" dbtype="text";
+	property name="last_error" type="string" dbtype="longtext";
 }


### PR DESCRIPTION
This is to update the db type of last_error to long_text as the error log is long and will throw error occasionally