### PR TITLE
PRESIDECMS-2188 OpenGraph meta: duplicate url path

### DIFF
--- a/system/views/general/_openGraphMeta.cfm
+++ b/system/views/general/_openGraphMeta.cfm
@@ -14,7 +14,7 @@
 <cfoutput>
 	<meta property="og:title" content="#XmlFormat( local.title )#" />
 	<meta property="og:type"  content="#local.ogType#" />
-	<meta property="og:url"   content="#event.getSiteUrl( includeLanguageSlug=false )##HtmlEditFormat( event.getCurrentUrl() )#" />
+	<meta property="og:url"   content="#event.getSiteUrl( includeLanguageSlug=false, includePath=false )##HtmlEditFormat( event.getCurrentUrl() )#" />
 	<cfif Len( local.teaser )>
 		<meta property="og:description" content="#HtmlEditFormat( local.teaser )#" />
 	</cfif>
@@ -22,4 +22,3 @@
 		<meta property="og:image" content="#event.buildLink( assetId=local.mainImage, derivative='openGraphImage' )#" />
 	</cfif>
 </cfoutput>
-


### PR DESCRIPTION
Do not include site path from site URL for `og:url`