### PR TITLE
PRESIDECMS-2255 Extending forms can sometimes throw 500 error

### DIFF
--- a/system/services/forms/FormsService.cfc
+++ b/system/services/forms/FormsService.cfc
@@ -889,7 +889,7 @@ component displayName="Forms service" {
 			resolvedExtensions[ arguments.formName ] = true;
 
 			return _mergeForms(
-				  form1 = resolveExtensions( parentFormName, arguments.allForms[ parentFormName ], arguments.allForms )
+				  form1 = duplicate( resolveExtensions( parentFormName, arguments.allForms[ parentFormName ], arguments.allForms ) )
 				, form2 = arguments.frmDefinition
 			);
 		};


### PR DESCRIPTION
Do not modify the original extended form definition when resolving extensions