### PR TITLE
Feature presidecms 2392 include contenteditable in useristyping condition to prevent triggering shortcut keys whilst typing

### DIFF
--- a/system/assets/js/admin/presidecore/preside.hotkeys.js
+++ b/system/assets/js/admin/presidecore/preside.hotkeys.js
@@ -345,7 +345,7 @@
 			return false;
 		}
 
-		isInFormField = $.inArray( $focused.prop('nodeName'), [ 'INPUT','TEXTAREA' ] ) >= 0 && $.inArray( $focused.prop('type').toLowerCase(), [ 'checkbox','radio','submit','button' ] ) === -1;
+		isInFormField = ( $.inArray( $focused.prop('nodeName'), [ 'INPUT','TEXTAREA' ] ) >= 0 && $.inArray( $focused.prop('type').toLowerCase(), [ 'checkbox','radio','submit','button' ] ) === -1 ) || $focused.prop('contenteditable') == true;
 		if ( isInFormField ) {
 			return true;
 		}


### PR DESCRIPTION
- Include 'contenteditable is true' condition to determine if `userIsTyping`. This will prevent triggering preside schortcut keys while typing, ie. 'e' for quick edit mode.