### PR TITLE
EmailStyleInliner fix

### DIFF
--- a/system/services/email/EmailStyleInliner.cfc
+++ b/system/services/email/EmailStyleInliner.cfc
@@ -56,10 +56,10 @@ component {
 
 		// add dummy wrapping html table and row tags to make sure jsoup parsing works as expected
 		if ( isHtmlTableCell ) {
-			arguments.html = "<table><tbody><tr>" & arguments.html & "</tr></tbody></table>";
+			arguments.html = "<table><tbody><tr id='_emailstyleinliner_wrap'>" & arguments.html & "</tr></tbody></table>";
 		}
 		else if ( isHtmlTableRow ) {
-			arguments.html = "<table><tbody>" & arguments.html & "</tbody></table>"; // tbody useful here as jsoup adds it anyway
+			arguments.html = "<table><tbody id='_emailstyleinliner_wrap'>" & arguments.html & "</tbody></table>"; // tbody useful here as jsoup adds it anyway
 		}
 
 		var doc = _jsoup.parse( arguments.html );
@@ -75,21 +75,12 @@ component {
 
 		var result = "";
 		if ( innerHtmlOnly ) {
-			result = doc.select( "body" );
+			var selector = ( isHtmlTableCell || isHtmlTableRow ) ? "##_emailstyleinliner_wrap" : "body";
+			result = doc.select( selector );
 			if ( IsArray( local.result ?: "" ) && ArrayLen( result ) ) {
 				result = result[ 1 ].html();
 			} else {
 				result = doc.toString();
-			}
-
-			// get rid of dummy wrapping html tags again (attention, there might be styles added to html tags during processing)
-			if ( isHtmlTableCell ) {
-				result = ReReplaceNoCase( result, "^<table[^>]*>\s*<tbody[^>]*>\s*<tr[^>]*>\s*", "" );
-				result = ReReplaceNoCase( result, "\s*</tr>\s*</tbody>\s*</table>$"            , "" );
-			}
-			else if ( isHtmlTableRow ) {
-				result = ReReplaceNoCase( result, "^<table[^>]*>\s*<tbody[^>]*>\s*", "" );
-				result = ReReplaceNoCase( result, "\s*</tbody>\s*</table>$"        , "" );
 			}
 		} else {
 			result = doc.toString();

--- a/tests/integration/api/email/EmailStyleInlinerTest.cfc
+++ b/tests/integration/api/email/EmailStyleInlinerTest.cfc
@@ -36,6 +36,26 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 
 				expect( inliner.inlineStyles( originalHtml ) ).toBe( expectedHtml );
 			} );
+
+			it( "should work fine with table cell only html snippets", function(){
+				var originalHtml = "<td>table cell content</td>";
+				var expectedHtml = "<td>table cell content</td>";
+
+				expect( inliner.inlineStyles( originalHtml ) ).toBe( expectedHtml );
+			} );
+
+			it( "should work fine with table row only html snippets", function(){
+				var originalHtml = "<tr><td>table row cell content</td></tr>";
+				var expectedHtml = "<tr><td>table row cell content</td></tr>";
+
+				var actualHtml = inliner.inlineStyles( originalHtml );
+
+				// attention: jsoup adds some whitespace between tags
+				actualHtml = reReplace( actualHtml, "<tr>\s*<td>", "<tr><td>" );
+				actualHtml = reReplace( actualHtml, "</td>\s*</tr>", "</td></tr>" );
+
+				expect( actualHtml ).toBe( expectedHtml );
+			} );
 		} );
 
 


### PR DESCRIPTION
See https://presidecms.atlassian.net/browse/PRESIDECMS-2288

There is a problem with HTML snippets consisting of only TD or TR wrapped content, without needed surrounding table tags. Internal JSOUP parsing will strip out HTML markup and email content ends up not being what was expected.

The fix adds dummy table and tr tags and removes them again after JSOUP parsing.