### PR TITLE
PRESIDECMS-2196 object property attribute to exclude auto generate filter keys

### DIFF
--- a/system/services/rulesEngine/RulesEngineExpressionService.cfc
+++ b/system/services/rulesEngine/RulesEngineExpressionService.cfc
@@ -506,11 +506,19 @@ component displayName="RulesEngine Expression Service" {
 		var fileName = "";
 		var filePath = GetTempDirectory();
 		var locale   = $i18n.getFwLocale();
+		var suffix   = Hash( arguments.excludeTags );
+
+		if ( !$getAdminLoginService().isSystemUser() ) {
+			var adminUserId     = $getAdminLoginService().getLoggedInUserId();
+			arguments.userRoles = $getAdminPermissionService().listUserGroupsRoles( userId=adminUserId );
+
+			suffix = hash( arguments.excludeTags & serializeJSON( arguments.userRoles ) );
+		}
 
 		if ( Len( arguments.context ) ) {
-			fileName = "conditionexpressions-#locale#-#arguments.context#-#Hash( excludeTags )#.json"
+			fileName = "conditionexpressions-#locale#-#arguments.context#-#suffix#.json"
 		} else {
-			fileName = "filterexpressions-#locale#-#arguments.filterObject#-#Hash( excludeTags )#.json"
+			fileName = "filterexpressions-#locale#-#arguments.filterObject#-#suffix#.json"
 		}
 		filePath &= fileName;
 
@@ -566,7 +574,7 @@ component displayName="RulesEngine Expression Service" {
 
 		for( var objectName in objects ) {
 			if ( !StructKeyExists( variables._lazyLoadDone, objectName ) ) {
-				var expressions = _getAutoExpressionGenerator().getAutoExpressionsForObject( objectName );
+				var expressions = _getAutoExpressionGenerator().getAutoExpressionsForObject( objectName=objectName, userRoles=arguments.userRoles ?: [] );
 				if ( expressions.len() ) {
 					contextService.addContext( id="presideobject_" & objectName, object=objectName, visible=false );
 					for( var expression in expressions ) {


### PR DESCRIPTION
The cached expression files will have different suffix when the login user is not a system user (new suffix will be hash of exclude tags + logged in admin user's roles).

Each property in an object able to exclude expression keys to be generate by new `excludeAutoExpressions` attribute.
Developer also able to control auto generate expression keys available for specific admin roles by new `autoFilterExpressions:{admin role}` attribute.