### PR TITLE
PRESIDECMS-2282: Multilingual auto-joins with partly drafts enabled result in error

### DIFF
--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -1655,12 +1655,29 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	private array function getTopRightButtonsForViewRecord() {
-		var objectName  = args.objectName ?: "";
+		var objectName   = args.objectName ?: "";
 		var objectTitle  = prc.objectTitle ?: "";
 		var recordId     = prc.recordId    ?: "";
 		var recordLabel  = prc.recordLabel ?: "";
 		var actions      = [];
 		var language     = rc.language ?: "";
+
+		if ( IsTrue( prc.canTranslate ?: "" ) ) {
+			var translationActions = customizationService.runCustomization(
+				  objectName = objectName
+				, action     = "getTranslationsActionButton"
+				, defaultHandler = "admin.datamanager.getTranslationsActionButton"
+				, args       = {
+					  objectName = objectName
+					, recordId   = recordId
+					, operation  = "viewRecord"
+				}
+			);
+
+			if ( StructCount( translationActions ?: {} ) ) {
+				actions.append( translationActions );
+			}
+		}
 
 		if ( IsTrue( prc.canEdit ?: "" ) ) {
 			var link = "";
@@ -1720,23 +1737,6 @@ component extends="preside.system.base.AdminHandler" {
 				, prompt    = translateResource( uri="cms:datamanager.deleteRecord.prompt", data=[ objectTitle, stripTags( recordLabel ) ] )
 				, match     = useTypedConfirmation ? datamanagerService.getDeletionConfirmationMatch( objectName, record ) : ""
 			} );
-		}
-
-		if ( IsTrue( prc.canTranslate ?: "" ) ) {
-			var translationActions = customizationService.runCustomization(
-				  objectName = objectName
-				, action     = "getTranslationsActionButton"
-				, defaultHandler = "admin.datamanager.getTranslationsActionButton"
-				, args       = {
-					  objectName = objectName
-					, recordId   = recordId
-					, operation  = "viewRecord"
-				}
-			);
-
-			if ( StructCount( translationActions ?: {} ) ) {
-				actions.append( translationActions );
-			}
 		}
 
 		customizationService.runCustomization(

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -2442,6 +2442,18 @@ component displayName="Preside Object Service" {
 		return stats;
 	}
 
+	/**
+	 * Returns the object name for a given database table name (reverse lookup)
+	 *
+	 * @autodoc   true
+	 * @tableName Name of the database table for which to return the object name
+	 */
+	public string function getObjectByTable( required string tableName ) {
+		var lookupCache = _getTableNameObjectLookupCache();
+
+		return lookupCache[ arguments.tableName ] ?: "";
+	}
+
 // PRIVATE HELPERS
 	private void function _loadObjects() {
 		var objectPaths = _getAllObjectPaths();
@@ -2464,6 +2476,7 @@ component displayName="Preside Object Service" {
 		_setObjects( objects );
 		_setDsns( StructKeyArray( dsns ) );
 		_setupAliasCache();
+		_setupTableNameObjectLookupCache();
 
 		_announceInterception( state="postLoadPresideObjects", interceptData={ objects=objects } );
 	}
@@ -2502,6 +2515,17 @@ component displayName="Preside Object Service" {
 		}
 
 		_setAliasCache( aliasCache );
+	}
+	
+	private void function _setupTableNameObjectLookupCache() {
+		var objects     = _getObjects();
+		var lookupCache = {};
+
+		for( var objName in objects ) {
+			lookupCache[ objects[ objName ].meta.tableName ] = objName;
+		}
+
+		_setTableNameObjectLookupCache( lookupCache );
 	}
 
 	private string function _getCacheKey( required string objectName, any filter="", struct filterParams={} ) {

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -4016,6 +4016,13 @@ component displayName="Preside Object Service" {
 		_aliasCache = arguments.aliasCache;
 	}
 
+	private struct function _getTableNameObjectLookupCache() {
+		return _tableNameObjectLookupCache;
+	}
+	private void function _setTableNameObjectLookupCache( required struct tableNameObjectLookupCache ) {
+		_tableNameObjectLookupCache = arguments.tableNameObjectLookupCache;
+	}
+
 	private struct function _getCacheMap() {
 		return _cacheMap;
 	}


### PR DESCRIPTION
If multilingual objects are auto-joined and the root object has drafts enabled but the object to be joined not, an error occurs because a db column is used which does not exist: _version_is_latest_draft

This is caused by the fact that Preside only checks the root main object if drafts are enabled or not. Target tables of joins are not checked.
So if there is on object which allows versioning, translations and drafts - and this joins to another object which has has versioning and translations enabled but not drafts (which is a pretty common scenario), then this results in an error.

The solution is to also check if the target table of a join belongs to an object that has drafts enabled.
Therefore I created a small lookup cache in the PresideObjectService that let's you find the Preside Object Name by a given table name.
Within the interception to add the translation checks for latest versions this is now used to determine whether the target table has drafts enabled or not.

One small additional off topic fix:
In Preside Datamanager the top right buttons in the View-Record screen are misaligned visually if translations are enabled.
If fixed this by changing the order of the buttons, putting the translation dropdown first in line. This is now also aligned to the edit record screen, where this was already the case.