### PR TITLE
PRESIDECMS-2190 permissions for data manager export fields

### DIFF
--- a/system/handlers/formcontrols/MultiSelectPanel.cfc
+++ b/system/handlers/formcontrols/MultiSelectPanel.cfc
@@ -1,5 +1,7 @@
 component {
 	property name="presideObjectService" inject="PresideObjectService";
+	property name="loginService"         inject="LoginService";
+	property name="permissionService"    inject="PermissionService";
 
 	public string function index( event, rc, prc, args={} ) {
 		args.labels    = args.labels ?: [];
@@ -14,7 +16,20 @@ component {
 				var props   = presideObjectService.getObjectProperties( objectName );
 
 				for ( var prop in props ) {
-					if ( !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" ) && !IsTrue( props[ prop ].excludeDataExport ?: "" ) ) {
+					var hasPermission     = true;
+					var requiredRoleCheck = structKeyExists( props[ prop ], "limitToAdminRoles" );
+
+					if ( isTrue( requiredRoleCheck ) && ( ( args.context ?: "" ) == "admin" ) ) {
+						hasPermission = permissionService.userHasAssignedRoles(
+							  userId = loginService.getLoggedInUserId()
+							, roles  = listToArray( props[ prop ].limitToAdminRoles )
+						) || loginService.isSystemUser();
+					}
+
+					if ( isTrue( hasPermission )
+						 && !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" )
+						 && !IsTrue( props[ prop ].excludeDataExport ?: "" )
+					) {
 						args.values.append( prop );
 					}
 				}

--- a/system/handlers/formcontrols/MultiSelectPanel.cfc
+++ b/system/handlers/formcontrols/MultiSelectPanel.cfc
@@ -16,21 +16,20 @@ component {
 				var props   = presideObjectService.getObjectProperties( objectName );
 
 				for ( var prop in props ) {
-					var hasPermission     = true;
-					var requiredRoleCheck = structKeyExists( props[ prop ], "limitToAdminRoles" );
+					if ( !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" ) && !IsTrue( props[ prop ].excludeDataExport ?: "" ) ) {
+						var hasPermission     = true;
+						var requiredRoleCheck = structKeyExists( props[ prop ], "limitToAdminRoles" );
 
-					if ( isTrue( requiredRoleCheck ) && ( ( args.context ?: "" ) == "admin" ) ) {
-						hasPermission = permissionService.userHasAssignedRoles(
-							  userId = loginService.getLoggedInUserId()
-							, roles  = listToArray( props[ prop ].limitToAdminRoles )
-						) || loginService.isSystemUser();
-					}
+						if ( isTrue( requiredRoleCheck ) && ( ( args.context ?: "" ) == "admin" ) ) {
+							hasPermission = permissionService.userHasAssignedRoles(
+								  userId = loginService.getLoggedInUserId()
+								, roles  = listToArray( props[ prop ].limitToAdminRoles )
+							) || loginService.isSystemUser();
+						}
 
-					if ( isTrue( hasPermission )
-						 && !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" )
-						 && !IsTrue( props[ prop ].excludeDataExport ?: "" )
-					) {
-						args.values.append( prop );
+						if ( isTrue( hasPermission ) ) {
+							args.values.append( prop );
+						}
 					}
 				}
 

--- a/system/services/security/PermissionService.cfc
+++ b/system/services/security/PermissionService.cfc
@@ -242,7 +242,7 @@ component displayName="Admin permissions service" {
 			);
 
 			for ( var q in rolesQuery ) {
-				for ( var role in q.roles ) {
+				for ( var role in listToArray( q.roles ) ) {
 					groupsRoles.append( role );
 				}
 			}


### PR DESCRIPTION
To be use along with object properties' attribute `limitToAdminRoles`, and the value could be a list of admin roles.