### PR TITLE
PRESIDECMS-2210 unique indexes with tenancy

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -183,6 +183,7 @@ component {
 		interceptorSettings.customInterceptionPoints.append( "postExtraTopRightButtonsForEditRecord" );
 		interceptorSettings.customInterceptionPoints.append( "postGetExtraCloneRecordActionButtons"  );
 		interceptorSettings.customInterceptionPoints.append( "postExtraTopRightButtons"              );
+		interceptorSettings.customInterceptionPoints.append( "preValidateForm"		                 );
 
 		cacheBox = {
 			configFile = _discoverCacheboxConfigurator()

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -2297,7 +2297,7 @@ component extends="preside.system.base.AdminHandler" {
 		,          any     validationResult
 	) {
 		arguments.formName = Len( Trim( arguments.mergeWithFormName ) ) ? formsService.getMergedFormName( arguments.formName, arguments.mergeWithFormName ) : arguments.formName;
-		var formData         = {};
+		var formData         = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
 		var labelField       = presideObjectService.getObjectAttribute( object, "labelfield", "label" );
 		var obj              = "";
 		var validationResult = "";
@@ -2307,19 +2307,12 @@ component extends="preside.system.base.AdminHandler" {
 		var isDraft          = false;
 		var args             = arguments;
 		
-		arguments.data = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
-		arguments.objectName = arguments.object;
-		
-		announceInterception( 'preValidateForm', arguments );
-		formData = arguments.data;
-
 		args.formData = formData;
 
 		validationResult = validateForm( formName=arguments.formName, formData=formData, validationResult=( arguments.validationResult ?: NullValue() ), stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
 
 		args.formData         = formData;
 		args.validationResult = validationResult;
-
 		if ( customizationService.objectHasCustomization( object, "preAddRecordAction" ) ) {
 			customizationService.runCustomization(
 				  objectName = object
@@ -2692,7 +2685,7 @@ component extends="preside.system.base.AdminHandler" {
 
 		var id               = rc.id      ?: "";
 		var version          = rc.version ?: "";
-		var formData         = {};
+		var formData         = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
 		var objectName       = translateResource( uri="preside-objects.#object#:title.singular", defaultValue=object );
 		var obj              = "";
 		var validationResult = "";
@@ -2707,16 +2700,9 @@ component extends="preside.system.base.AdminHandler" {
 			setNextEvent( url=missingUrl );
 		}
 
-		arguments.data = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
-		arguments.objectName = object;
-		
-		announceInterception( 'preValidateForm', arguments );
-
-		formData = arguments.data;
 		formData.id = id;
-
 		validationResult = validateForm( formName=formName, formData=formData, validationResult=( arguments.validationResult ?: NullValue() ), stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
-
+		
 		var args = arguments;
 
 		args.formData         = formData;

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -2297,7 +2297,7 @@ component extends="preside.system.base.AdminHandler" {
 		,          any     validationResult
 	) {
 		arguments.formName = Len( Trim( arguments.mergeWithFormName ) ) ? formsService.getMergedFormName( arguments.formName, arguments.mergeWithFormName ) : arguments.formName;
-		var formData         = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
+		var formData         = {};
 		var labelField       = presideObjectService.getObjectAttribute( object, "labelfield", "label" );
 		var obj              = "";
 		var validationResult = "";
@@ -2306,6 +2306,12 @@ component extends="preside.system.base.AdminHandler" {
 		var persist          = "";
 		var isDraft          = false;
 		var args             = arguments;
+		
+		arguments.data = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
+		arguments.objectName = arguments.object;
+		
+		announceInterception( 'preValidateForm', arguments );
+		formData = arguments.data;
 
 		args.formData = formData;
 
@@ -2313,6 +2319,7 @@ component extends="preside.system.base.AdminHandler" {
 
 		args.formData         = formData;
 		args.validationResult = validationResult;
+
 		if ( customizationService.objectHasCustomization( object, "preAddRecordAction" ) ) {
 			customizationService.runCustomization(
 				  objectName = object
@@ -2685,7 +2692,7 @@ component extends="preside.system.base.AdminHandler" {
 
 		var id               = rc.id      ?: "";
 		var version          = rc.version ?: "";
-		var formData         = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
+		var formData         = {};
 		var objectName       = translateResource( uri="preside-objects.#object#:title.singular", defaultValue=object );
 		var obj              = "";
 		var validationResult = "";
@@ -2700,8 +2707,15 @@ component extends="preside.system.base.AdminHandler" {
 			setNextEvent( url=missingUrl );
 		}
 
+		arguments.data = event.getCollectionForForm( formName=arguments.formName, stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
+		arguments.objectName = object;
+		
+		announceInterception( 'preValidateForm', arguments );
+
 		formData.id = id;
+
 		validationResult = validateForm( formName=formName, formData=formData, validationResult=( arguments.validationResult ?: NullValue() ), stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
+		formData = arguments.data;
 
 		var args = arguments;
 

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -2712,10 +2712,10 @@ component extends="preside.system.base.AdminHandler" {
 		
 		announceInterception( 'preValidateForm', arguments );
 
+		formData = arguments.data;
 		formData.id = id;
 
 		validationResult = validateForm( formName=formName, formData=formData, validationResult=( arguments.validationResult ?: NullValue() ), stripPermissionedFields=arguments.stripPermissionedFields, permissionContext=arguments.permissionContext, permissionContextKeys=arguments.permissionContextKeys );
-		formData = arguments.data;
 
 		var args = arguments;
 

--- a/system/interceptors/TenancyPresideObjectInterceptor.cfc
+++ b/system/interceptors/TenancyPresideObjectInterceptor.cfc
@@ -29,7 +29,7 @@ component extends="coldbox.system.Interceptor" {
 	}
 
 	public void function preInsertObjectData( event, interceptData ) {
-		var tenancyData = tenancyService.get().getTenancyFieldsForInsertData( argumentCollection=interceptData );
+		var tenancyData = tenancyService.get().getTenancyFieldsForInsertOrUpdateData( argumentCollection=interceptData );
 		if ( tenancyData.count() ) {
 			interceptData.data = interceptData.data ?: {};
 			interceptData.data.append( tenancyData );

--- a/system/interceptors/TenancyPresideObjectInterceptor.cfc
+++ b/system/interceptors/TenancyPresideObjectInterceptor.cfc
@@ -35,4 +35,12 @@ component extends="coldbox.system.Interceptor" {
 			interceptData.data.append( tenancyData );
 		}
 	}
+
+	public void function preValidateForm( event, interceptData ) {
+		var tenancyData = tenancyService.get().getTenancyFieldsForInsertOrUpdateData( argumentCollection=interceptData );
+		if ( tenancyData.count() ) {
+			interceptData.data = interceptData.data ?: {};
+			interceptData.data.append( tenancyData );
+		}
+	}
 }

--- a/system/services/forms/FormsService.cfc
+++ b/system/services/forms/FormsService.cfc
@@ -604,6 +604,10 @@ component displayName="Forms service" {
 		,          string  fieldNameSuffix         = ""
 		,          array   suppressFields          = []
 	) {
+		arguments.objectName = _getPresideObjectNameFromFormNameByConvention( arguments.formName );
+		arguments.data = arguments.formData;
+		$announceInterception( "preValidateForm", arguments );
+
 		var ruleset = _getValidationRulesetFromFormName( argumentCollection=arguments );
 		var result  = arguments.preProcessData ? preProcessForm( argumentCollection = arguments ) : "";
 		var data    = Duplicate( arguments.formData );

--- a/system/services/tenancy/TenancyService.cfc
+++ b/system/services/tenancy/TenancyService.cfc
@@ -155,7 +155,7 @@ component displayName="Tenancy service" {
 		return "";
 	}
 
-	public struct function getTenancyFieldsForInsertData( required string objectName, array bypassTenants=[] ) {
+	public struct function getTenancyFieldsForInsertOrUpdateData( required string objectName, array bypassTenants=[] ) {
 		var tenant = getObjectTenant( arguments.objectName );
 		var fields = {};
 

--- a/system/services/tenancy/TenancyService.cfc
+++ b/system/services/tenancy/TenancyService.cfc
@@ -145,6 +145,16 @@ component displayName="Tenancy service" {
 		return request.__presideTenancy[ arguments.tenant ] ?: "";
 	}
 
+	public string function getTenantIdFromRecord( required string objectName, required string id, required string fk ){
+		
+		var recordData = $getPresideObjectService().selectData(
+				objectName = arguments.objectName
+			  , id = arguments.id
+		);
+
+		return recordData.recordCount ? recordData[ arguments.fk ] : '';
+	}
+
 	public string function getTenancyCacheKey( required string objectName, array bypassTenants=[], struct tenantIds={} ) {
 		var tenant = getObjectTenant( arguments.objectName );
 
@@ -158,10 +168,17 @@ component displayName="Tenancy service" {
 	public struct function getTenancyFieldsForInsertOrUpdateData( required string objectName, array bypassTenants=[] ) {
 		var tenant = getObjectTenant( arguments.objectName );
 		var fields = {};
+		var formData = arguments.formData ?: {};
 
 		if ( tenant.len() && !arguments.bypassTenants.findNoCase( tenant ) ) {
 			var fk       = getTenantFkForObject( arguments.objectName );
-			var tenantId = getTenantId( tenant );
+			var tenantId = "";
+
+			if ( len( formData.id ?: "" ) ) {
+				tenantId = getTenantIdFromRecord( arguments.objectName, formData.id, fk ) ;
+			} else {
+				tenantId = getTenantId( tenant );
+			}
 
 			fields[ fk ] = tenantId;
 		}

--- a/tests/integration/api/tenancy/TenancyServiceTest.cfc
+++ b/tests/integration/api/tenancy/TenancyServiceTest.cfc
@@ -309,14 +309,14 @@ component extends="testbox.system.BaseSpec"{
 			} );
 		} );
 
-		describe( "getTenancyFieldsForInsertData()", function() {
+		describe( "getTenancyFieldsForInsertOrUpdateData()", function() {
 			it( "should do nothing when the object is not using tenancy", function(){
 				var service    = _getService();
 				var objectName = "test";
 
 				service.$( "getObjectTenant" ).$args( objectName ).$results( "" );
 
-				expect( service.getTenancyFieldsForInsertData( objectName ) ).toBe( {} );
+				expect( service.getTenancyFieldsForInsertOrUpdateData( objectName ) ).toBe( {} );
 			} );
 
 			it( "should add the currently set tenant ID for the tenant that the object uses", function(){
@@ -331,7 +331,7 @@ component extends="testbox.system.BaseSpec"{
 				service.$( "getTenantFkForObject" ).$args( objectName ).$results( fk );
 				service.$( "getTenantId" ).$args( tenant ).$results( tenantId );
 
-				expect( service.getTenancyFieldsForInsertData( objectName ) ).toBe( expected );
+				expect( service.getTenancyFieldsForInsertOrUpdateData( objectName ) ).toBe( expected );
 			} );
 		} );
 


### PR DESCRIPTION
Fixes PRESIDECMS-2200. Unique indexes are not properly validated when used in objects with a tenant.

The reason he validation unique indexes previously failed was, that the tenant FK is not present in the form data and if one of the fields of a combined key is NULL, the validation is considered successful.

I added a new interception point 'preValidateForm' that calls the tenancy service, retrieves the tenant FK value and injects it into the form data before validation.