### PR TITLE
PRESIDECMS-2232 make sure the needed argument value is passed along

### DIFF
--- a/system/handlers/admin/emailCenter/SystemTemplates.cfc
+++ b/system/handlers/admin/emailCenter/SystemTemplates.cfc
@@ -241,7 +241,7 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	public void function stats( event, rc, prc ) {
-		var templateId = rc.template ?: "";
+		var templateId = rc.id ?: rc.template ?: "";
 
 		prc.template = emailTemplateService.getTemplate( id=templateId );
 

--- a/system/views/admin/emailcenter/_templateStatsFilter.cfm
+++ b/system/views/admin/emailcenter/_templateStatsFilter.cfm
@@ -1,5 +1,5 @@
 <cfscript>
-	templateId = rc.id ?: "";
+	templateId = rc.id ?: args.templateId ?: "";
 
 	dateFrom = "<strong>#DateTimeFormat( args.dateFrom, "yyyy-mm-dd HH:nn" )#</strong>";
 	dateTo   = "<strong>#DateTimeFormat( args.dateTo  , "yyyy-mm-dd HH:nn" )#</strong>";

--- a/system/views/admin/emailcenter/systemTemplates/stats.cfm
+++ b/system/views/admin/emailcenter/systemTemplates/stats.cfm
@@ -1,5 +1,5 @@
 <cfscript>
-	templateId = rc.template ?: "";
+	templateId = rc.template ?: rc.id ?: "";
 	showClicks = IsTrue( prc.showClicks ?: "" );
 </cfscript>
 <cfoutput>


### PR DESCRIPTION
This is to pass the id of the system email template along to prevent 404 error when admin trying to filter the stats