### PR TITLE
PRESIDECMS-2448 Refactor auto rules generation for related properties

### DIFF
--- a/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
@@ -1,0 +1,114 @@
+/**
+ * Proxy expression executor for use with
+ * auto-generated rules using relationship properties
+ *
+ */
+component {
+
+	property name="presideObjectService" inject="presideObjectService";
+
+	private boolean function evaluateExpression(
+		  required string  parentObjectName
+		, required string  parentPropertyName
+		, required string  parentRelationship
+		, required string  originalFilterHandler
+		, required string  objectName
+		, required string  propertyName
+	) {
+		return presideObjectService.dataExists(
+			  objectName   = arguments.parentObjectName
+			, id           = payload[ arguments.parentObjectName ].id ?: ""
+			, extraFilters = prepareFilters( argumentCollection=arguments )
+		);
+	}
+
+	private array function prepareFilters(
+		  required string  parentObjectName
+		, required string  parentPropertyName
+		, required string  parentRelationship
+		, required string  originalFilterHandler
+		, required string  objectName
+		, required string  propertyName
+	){
+		var relationshipJoinArgs = _getArgsForRelationshipType( argumentCollection=arguments );
+
+		relationshipJoinArgs.extraFilters = relationshipJoinArgs.extraFilter ?: [];
+		ArrayAppend( relationshipJoinArgs.extraFilters, _getRelatedPropertyFilters( argumentCollection=arguments ), true );
+
+		var subQuery  = presideObjectService.selectData(
+			  argumentCollection  = relationshipJoinArgs
+			, objectName          = arguments.objectName
+			, selectFields        = [ "1" ]
+			, getSqlAndParamsOnly = true
+			, formatSqlParams     = true
+		);
+
+		return [ {
+			  filter = obfuscateSqlForPreside( "exists (#subquery.sql#)" )
+			, filterParams = subQuery.params
+		}];
+	}
+
+// HELPERS
+	private array function _getRelatedPropertyFilters() {
+		var args = StructCopy( arguments );
+		for( var ignore in [ "event", "rc", "prc", "parentObjectName", "parentPropertyName", "parentRelationship", "originalFilterHandler", "filterprefix" ] ) {
+			StructDelete( args, ignore );
+		}
+		return runEvent(
+			  event          = arguments.originalFilterHandler
+			, eventArguments = args
+			, private        = true
+			, prepostExempt  = true
+		);
+	}
+
+	private struct function _getArgsForRelationshipType() {
+		switch( arguments.parentRelationship ) {
+			case "many-to-one":
+				return _getOuterJoinForManyToOne( argumentCollection=arguments );
+			case "one-to-many":
+				return _getOuterJoinForOneToMany( argumentCollection=arguments );
+			case "many-to-many":
+				return _getFilterJoinsForManyToMany( argumentCollection=arguments );
+		}
+	}
+
+	private struct function _getOuterJoinForManyToOne() {
+		var idField    = presideObjectService.getIdField( arguments.objectName );
+		var innerField = "#arguments.objectName#.#idField#";
+		var outerField = "#arguments.parentObjectName#.#arguments.parentPropertyName#";
+
+		return { filter = obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
+	}
+
+	private struct function _getOuterJoinForOneToMany() {
+		var relationshipKey = presideObjectService.getObjectPropertyAttribute( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName, attributeName="relationshipKey", defaultValue=arguments.parentObjectName );
+		var idField = presideObjectService.getIdField( arguments.parentObjectName );
+		var innerField = "#arguments.objectName#.#relationshipKey#";
+		var outerField = "#arguments.parentObjectName#.#idField#";
+
+		return { filter = obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
+	}
+
+	private struct function _getFilterJoinsForManyToMany() {
+		var idField    = presideObjectService.getIdField( arguments.parentObjectName );
+		var outerField = "#arguments.parentObjectName#.#idField#";
+
+		var prop       = presideObjectService.getObjectProperty( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName );
+		var relatedVia = prop.relatedVia           ?: "";
+		var outerFk    = "";
+
+		if ( isTrue( prop.relationshipIsSource ?: true ) ) {
+			outerFk = prop.relatedViaSourceFk ?: arguments.parentObjectName;
+		} else {
+			outerFk = prop.relatedViaTargetFk ?: arguments.parentObjectName;
+		}
+		var innerField = "#relatedVia#.#outerFk#"
+
+		return {
+			  filter     = "#innerField# = #obfuscateSqlForPreside( outerField )#"
+			, forceJoins = "inner"
+		};
+	}
+}

--- a/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
@@ -8,12 +8,12 @@ component {
 	property name="presideObjectService" inject="presideObjectService";
 
 	private boolean function evaluateExpression(
-		  required string  parentObjectName
-		, required string  parentPropertyName
-		, required string  parentRelationship
-		, required string  originalFilterHandler
-		, required string  objectName
-		, required string  propertyName
+		  required string parentObjectName
+		, required string parentPropertyName
+		, required array  relationshipHelpers
+		, required string originalFilterHandler
+		, required string objectName
+		, required string propertyName
 	) {
 		return presideObjectService.dataExists(
 			  objectName   = arguments.parentObjectName
@@ -23,28 +23,39 @@ component {
 	}
 
 	private array function prepareFilters(
-		  required string  parentObjectName
-		, required string  parentPropertyName
-		, required string  parentRelationship
-		, required string  originalFilterHandler
-		, required string  objectName
-		, required string  propertyName
+		  required string parentObjectName
+		, required string parentPropertyName
+		, required array  relationshipHelpers
+		, required string originalFilterHandler
+		, required string objectName
+		, required string propertyName
 	){
-		var relationshipJoinArgs = _getArgsForRelationshipType( argumentCollection=arguments );
+		var filter = "";
+		var params = {};
 
-		relationshipJoinArgs.extraFilters = relationshipJoinArgs.extraFilter ?: [];
-		ArrayAppend( relationshipJoinArgs.extraFilters, _getRelatedPropertyFilters( argumentCollection=arguments ), true );
+		for( var i=ArrayLen( arguments.relationshipHelpers ); i>0; i-- ) {
+			var filterArgs = StructCopy( arguments.relationshipHelpers[ i ].filterArgs );
 
-		var subQuery  = presideObjectService.selectData(
-			  argumentCollection  = relationshipJoinArgs
-			, objectName          = arguments.objectName
-			, selectFields        = [ "1" ]
-			, getSqlAndParamsOnly = true
-			, formatSqlParams     = true
-		);
+			if ( !Len( filter ) ) {
+				filterArgs.extraFilters = _getRelatedPropertyFilters( argumentCollection=arguments );
+			} else {
+				filterArgs.extraFilters = [ { filter=filter } ];
+			}
+
+			var subQuery  = presideObjectService.selectData(
+				  argumentCollection  = filterArgs
+				, objectName          = arguments.relationshipHelpers[ i ].objectName
+				, selectFields        = [ "1" ]
+				, getSqlAndParamsOnly = true
+				, formatSqlParams     = true
+			);
+
+			filter = "exists (#obfuscateSqlForPreside( subQuery.sql )#)";
+			StructAppend( params, subQuery.params );
+		}
 
 		return [ {
-			  filter = obfuscateSqlForPreside( "exists (#subquery.sql#)" )
+			  filter       = filter
 			, filterParams = subQuery.params
 		}];
 	}
@@ -52,7 +63,7 @@ component {
 // HELPERS
 	private array function _getRelatedPropertyFilters() {
 		var args = StructCopy( arguments );
-		for( var ignore in [ "event", "rc", "prc", "parentObjectName", "parentPropertyName", "parentRelationship", "originalFilterHandler", "filterprefix" ] ) {
+		for( var ignore in [ "event", "rc", "prc", "parentObjectName", "parentPropertyName", "relationshipHelpers", "originalFilterHandler", "filterprefix" ] ) {
 			StructDelete( args, ignore );
 		}
 		return runEvent(
@@ -63,52 +74,5 @@ component {
 		);
 	}
 
-	private struct function _getArgsForRelationshipType() {
-		switch( arguments.parentRelationship ) {
-			case "many-to-one":
-				return _getOuterJoinForManyToOne( argumentCollection=arguments );
-			case "one-to-many":
-				return _getOuterJoinForOneToMany( argumentCollection=arguments );
-			case "many-to-many":
-				return _getFilterJoinsForManyToMany( argumentCollection=arguments );
-		}
-	}
 
-	private struct function _getOuterJoinForManyToOne() {
-		var idField    = presideObjectService.getIdField( arguments.objectName );
-		var innerField = "#arguments.objectName#.#idField#";
-		var outerField = "#arguments.parentObjectName#.#arguments.parentPropertyName#";
-
-		return { filter = obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
-	}
-
-	private struct function _getOuterJoinForOneToMany() {
-		var relationshipKey = presideObjectService.getObjectPropertyAttribute( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName, attributeName="relationshipKey", defaultValue=arguments.parentObjectName );
-		var idField = presideObjectService.getIdField( arguments.parentObjectName );
-		var innerField = "#arguments.objectName#.#relationshipKey#";
-		var outerField = "#arguments.parentObjectName#.#idField#";
-
-		return { filter = obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
-	}
-
-	private struct function _getFilterJoinsForManyToMany() {
-		var idField    = presideObjectService.getIdField( arguments.parentObjectName );
-		var outerField = "#arguments.parentObjectName#.#idField#";
-
-		var prop       = presideObjectService.getObjectProperty( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName );
-		var relatedVia = prop.relatedVia           ?: "";
-		var outerFk    = "";
-
-		if ( isTrue( prop.relationshipIsSource ?: true ) ) {
-			outerFk = prop.relatedViaSourceFk ?: arguments.parentObjectName;
-		} else {
-			outerFk = prop.relatedViaTargetFk ?: arguments.parentObjectName;
-		}
-		var innerField = "#relatedVia#.#outerFk#"
-
-		return {
-			  filter     = "#innerField# = #obfuscateSqlForPreside( outerField )#"
-			, forceJoins = "inner"
-		};
-	}
 }

--- a/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
+++ b/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
@@ -31,28 +31,12 @@ component {
 		for( var propName in properties ) {
 			expressions.append( generateExpressionsForProperty( arguments.objectName, properties[ propName ] ), true );
 		}
-		for( var propertyName in relatedObjectsForAutoGeneration.listToArray() ) {
-			propertyName = Trim( propertyName );
-
-			var relationshipType = properties[ propertyName ].relationship ?: "";
-
-			if ( ArrayFindNoCase( [ "one-to-many", "many-to-one", "many-to-many" ], relationshipType ) ) {
-				expressions.append( _createExpressionsForRelatedObjectProperties(
-					  objectName       = arguments.objectName
-					, propertyName     = propertyName
-					, relationshipType = relationshipType
-				), true );
-			} else {
-				try {
-					throw(
-						  type    = "preside.auto.rules.bad.property"
-						, message = "[#propertyName#] is listed as an @autoGenerateFilterExpressionsFor property on object [#arguments.objectName#]. However, this is either NOT a property on the object, OR it is not a standard *relationship* property. We are therefore not generating any rules for this property. We are not expecting any applications to be implementing this pattern; please raise this with Pixl8 support/development team if you are expecting this to work, thank you."
-					);
-				} catch( any e ) {
-					// allow the logic to continue, but log the error with the system.
-					$raiseError( e );
-				}
-			}
+		for( var relatedObjectPath in relatedObjectsForAutoGeneration.listToArray() ) {
+			expressions.append( _createExpressionsForRelatedObjectProperties(
+				  objectName       = arguments.objectName
+				, propertyName     = Trim( relatedObjectPath )
+				, relationshipType = ( properties[ Trim( relatedObjectPath ) ].relationship ?: "" )
+			), true );
 		}
 
 		return expressions;
@@ -667,37 +651,41 @@ component {
 		, required string propertyName
 		,          string relationshipType = ""
 	) {
-		var poService   = $getPresideObjectService();
-		var expressions = [];
-		var relatedTo   = poService.getObjectPropertyAttribute(
-			  objectName    = arguments.objectName
-			, propertyName  = arguments.propertyName
-			, attributeName = "relatedTo"
-		);
+		var poService          = $getPresideObjectService();
+		var propertyChain      = arguments.propertyName.listToArray( "." );
+		var currentObjectName  = arguments.objectName;
+		var parentPropertyName = arguments.propertyName.listChangeDelims( "$", "." );
+		var expressions        = [];
 
-		if ( Len( relatedTo ) && poService.objectExists( relatedTo ) ) {
-			var properties = poService.getObjectProperties( relatedTo );
+		for( var propName in propertyChain ) {
+			var prop = poService.getObjectProperty( currentObjectName, propName );
+
+			currentObjectName = prop.relatedto ?: "";
+		}
+
+		if ( currentObjectName.len() ) {
+			var properties = $getPresideObjectService().getObjectProperties( currentObjectName );
 
 			for( var propName in properties ) {
 				expressions.append( generateExpressionsForProperty(
-					  objectName         = relatedTo
+					  objectName         = currentObjectName
 					, propertyDefinition = properties[ propName ]
 					, parentObjectName   = objectName
-					, parentPropertyName = arguments.propertyName
+					, parentPropertyName = parentPropertyName
 				), true );
 			}
+		}
 
-			// wrap expressions using a handler designed for related property filtering
-			for( var expression in expressions ) {
-				expression.expressionHandlerArgs.originalFilterHandler = expression.filterHandler;
-				expression.expressionHandlerArgs.parentRelationship    = arguments.relationshipType;
+		// wrap expressions using a handler designed for related property filtering
+		for( var expression in expressions ) {
+			expression.expressionHandlerArgs.originalFilterHandler = expression.filterHandler;
+			expression.expressionHandlerArgs.parentRelationship    = arguments.relationshipType;
 
-				expression.filterHandlerArgs.originalFilterHandler     = expression.filterHandler;
-				expression.filterHandlerArgs.parentRelationship        = arguments.relationshipType;
+			expression.filterHandlerArgs.originalFilterHandler     = expression.filterHandler;
+			expression.filterHandlerArgs.parentRelationship        = arguments.relationshipType;
 
-				expression.expressionHandler = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.evaluateExpression";
-				expression.filterHandler     = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.prepareFilters";
-			}
+			expression.expressionHandler = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.evaluateExpression";
+			expression.filterHandler     = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.prepareFilters";
 		}
 
 		return expressions;

--- a/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
+++ b/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
@@ -31,12 +31,8 @@ component {
 		for( var propName in properties ) {
 			expressions.append( generateExpressionsForProperty( arguments.objectName, properties[ propName ] ), true );
 		}
-		for( var relatedObjectPath in relatedObjectsForAutoGeneration.listToArray() ) {
-			expressions.append( _createExpressionsForRelatedObjectProperties(
-				  objectName       = arguments.objectName
-				, propertyName     = Trim( relatedObjectPath )
-				, relationshipType = ( properties[ Trim( relatedObjectPath ) ].relationship ?: "" )
-			), true );
+		for( var relatedObjectPath in ListToArray( relatedObjectsForAutoGeneration ) ) {
+			ArrayAppend( expressions, _createExpressionsForRelatedObjectProperties( arguments.objectName, relatedObjectPath ), true );
 		}
 
 		return expressions;
@@ -142,12 +138,12 @@ component {
 				}
 				if ( !arguments.parentObjectName.len() ) {
 					if ( IsBoolean( propertyDefinition.autoGenerateFilterExpressions ?: "" ) && propertyDefinition.autoGenerateFilterExpressions ) {
-						expressions.append( _createExpressionsForRelatedObjectProperties( objectName, propertyDefinition.name, "many-to-one" ), true );
+						expressions.append( _createExpressionsForRelatedObjectProperties( objectName, propertyDefinition.name ), true );
 					} else {
 						var uniqueIndexes = ListToArray( propertyDefinition.uniqueIndexes ?: "" );
 						for( var ux in uniqueIndexes ) {
 							if ( ListLen( ux, "|" ) == 1 ) {
-								expressions.append( _createExpressionsForRelatedObjectProperties( objectName, propertyDefinition.name, "many-to-one" ), true );
+								expressions.append( _createExpressionsForRelatedObjectProperties( objectName, propertyDefinition.name ), true );
 								break;
 							}
 						}
@@ -646,43 +642,58 @@ component {
 		};
 	}
 
+	/**
+	 * In addition to auto expressions being generated per property on an object,
+	 * developers can specify additional relationship properties + property *chains*
+	 * to have a related object's auto generated rules also applied to the source
+	 * object. This logic deals with creating those
+	 */
 	private array function _createExpressionsForRelatedObjectProperties(
 		  required string objectName
-		, required string propertyName
-		,          string relationshipType = ""
+		, required string relatedObjectPath
 	) {
-		var poService          = $getPresideObjectService();
-		var propertyChain      = arguments.propertyName.listToArray( "." );
-		var currentObjectName  = arguments.objectName;
-		var parentPropertyName = arguments.propertyName.listChangeDelims( "$", "." );
-		var expressions        = [];
+		var poService              = $getPresideObjectService();
+		var currentObjectName      = arguments.objectName;
+		var parentPropertyName     = ListChangeDelims( arguments.relatedObjectPath, "$", "." );
+		var supportedRelationships = [ "many-to-one", "many-to-many", "one-to-many" ];
+		var relationshipHelpers    = [];
+		var expressions            = [];
 
-		for( var propName in propertyChain ) {
-			var prop = poService.getObjectProperty( currentObjectName, propName );
+		for( var propName in ListToArray( arguments.relatedObjectPath, "." ) ) {
+			var prop    = poService.getObjectProperty( currentObjectName, propName );
+			var isValid = Len( prop.relatedTo ?: "" ) && ArrayFindNoCase( supportedRelationships, prop.relationship ?: "" );
 
-			currentObjectName = prop.relatedto ?: "";
+			if ( !isValid ) {
+				return [];
+			}
+
+			ArrayAppend( relationshipHelpers,  _prepareRelatedObjectRelationshipHelpers(
+				  objectName         = prop.relatedTo
+				, parentObjectName   = currentObjectName
+				, parentPropertyName = propName
+				, parentProperty     = prop
+			) );
+
+			currentObjectName = prop.relatedto;
 		}
 
-		if ( currentObjectName.len() ) {
-			var properties = $getPresideObjectService().getObjectProperties( currentObjectName );
-
-			for( var propName in properties ) {
-				expressions.append( generateExpressionsForProperty(
-					  objectName         = currentObjectName
-					, propertyDefinition = properties[ propName ]
-					, parentObjectName   = objectName
-					, parentPropertyName = parentPropertyName
-				), true );
-			}
+		var properties = $getPresideObjectService().getObjectProperties( currentObjectName );
+		for( var propName in properties ) {
+			expressions.append( generateExpressionsForProperty(
+				  objectName         = currentObjectName
+				, propertyDefinition = properties[ propName ]
+				, parentObjectName   = arguments.objectName
+				, parentPropertyName = parentPropertyName
+			), true );
 		}
 
 		// wrap expressions using a handler designed for related property filtering
 		for( var expression in expressions ) {
 			expression.expressionHandlerArgs.originalFilterHandler = expression.filterHandler;
-			expression.expressionHandlerArgs.parentRelationship    = arguments.relationshipType;
+			expression.expressionHandlerArgs.relationshipHelpers   = relationshipHelpers;
 
-			expression.filterHandlerArgs.originalFilterHandler     = expression.filterHandler;
-			expression.filterHandlerArgs.parentRelationship        = arguments.relationshipType;
+			expression.filterHandlerArgs.originalFilterHandler = expression.filterHandler;
+			expression.filterHandlerArgs.relationshipHelpers   = relationshipHelpers;
 
 			expression.expressionHandler = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.evaluateExpression";
 			expression.filterHandler     = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.prepareFilters";
@@ -708,6 +719,71 @@ component {
 		}
 
 		return defaultVariety;
+	}
+
+	private struct function _prepareRelatedObjectRelationshipHelpers(
+		  required string objectName
+		, required string parentObjectName
+		, required string parentPropertyName
+		, required struct parentProperty
+	) {
+		var helpers = {
+			  objectName = arguments.objectName
+		};
+		switch( arguments.parentProperty.relationship ) {
+			case "many-to-one":
+				helpers.filterArgs = _getOuterJoinForManyToOne( argumentCollection=arguments );
+			break;
+
+			case "one-to-many":
+				helpers.filterArgs = _getOuterJoinForOneToMany( argumentCollection=arguments );
+			break;
+
+			case "many-to-many":
+				helpers.filterArgs = _getFilterJoinsForManyToMany( argumentCollection=arguments );
+			break;
+		}
+
+		return helpers;
+	}
+
+
+	private struct function _getOuterJoinForManyToOne() {
+		var idField    = $getPresideObjectService().getIdField( arguments.objectName );
+		var innerField = "#arguments.objectName#.#idField#";
+		var outerField = "#arguments.parentObjectName#.#arguments.parentPropertyName#";
+
+		return { filter = $helpers.obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
+	}
+
+	private struct function _getOuterJoinForOneToMany() {
+		var relationshipKey = $getPresideObjectService().getObjectPropertyAttribute( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName, attributeName="relationshipKey", defaultValue=arguments.parentObjectName );
+		var idField = $getPresideObjectService().getIdField( arguments.parentObjectName );
+		var innerField = "#arguments.objectName#.#relationshipKey#";
+		var outerField = "#arguments.parentObjectName#.#idField#";
+
+		return { filter = $helpers.obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
+	}
+
+	private struct function _getFilterJoinsForManyToMany() {
+		var idField    = $getPresideObjectService().getIdField( arguments.parentObjectName );
+		var outerField = "#arguments.parentObjectName#.#idField#";
+
+		var prop       = $getPresideObjectService().getObjectProperty( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName );
+		var relatedVia = prop.relatedVia           ?: "";
+		var outerFk    = "";
+
+		if ( $helpers.isTrue( prop.relationshipIsSource ?: true ) ) {
+			outerFk = prop.relatedViaSourceFk ?: arguments.parentObjectName;
+		} else {
+			outerFk = prop.relatedViaTargetFk ?: arguments.parentObjectName;
+		}
+		var innerField = "#relatedVia#.#outerFk#"
+
+		return {
+			  filter     = "#innerField# = #$helpers.obfuscateSqlForPreside( outerField )#"
+			, forceJoins = "inner"
+		};
 	}
 
 

--- a/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
+++ b/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
@@ -32,7 +32,7 @@ component {
 			expressions.append( generateExpressionsForProperty( arguments.objectName, properties[ propName ] ), true );
 		}
 		for( var relatedObjectPath in ListToArray( relatedObjectsForAutoGeneration ) ) {
-			ArrayAppend( expressions, _createExpressionsForRelatedObjectProperties( arguments.objectName, relatedObjectPath ), true );
+			ArrayAppend( expressions, _createExpressionsForRelatedObjectProperties( arguments.objectName, Trim( relatedObjectPath ) ), true );
 		}
 
 		return expressions;


### PR DESCRIPTION
Refactor how related property auto rules are implemented.
    
Instead of expecting all other rules expressions to understand this possibility - wrap any generated expressions of this kind in a wrapper logic that takes care of making an exists () subquery to isolate all the filter logic.
    
This means that child expressions need know nothing at all of chaining expressions, etc. and should keep queries far simpler.