### PR TITLE
PRESIDECMS-2391 multiformbuilder on a page issue

### DIFF
--- a/system/services/formbuilder/FormBuilderService.cfc
+++ b/system/services/formbuilder/FormBuilderService.cfc
@@ -710,7 +710,7 @@ component {
 		var coreLayoutViewlet = "formbuilder.core.formLayout";
 		var formLayoutArgs    = Duplicate( arguments.configuration );
 		var formLayoutViewlet = _getFormBuilderRenderingService().getFormLayoutViewlet( layout=arguments.layout );
-		var idPrefixForFields = _createIdPrefix();
+		var idPrefixForFields = _createIdPrefix( formId=arguments.formId );
 
 		for( var item in items ) {
 			var config    = Duplicate( item.configuration );
@@ -2180,8 +2180,8 @@ component {
 		return newFormId;
 	}
 
-	private string function _createIdPrefix() {
-		return "formbuilder_" & LCase( Hash( Now() ) );
+	private string function _createIdPrefix( required string formId ) {
+		return "formbuilder_" & LCase( Hash( Now() & arguments.formId ) );
 	}
 
 	private struct function _getItemConfigurationForV2Question( required string questionId ) {


### PR DESCRIPTION
Add formId to be part of the idPrefix hash to ensure each forms and inputs will have unique id when multiple form used on same page