### PR TITLE
PRESIDECMS-2448 Refactor (and fix) related object auto filter generation

### DIFF
--- a/system/handlers/rules/dynamic/presideObjectExpressions/BooleanFormulaPropertyIsTrue.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/BooleanFormulaPropertyIsTrue.cfc
@@ -10,16 +10,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is = true
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,14 +22,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is = true
 	){
 		var paramName           = "booleanFormulaPropertyIsTrue" & CreateUUId().lCase().replace( "-", "", "all" );
-		var prefix              = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var formulaPropertyName = "#prefix#.#propertyName#";
+		var formulaPropertyName = "#arguments.objectName#.#propertyName#";
 
 		return [ {
 			  having       = "#formulaPropertyName# = :#paramName#"
@@ -44,10 +35,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/BooleanPropertyIsTrue.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/BooleanPropertyIsTrue.cfc
@@ -10,16 +10,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is = true
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,25 +22,21 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is = true
 	){
 		var paramName = "booleanPropertyIsTrue" & CreateUUId().lCase().replace( "-", "", "all" );
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
 
 		return [ {
-			  filter       = "#prefix#.#propertyName# = :#paramName#"
+			  filter       = "#arguments.objectName#.#propertyName# = :#paramName#"
 			, filterParams = { "#paramName#" = { value=arguments._is, type="cf_sql_boolean" } }
 		} ];
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 
@@ -62,7 +53,6 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string propertyName
 		,          string parentObjectName   = ""
 		,          string parentPropertyName = ""
-
 	){
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 		if ( Len( Trim( parentPropertyName ) ) ) {

--- a/system/handlers/rules/dynamic/presideObjectExpressions/DateFormulaPropertyInRange.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/DateFormulaPropertyInRange.cfc
@@ -10,16 +10,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          struct  _time
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,16 +22,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          struct  _time = {}
 	){
 		var params              = {};
 		var sql                 = "";
-		var prefix              = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
 		var delim               = "";
-		var formulaPropertyName = "#prefix#.#propertyName#";
+		var formulaPropertyName = "#arguments.objectName#.#arguments.propertyName#";
 
 		if ( IsDate( _time.from ?: "" ) ) {
 			var fromParam = "dateFormulaPropertyInRange" & CreateUUId().lCase().replace( "-", "", "all" );
@@ -55,14 +46,13 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		}
 
 		return [];
-
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/DatePropertyInRange.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/DatePropertyInRange.cfc
@@ -10,16 +10,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          struct  _time
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,15 +22,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          struct  _time = {}
 	){
 		var params      = {};
 		var sql         = "";
-		var prefix      = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var propertySql = "#prefix#.#propertyName#";
+		var propertySql = "#arguments.objectName#.#propertyName#";
 		var delim       = "";
 
 		if ( IsDate( _time.from ?: "" ) ) {
@@ -59,10 +50,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/EnumPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/EnumPropertyMatches.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is       = true
 		,          string  enumValue = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -28,15 +23,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is          = true
 		,          string  enumValue    = ""
 	){
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
 		var paramName = "textPropertyMatches" & CreateUUId().lCase().replace( "-", "", "all" );
-		var filterSql = "#prefix#.#propertyName# ${operator} (:#paramName#)";
+		var filterSql = "#arguments.objectName#.#propertyName# ${operator} (:#paramName#)";
 		var params    = { "#paramName#" = { value=arguments.enumValue, type="cf_sql_varchar", list=true } };
 
 		if ( _is ) {
@@ -49,10 +40,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 
@@ -67,8 +58,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private string function getText(
 		  required string objectName
 		, required string propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	){
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyCount.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyCount.cfc
@@ -11,18 +11,13 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          string  _numericOperator = "eq"
 		,          string  savedFilter      = ""
 		,          numeric value            = 0
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -30,21 +25,16 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 		,          string  _numericOperator   = "eq"
 		,          string  savedFilter        = ""
 		,          numeric value              = 0
 	){
-		var prefix               = Len( arguments.filterPrefix ) ? arguments.filterPrefix : ( Len( arguments.parentPropertyName ) ? arguments.parentPropertyName : arguments.objectName );
-		var hasParent            = Len( arguments.parentObjectName ) && Len( arguments.parentPropertyName );
 		var params               = {};
 		var subQueryExtraFilters = [];
 		var propAttributes       = presideObjectService.getObjectProperty( arguments.objectName, arguments.propertyName );
 		var keyFk                = propAttributes.relationshipIsSource ? propAttributes.relatedViaSourceFk : propAttributes.relatedViaTargetFk;
 		var valueFk              = propAttributes.relationshipIsSource ? propAttributes.relatedViaTargetFk : propAttributes.relatedViaSourceFk;
-		var outerPk              = hasParent ? "#arguments.parentObjectName#.#arguments.parentPropertyName#" : "#prefix#.#presideObjectService.getIdField( arguments.objectName )#";
+		var outerPk              = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 
 		if ( Len( Trim( arguments.savedFilter ) ) ) {
 			ArrayAppend( subQueryExtraFilters, getExistsFilterForEntityMatchingFilters(
@@ -80,11 +70,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyHas.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyHas.cfc
@@ -11,17 +11,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _possesses         = true
 		,          string  savedFilter        = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -29,20 +24,15 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 		,          boolean _possesses         = true
 		,          string  savedFilter        = ""
 	){
-		var prefix               = Len( arguments.filterPrefix ) ? arguments.filterPrefix : ( Len( arguments.parentPropertyName ) ? arguments.parentPropertyName : arguments.objectName );
-		var hasParent            = Len( arguments.parentObjectName ) && Len( arguments.parentPropertyName );
 		var params               = {};
 		var subQueryExtraFilters = [];
 		var propAttributes       = presideObjectService.getObjectProperty( arguments.objectname, arguments.propertyname );
 		var keyFk                = propAttributes.relationshipIsSource ? propAttributes.relatedViaSourceFk : propAttributes.relatedViaTargetFk;
 		var valueFk              = propAttributes.relationshipIsSource ? propAttributes.relatedViaTargetFk : propAttributes.relatedViaSourceFk;
-		var outerPk              = hasParent ? "#arguments.parentObjectName#.#arguments.parentPropertyName#" : "#prefix#.#presideObjectService.getIdField( arguments.objectName )#";
+		var outerPk              = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 		var exists               = arguments._possesses ? "exists" : "not exists";
 
 		if ( Len( Trim( arguments.savedFilter ) ) ) {
@@ -75,11 +65,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyMatch.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyMatch.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _possesses = true
 		,          string  value      = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -33,18 +28,13 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string  relatedViaSourceFk
 		, required string  relatedViaTargetFk
 		, required string  relationshipIsSource
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _possesses = true
 		,          string  value      = ""
 	){
-		var prefix    = Len( arguments.filterPrefix ) ? arguments.filterPrefix : ( Len( arguments.parentPropertyName ) ? arguments.parentPropertyName : arguments.objectName );
-		var hasParent = Len( arguments.parentObjectName ) && Len( arguments.parentPropertyName );
 		var paramName = "manyToManyMatch" & CreateUUId().lCase().replace( "-", "", "all" );
 		var valueFk   = arguments.relationshipIsSource ? arguments.relatedViaTargetFk : arguments.relatedViaSourceFk;
 		var keyFk     = arguments.relationshipIsSource ? arguments.relatedViaSourceFk : arguments.relatedViaTargetFk;
-		var outerPk   = hasParent ? "#arguments.parentObjectName#.#arguments.parentPropertyName#" : "#prefix#.#presideObjectService.getIdField( arguments.objectName )#";
+		var outerPk   = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 		var exists    = arguments._possesses ? "exists" : "not exists";
 		var subquery  = presideObjectService.selectData(
 			  objectName          = arguments.relatedVia
@@ -62,11 +52,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var objectBaseUri        = presideObjectService.getResourceBundleUriRoot( objectName );
 		var objectNameTranslated = translateResource( objectBaseUri & "title.singular", objectName );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyMatch.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToManyMatch.cfc
@@ -32,8 +32,9 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  value      = ""
 	){
 		var paramName = "manyToManyMatch" & CreateUUId().lCase().replace( "-", "", "all" );
-		var valueFk   = arguments.relationshipIsSource ? arguments.relatedViaTargetFk : arguments.relatedViaSourceFk;
-		var keyFk     = arguments.relationshipIsSource ? arguments.relatedViaSourceFk : arguments.relatedViaTargetFk;
+		var isSource  = !IsBoolean( arguments.relationshipIsSource ) || arguments.relationshipIsSource;
+		var valueFk   = isSource ? arguments.relatedViaTargetFk : arguments.relatedViaSourceFk;
+		var keyFk     = isSource ? arguments.relatedViaSourceFk : arguments.relatedViaTargetFk;
 		var outerPk   = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 		var exists    = arguments._possesses ? "exists" : "not exists";
 		var subquery  = presideObjectService.selectData(

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToOneMatch.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToOneMatch.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is   = true
 		,          string  value = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -28,27 +23,23 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is   = true
 		,          string  value = ""
 	){
 		var paramName = "manyToOneMatch" & CreateUUId().lCase().replace( "-", "", "all" );
 		var operator  = _is ? "in" : "not in";
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var filterSql = "#prefix#.#propertyName# #operator# (:#paramName#)";
+		var filterSql = "#arguments.objectName#.#propertyName# #operator# (:#paramName#)";
 		var params    = { "#paramName#" = { value=arguments.value, type="cf_sql_varchar", list=true } };
 
 		return [ { filter=filterSql, filterParams=params } ];
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( relatedTo );
 		var relatedToTranslated = translateResource( relatedToBaseUri & "title", relatedTo );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToOneMatchLoggedInAdminUser.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToOneMatchLoggedInAdminUser.cfc
@@ -10,16 +10,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is   = true
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,15 +22,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is   = true
 	){
 		var paramName = "manyToOneMatchLoggedInAdminUser" & CreateUUId().lCase().replace( "-", "", "all" );
 		var operator  = _is ? "=" : "!=";
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var filterSql = "#prefix#.#propertyName# #operator# :#paramName#";
+		var filterSql = "#arguments.objectName#.#propertyName# #operator# :#paramName#";
 		var loggedInUserId = event.getAdminUserId();
 
 		if ( !loggedInUserId.len() ) {
@@ -47,10 +38,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( "security_user" );
 		var relatedToTranslated = translateResource( relatedToBaseUri & "title", "security_user" );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/ManyToOneMatchLoggedInWebUser.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/ManyToOneMatchLoggedInWebUser.cfc
@@ -10,16 +10,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is   = true
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,15 +22,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is   = true
 	){
 		var paramName = "manyToOneMatchLoggedInWebUser" & CreateUUId().lCase().replace( "-", "", "all" );
 		var operator  = _is ? "=" : "!=";
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var filterSql = "#prefix#.#propertyName# #operator# :#paramName#";
+		var filterSql = "#arguments.objectName#.#propertyName# #operator# :#paramName#";
 		var loggedInUserId = getLoggedInUserId();
 
 		if ( !loggedInUserId.len() ) {
@@ -47,10 +38,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var relatedToBaseUri    = presideObjectService.getResourceBundleUriRoot( "website_user" );
 		var relatedToTranslated = translateResource( relatedToBaseUri & "title", "website_user" );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/NumericFormulaPropertyCompares.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/NumericFormulaPropertyCompares.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          string  _numericOperator = "eq"
 		,          numeric value            = 0
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -28,15 +23,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          string  _numericOperator = "eq"
 		,          numeric value            = 0
 	){
 		var paramName           = "numericFormulaPropertyCompares" & CreateUUId().lCase().replace( "-", "", "all" );
-		var prefix              = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var formulaPropertyName = "#prefix#.#propertyName#";
+		var formulaPropertyName = "#arguments.objectName#.#propertyName#";
 		var filterSql           = "#formulaPropertyName# ${operator} :#paramName#";
 		var params              = { "#paramName#" = { value=arguments.value, type="cf_sql_number" } };
 
@@ -65,10 +56,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 
@@ -83,8 +74,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private string function getText(
 		  required string objectName
 		, required string propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	){
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/NumericPropertyCompares.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/NumericPropertyCompares.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          string  _numericOperator = "eq"
 		,          numeric value            = 0
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -28,15 +23,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          string  _numericOperator = "eq"
 		,          numeric value            = 0
 	){
 		var paramName = "numericPropertyCompares" & CreateUUId().lCase().replace( "-", "", "all" );
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
-		var filterSql = "#prefix#.#propertyName# ${operator} :#paramName#";
+		var filterSql = "#arguments.objectName#.#propertyName# ${operator} :#paramName#";
 		var params    = { "#paramName#" = { value=arguments.value, type="cf_sql_number" } };
 
 		switch ( _numericOperator ) {
@@ -64,10 +55,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 
@@ -82,8 +73,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private string function getText(
 		  required string objectName
 		, required string propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	){
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyCount.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyCount.cfc
@@ -11,18 +11,13 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          string  _numericOperator = "eq"
 		,          string  savedFilter      = ""
 		,          numeric value            = 0
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -32,15 +27,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string  propertyName
 		, required string  relatedTo
 		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 		,          string  savedFilter        = ""
 		,          string  _numericOperator   = "eq"
 		,          numeric value              = 0
 	){
-		var prefix               = Len( arguments.filterPrefix ) ? arguments.filterPrefix : ( Len( arguments.parentPropertyName ) ? arguments.parentPropertyName : arguments.objectName );
-		var hasParent            = Len( arguments.parentObjectName ) && Len( arguments.parentPropertyName );
 		var params               = {};
 		var subQueryExtraFilters = [];
 
@@ -51,7 +41,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 			StructAppend( params, extraFilter.filterParams ?: {} );
 		}
 
-		var outerPk       = hasParent ? "#arguments.parentObjectName#.#arguments.parentPropertyName#" : "#prefix#.#presideObjectService.getIdField( arguments.objectName )#";
+		var outerPk       = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 		var countOperator = rulesEngineNumericOperatorToSqlOperator( arguments._numericOperator );
 		var countParam    = "oneToManyCount" & CreateUUId().lCase().replace( "-", "", "all" );
 		var countField    = "#arguments.relatedTo#.#relationshipKey#";
@@ -75,12 +65,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		, required string relationshipKey
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
 		var relatedToTranslated = translateObjectProperty( objectName, propertyName );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyHas.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyHas.cfc
@@ -11,17 +11,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is                = true
 		,          string  savedFilter        = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -31,14 +26,9 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string  propertyName
 		, required string  relatedTo
 		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 		,          boolean _is                = true
 		,          string  savedFilter        = ""
 	){
-		var prefix               = Len( arguments.filterPrefix ) ? arguments.filterPrefix : ( Len( arguments.parentPropertyName ) ? arguments.parentPropertyName : arguments.objectName );
-		var hasParent            = Len( arguments.parentObjectName ) && Len( arguments.parentPropertyName );
 		var params               = {};
 		var subQueryExtraFilters = [];
 
@@ -49,7 +39,7 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 			StructAppend( params, extraFilter.filterParams ?: {} );
 		}
 
-		var outerPk   = hasParent ? "#arguments.parentObjectName#.#arguments.parentPropertyName#" : "#prefix#.#presideObjectService.getIdField( arguments.objectName )#";
+		var outerPk   = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 		var exists    = arguments._is ? "exists" : "not exists";
 		var subquery  = presideObjectService.selectData(
 			  objectName          = arguments.relatedTo
@@ -69,12 +59,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		, required string relationshipKey
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
 		var relatedToTranslated = translateObjectProperty( objectName, propertyName );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyMatch.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/OneToManyMatch.cfc
@@ -12,17 +12,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string  propertyName
 		, required string  relatedTo
 		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is   = true
 		,          string  value = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -32,17 +27,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string  propertyName
 		, required string  relatedTo
 		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 		,          boolean _is                = true
 		,          string  value              = ""
 	){
-		var prefix    = Len( arguments.filterPrefix ) ? arguments.filterPrefix : ( Len( arguments.parentPropertyName ) ? arguments.parentPropertyName : arguments.objectName );
-		var hasParent = Len( arguments.parentObjectName ) && Len( arguments.parentPropertyName );
 		var paramName = "oneToManyMatch" & CreateUUId().lCase().replace( "-", "", "all" );
 		var valuePk   = presideObjectService.getIdField( arguments.relatedto );
-		var outerPk   = hasParent ? "#arguments.parentObjectName#.#arguments.parentPropertyName#" : "#prefix#.#presideObjectService.getIdField( arguments.objectName )#";
+		var outerPk   = "#arguments.objectName#.#presideObjectService.getIdField( arguments.objectName )#";
 		var exists    = arguments._is ? "exists" : "not exists";
 		var subquery  = presideObjectService.selectData(
 			  objectName          = arguments.relatedTo
@@ -60,12 +50,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		, required string  relatedTo
-		, required string  relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		, required string relatedTo
+		, required string relationshipKey
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var objectBaseUri       = presideObjectService.getResourceBundleUriRoot( objectName );
 		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
@@ -87,8 +77,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string propertyName
 		, required string relatedTo
 		, required string relationshipKey
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	){
 		var relatedToTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/PropertyIsNull.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/PropertyIsNull.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          boolean _is     = true
 		,          string  variety = "isEmpty"
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -28,24 +23,20 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          boolean _is     = true
 		,          string  variety = "isEmpty"
 	){
-		var prefix = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
 		var isIsNot  = ( _is == ( variety == "isEmpty" ) ) ? "is" : "is not";
 
-		return [ { filter="#prefix#.#propertyName# #isIsNot# null" } ];
+		return [ { filter="#arguments.objectName#.#arguments.propertyName# #isIsNot# null" } ];
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  variety = "isEmpty"
+		  required string objectName
+		, required string propertyName
+		,          string variety = "isEmpty"
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 
@@ -60,9 +51,9 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private string function getText(
 		  required string objectName
 		, required string propertyName
+		,          string variety = "isEmpty"
 		,          string parentObjectName   = ""
 		,          string parentPropertyName = ""
-		,          string variety = "isEmpty"
 	){
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/RecordMatchesFilters.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/RecordMatchesFilters.cfc
@@ -13,18 +13,15 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  value = ""
 		,          boolean _does = true
 	) {
-		var recordId     = payload[ arguments.objectName ].id ?: "";
-
 		return presideObjectService.dataExists(
 			  objectName   = arguments.objectName
-			, id           = recordId
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
 
 	private array function prepareFilters(
 		  required string  objectName
-		,          string  filterPrefix = ""
 		,          string  value = ""
 		,          boolean _does = true
 	){
@@ -67,8 +64,6 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 
 	private string function getLabel(
 		  required string  objectName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 	) {
 		var objectLabelSingular = translateObjectName( arguments.objectName );
 
@@ -77,8 +72,6 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 
 	private string function getText(
 		  required string objectName
-		,          string parentObjectName   = ""
-		,          string parentPropertyName = ""
 
 	){
 		var objectLabelSingular = translateObjectName( arguments.objectName );

--- a/system/handlers/rules/dynamic/presideObjectExpressions/TextFormulaPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/TextFormulaPropertyMatches.cfc
@@ -9,17 +9,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -27,15 +22,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	){
-		var prefix              = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
 		var paramName           = "textFormulaPropertyMatches" & CreateUUId().lCase().replace( "-", "", "all" );
-		var formulaPropertyName = "#prefix#.#propertyName#";
+		var formulaPropertyName = "#arguments.objectName#.#propertyName#";
 		var filterSql           = "#formulaPropertyName# ${operator} :#paramName#";
 		var params              = { "#paramName#" = { value=arguments.value, type="cf_sql_varchar" } };
 
@@ -76,10 +67,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/TextPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/TextPropertyMatches.cfc
@@ -10,17 +10,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private boolean function evaluateExpression(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	) {
-		var sourceObject = parentObjectName.len() ? parentObjectName : objectName;
-		var recordId     = payload[ sourceObject ].id ?: "";
-
 		return presideObjectService.dataExists(
-			  objectName   = sourceObject
-			, id           = recordId
+			  objectName   = arguments.objectName
+			, id           = payload[ arguments.objectName ].id ?: ""
 			, extraFilters = prepareFilters( argumentCollection=arguments )
 		);
 	}
@@ -28,15 +23,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	private array function prepareFilters(
 		  required string  objectName
 		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix = ""
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	){
-		var prefix    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : objectName );
 		var paramName = "textPropertyMatches" & CreateUUId().lCase().replace( "-", "", "all" );
-		var filterSql = "#prefix#.#propertyName# ${operator} :#paramName#";
+		var filterSql = "#arguments.objectName#.#propertyName# ${operator} :#paramName#";
 		var params    = { "#paramName#" = { value=arguments.value, type="cf_sql_varchar" } };
 
 		switch ( _stringOperator ) {
@@ -76,10 +67,10 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 	}
 
 	private string function getLabel(
-		  required string  objectName
-		, required string  propertyName
-		,          string  parentObjectName   = ""
-		,          string  parentPropertyName = ""
+		  required string objectName
+		, required string propertyName
+		,          string parentObjectName   = ""
+		,          string parentPropertyName = ""
 	) {
 		var propNameTranslated = translateObjectProperty( objectName, propertyName );
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
@@ -56,7 +56,7 @@ component {
 
 		return [ {
 			  filter       = filter
-			, filterParams = subQuery.params
+			, filterParams = params
 		}];
 	}
 

--- a/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/_relatedObjectExpressions.cfc
@@ -1,0 +1,78 @@
+/**
+ * Proxy expression executor for use with
+ * auto-generated rules using relationship properties
+ *
+ */
+component {
+
+	property name="presideObjectService" inject="presideObjectService";
+
+	private boolean function evaluateExpression(
+		  required string parentObjectName
+		, required string parentPropertyName
+		, required array  relationshipHelpers
+		, required string originalFilterHandler
+		, required string objectName
+		, required string propertyName
+	) {
+		return presideObjectService.dataExists(
+			  objectName   = arguments.parentObjectName
+			, id           = payload[ arguments.parentObjectName ].id ?: ""
+			, extraFilters = prepareFilters( argumentCollection=arguments )
+		);
+	}
+
+	private array function prepareFilters(
+		  required string parentObjectName
+		, required string parentPropertyName
+		, required array  relationshipHelpers
+		, required string originalFilterHandler
+		, required string objectName
+		, required string propertyName
+	){
+		var filter = "";
+		var params = {};
+
+		for( var i=ArrayLen( arguments.relationshipHelpers ); i>0; i-- ) {
+			var filterArgs = StructCopy( arguments.relationshipHelpers[ i ].filterArgs );
+
+			if ( !Len( filter ) ) {
+				filterArgs.extraFilters = _getRelatedPropertyFilters( argumentCollection=arguments );
+			} else {
+				filterArgs.extraFilters = [ { filter=filter } ];
+			}
+
+			var subQuery  = presideObjectService.selectData(
+				  argumentCollection  = filterArgs
+				, objectName          = arguments.relationshipHelpers[ i ].objectName
+				, selectFields        = [ "1" ]
+				, getSqlAndParamsOnly = true
+				, formatSqlParams     = true
+			);
+
+			filter = "exists (#obfuscateSqlForPreside( subQuery.sql )#)";
+			StructAppend( params, subQuery.params );
+		}
+
+		return [ {
+			  filter       = filter
+			, filterParams = subQuery.params
+		}];
+	}
+
+// HELPERS
+	private array function _getRelatedPropertyFilters() {
+		var args = StructCopy( arguments );
+		for( var ignore in [ "event", "rc", "prc", "parentObjectName", "parentPropertyName", "relationshipHelpers", "originalFilterHandler", "filterprefix" ] ) {
+			StructDelete( args, ignore );
+		}
+		return runEvent(
+			  event          = arguments.originalFilterHandler
+			, eventArguments = args
+			, private        = true
+			, prepostExempt  = true
+		);
+	}
+
+
+}

--- a/system/handlers/rules/expressions/LastUserEmailBounced.cfc
+++ b/system/handlers/rules/expressions/LastUserEmailBounced.cfc
@@ -26,10 +26,7 @@ component {
 	 * @objects website_user
 	 *
 	 */
-	private array function prepareFilters(
-		  string parentPropertyName = ""
-		, string filterPrefix       = ""
-	){
+	private array function prepareFilters(){
 		var paramSuffix = CreateUUId().lCase().replace( "-", "", "all" );
 		var params      = {
 			"bounced#paramSuffix#" = { type="cf_sql_boolean", value=true }
@@ -49,7 +46,7 @@ component {
 			, subQuery       = subQuery.sql
 			, subQueryAlias  = subQueryAlias
 			, subQueryColumn = "id"
-			, joinToTable    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : "website_user" )
+			, joinToTable    = "website_user"
 			, joinToColumn   = "id"
 		} ] } ];
 	}

--- a/system/handlers/rules/expressions/PageIsDescendant.cfc
+++ b/system/handlers/rules/expressions/PageIsDescendant.cfc
@@ -35,13 +35,12 @@ component {
 	private array function prepareFilters(
 		  required string  pages
 		,          boolean _is = true
-		,          string  filterPrefix = ""
 	) {
 		var sql       = "";
 		var ancestors = presideObjectService.selectData( objectName="page", filter={ id=pages.listToArray() }, selectFields=["_hierarchy_id"] );
 		var delim     = "";
 		var params    = {};
-		var prefix    = filterPrefix.len() ? filterPrefix : "page";
+		var prefix    = "page";
 
 		for( var ancestor in ancestors ) {
 			var paramName = "pageIsDescendant#ancestor._hierarchy_id#";

--- a/system/handlers/rules/expressions/PageIsType.cfc
+++ b/system/handlers/rules/expressions/PageIsType.cfc
@@ -25,15 +25,12 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  pagetypes
-		,          boolean _is                = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _is = true
 	) {
 		var paramsuffix = CreateUUId().lCase().replace( "-", "", "all" );
-		var prefix      = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : "page" );
 
 		return [ {
-			  filter       = "#prefix#.page_type #( arguments._is ? 'in' : 'not in' )# (:pagetypes#paramsuffix#)"
+			  filter       = "page.page_type #( arguments._is ? 'in' : 'not in' )# (:pagetypes#paramsuffix#)"
 			, filterParams = { "pagetypes#paramsuffix#"={ type="cf_sql_varchar", list=true, value=arguments.pageTypes } }
 		} ];
 	}

--- a/system/handlers/rules/expressions/UserDownloadedAssetANumberOfTimes.cfc
+++ b/system/handlers/rules/expressions/UserDownloadedAssetANumberOfTimes.cfc
@@ -44,22 +44,18 @@ component {
 		  required string  asset
 		, required numeric times
 		,          string  _numericOperator = "eq"
-		,          boolean _has               = true
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          boolean _has             = true
+		,          struct  _pastTime        = {}
 	) {
 		return websiteUserActionService.getUserPerformedActionFilter(
-			  action             = "download"
-			, type               = "asset"
-			, has                = arguments._has
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, identifiers        = [ arguments.asset ]
-			, qty                = arguments.times
-			, qtyOperator        = arguments._numericOperator
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action      = "download"
+			, type        = "asset"
+			, has         = arguments._has
+			, datefrom    = arguments._pastTime.from ?: ""
+			, dateto      = arguments._pastTime.to   ?: ""
+			, identifiers = [ arguments.asset ]
+			, qty         = arguments.times
+			, qtyOperator = arguments._numericOperator
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserDownloadedAssets.cfc
+++ b/system/handlers/rules/expressions/UserDownloadedAssets.cfc
@@ -57,22 +57,18 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  assets
-		,          boolean _has               = true
-		,          boolean _all               = false
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          boolean _has      = true
+		,          boolean _all      = false
+		,          struct  _pastTime = {}
 	) {
 		return websiteUserActionService.getUserPerformedActionFilter(
-			  action             = "download"
-			, type               = "asset"
-			, has                = arguments._has
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, identifiers        = arguments.assets.listToArray()
-			, allIdentifiers     = arguments._all
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action         = "download"
+			, type           = "asset"
+			, has            = arguments._has
+			, datefrom       = arguments._pastTime.from ?: ""
+			, dateto         = arguments._pastTime.to   ?: ""
+			, identifiers    = arguments.assets.listToArray()
+			, allIdentifiers = arguments._all
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserEmailInteraction.cfc
+++ b/system/handlers/rules/expressions/UserEmailInteraction.cfc
@@ -46,8 +46,6 @@ component {
 		, string  action             = "opened"
 		, boolean _has               = true
 		, struct  _pastTime          = {}
-		, string  parentPropertyName = ""
-		, string  filterPrefix       = ""
 	){
 		var subqueryfilters = "";
 		var params          = {};
@@ -126,7 +124,7 @@ component {
 			, subQuery       = subQuery.sql
 			, subQueryAlias  = subQueryAlias
 			, subQueryColumn = "id"
-			, joinToTable    = filterPrefix.len() ? filterPrefix : ( parentPropertyName.len() ? parentPropertyName : "website_user" )
+			, joinToTable    = "website_user"
 			, joinToColumn   = "id"
 		} ] } ];
 	}

--- a/system/handlers/rules/expressions/UserLastDownloadedAsset.cfc
+++ b/system/handlers/rules/expressions/UserLastDownloadedAsset.cfc
@@ -43,19 +43,15 @@ component {
 	 *
 	 */
 	private array function prepareFilters(
-		  required string  asset
-		,          struct  _pastTime
-		,          string  filterPrefix
-		,          string  parentPropertyName
+		  required string asset
+		,          struct _pastTime
 	) {
 		return websiteUserActionService.getUserLastPerformedActionFilter(
-			  action             = "download"
-			, type               = "asset"
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, identifier         = arguments.asset
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action     = "download"
+			, type       = "asset"
+			, datefrom   = arguments._pastTime.from ?: ""
+			, dateto     = arguments._pastTime.to   ?: ""
+			, identifier = arguments.asset
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserLastPerformedAction.cfc
+++ b/system/handlers/rules/expressions/UserLastPerformedAction.cfc
@@ -46,18 +46,14 @@ component {
 	 *
 	 */
 	private array function prepareFilters(
-		  required string  action
-		,          struct  _pastTime
-		,          string  filterPrefix
-		,          string  parentPropertyName
+		  required string action
+		,          struct _pastTime
 	) {
 		return websiteUserActionService.getUserLastPerformedActionFilter(
-			  action             = ListRest( arguments.action, "." )
-			, type               = ListFirst( arguments.action, "." )
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action   = ListRest( arguments.action, "." )
+			, type     = ListFirst( arguments.action, "." )
+			, datefrom = arguments._pastTime.from ?: ""
+			, dateto   = arguments._pastTime.to   ?: ""
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserLastSubmittedFormBuilderForm.cfc
+++ b/system/handlers/rules/expressions/UserLastSubmittedFormBuilderForm.cfc
@@ -32,17 +32,13 @@ component {
 	 *
 	 */
 	private array function prepareFilters(
-		  required string  fbform
-		,          struct  _pastTime
-		,          string  filterPrefix
-		,          string  parentPropertyName
+		  required string fbform
+		,          struct _pastTime
 	) {
 		return formBuilderFilterService.prepareFilterForUserSubmittedFormBuilderForm(
-			  formId             = arguments.fbform
-			, from               = isDate( arguments._pastTime.from ?: "" ) ? arguments._pastTime.from : nullValue()
-			, to                 = isDate( arguments._pastTime.to   ?: "" ) ? arguments._pastTime.to   : nullValue()
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  formId = arguments.fbform
+			, from   = isDate( arguments._pastTime.from ?: "" ) ? arguments._pastTime.from : nullValue()
+			, to     = isDate( arguments._pastTime.to   ?: "" ) ? arguments._pastTime.to   : nullValue()
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserLastVisitedPage.cfc
+++ b/system/handlers/rules/expressions/UserLastVisitedPage.cfc
@@ -43,19 +43,15 @@ component {
 	 *
 	 */
 	private array function prepareFilters(
-		  required string  page
-		,          struct  _pastTime
-		,          string  filterPrefix
-		,          string  parentPropertyName
+		  required string page
+		,          struct _pastTime
 	) {
 		return websiteUserActionService.getUserLastPerformedActionFilter(
-			  action             = "pagevisit"
-			, type               = "request"
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, identifier         = arguments.page
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action     = "pagevisit"
+			, type       = "request"
+			, datefrom   = arguments._pastTime.from ?: ""
+			, dateto     = arguments._pastTime.to   ?: ""
+			, identifier = arguments.page
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserPerformedAction.cfc
+++ b/system/handlers/rules/expressions/UserPerformedAction.cfc
@@ -40,21 +40,17 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  action
-		,          boolean _has               = true
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          boolean _has      = true
+		,          struct  _pastTime = {}
 	) {
 		return websiteUserActionService.getUserPerformedActionFilter(
-			  action             = ListRest( arguments.action, "." )
-			, type               = ListFirst( arguments.action, "." )
-			, has                = arguments._has
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, qty                = 0
-			, qtyOperator        = arguments._has ? "gt" : "eq"
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action      = ListRest( arguments.action, "." )
+			, type        = ListFirst( arguments.action, "." )
+			, has         = arguments._has
+			, datefrom    = arguments._pastTime.from ?: ""
+			, dateto      = arguments._pastTime.to   ?: ""
+			, qty         = 0
+			, qtyOperator = arguments._has ? "gt" : "eq"
 		);
 	}
 }

--- a/system/handlers/rules/expressions/UserPerformedActionANumberOfTimes.cfc
+++ b/system/handlers/rules/expressions/UserPerformedActionANumberOfTimes.cfc
@@ -44,22 +44,18 @@ component {
 	private array function prepareFilters(
 		  required string  action
 		, required numeric times
-		,          boolean _has               = true
-		,          string  _numericOperator   = "eq"
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          boolean _has             = true
+		,          string  _numericOperator = "eq"
+		,          struct  _pastTime        = {}
 	) {
 		return websiteUserActionService.getUserPerformedActionFilter(
-			  action             = ListRest( arguments.action, "." )
-			, type               = ListFirst( arguments.action, "." )
-			, has                = arguments._has
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, qty                = arguments.times
-			, qtyOperator        = arguments._numericOperator
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action      = ListRest( arguments.action, "." )
+			, type        = ListFirst( arguments.action, "." )
+			, has         = arguments._has
+			, datefrom    = arguments._pastTime.from ?: ""
+			, dateto      = arguments._pastTime.to   ?: ""
+			, qty         = arguments.times
+			, qtyOperator = arguments._numericOperator
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserSubmittedFormBuilderFormANumberOfTimes.cfc
+++ b/system/handlers/rules/expressions/UserSubmittedFormBuilderFormANumberOfTimes.cfc
@@ -40,21 +40,17 @@ component {
 	private array function prepareFilters(
 		  required string  fbform
 		, required numeric times
-		,          string  _numericOperator   = "eq"
-		,          boolean _has               = true
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          string  _numericOperator = "eq"
+		,          boolean _has             = true
+		,          struct  _pastTime        = {}
 	) {
 		return formBuilderFilterService.prepareFilterForUserSubmittedFormBuilderForm(
-			  formId             = arguments.fbform
-			, has                = arguments._has
-			, qty                = arguments.times
-			, qtyOperator        = arguments._numericOperator
-			, from               = isDate( arguments._pastTime.from ?: "" ) ? arguments._pastTime.from : nullValue()
-			, to                 = isDate( arguments._pastTime.to   ?: "" ) ? arguments._pastTime.to   : nullValue()
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  formId      = arguments.fbform
+			, has         = arguments._has
+			, qty         = arguments.times
+			, qtyOperator = arguments._numericOperator
+			, from        = isDate( arguments._pastTime.from ?: "" ) ? arguments._pastTime.from : nullValue()
+			, to          = isDate( arguments._pastTime.to   ?: "" ) ? arguments._pastTime.to   : nullValue()
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserSubmittedFormBuilderForms.cfc
+++ b/system/handlers/rules/expressions/UserSubmittedFormBuilderForms.cfc
@@ -42,19 +42,14 @@ component {
 		,          boolean _has               = true
 		,          boolean _all               = false
 		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
 	) {
-
 		return formBuilderFilterService.prepareFilterForUserHasSubmittedFormFilter(
-			  formId = ListToArray( forms )
-			, _has   = arguments._has
-			, _all   = arguments._all
+			  formId   = ListToArray( forms )
+			, _has     = arguments._has
+			, _all     = arguments._all
 			, dateFrom = arguments._pastTime.from ?: ""
 			, dateTo   = arguments._pastTime.to   ?: ""
 		);
-
-
 	}
 
 }

--- a/system/handlers/rules/expressions/UserVisitedPageANumberOfTimes.cfc
+++ b/system/handlers/rules/expressions/UserVisitedPageANumberOfTimes.cfc
@@ -43,23 +43,19 @@ component {
 	private array function prepareFilters(
 		  required string  page
 		, required numeric times
-		,          string  _numericOperator   = "eq"
-		,          boolean _has               = true
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          string  _numericOperator = "eq"
+		,          boolean _has             = true
+		,          struct  _pastTime        = {}
 	) {
 		return websiteUserActionService.getUserPerformedActionFilter(
-			  action             = "pagevisit"
-			, type               = "request"
-			, has                = arguments._has
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, identifiers        = [ arguments.page ]
-			, qty                = arguments.times
-			, qtyOperator        = arguments._numericOperator
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action      = "pagevisit"
+			, type        = "request"
+			, has         = arguments._has
+			, datefrom    = arguments._pastTime.from ?: ""
+			, dateto      = arguments._pastTime.to   ?: ""
+			, identifiers = [ arguments.page ]
+			, qty         = arguments.times
+			, qtyOperator = arguments._numericOperator
 		);
 	}
 

--- a/system/handlers/rules/expressions/UserVisitedPages.cfc
+++ b/system/handlers/rules/expressions/UserVisitedPages.cfc
@@ -58,22 +58,18 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  pages
-		,          boolean _has               = true
-		,          boolean _all               = false
-		,          struct  _pastTime          = {}
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
+		,          boolean _has      = true
+		,          boolean _all      = false
+		,          struct  _pastTime = {}
 	) {
 		return websiteUserActionService.getUserPerformedActionFilter(
-			  action             = "pagevisit"
-			, type               = "request"
-			, has                = arguments._has
-			, datefrom           = arguments._pastTime.from ?: ""
-			, dateto             = arguments._pastTime.to   ?: ""
-			, identifiers        = arguments.pages.listToArray()
-			, allIdentifiers     = arguments._all
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  action         = "pagevisit"
+			, type           = "request"
+			, has            = arguments._has
+			, datefrom       = arguments._pastTime.from ?: ""
+			, dateto         = arguments._pastTime.to   ?: ""
+			, identifiers    = arguments.pages.listToArray()
+			, allIdentifiers = arguments._all
 		);
 	}
 

--- a/system/handlers/rules/expressions/question/CheckboxFieldChecked.cfc
+++ b/system/handlers/rules/expressions/question/CheckboxFieldChecked.cfc
@@ -37,9 +37,7 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  question
-		,          boolean _is                = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _is = true
 	){
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionHasResponded( argumentCollection=arguments, _has = _is );
 	}

--- a/system/handlers/rules/expressions/question/DateFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/DateFieldMatches.cfc
@@ -38,9 +38,7 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string question
-		,          struct _time              = {}
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          struct _time = {}
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionResponseDateComparison( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/FileUploadTypeMatches.cfc
+++ b/system/handlers/rules/expressions/question/FileUploadTypeMatches.cfc
@@ -41,9 +41,7 @@ component {
 	private array function prepareFilters(
 		  required string question
 		, required string filetype
-		,          boolean _is               = true
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          boolean _is = true
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionFileUploadTypeMatches( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/HasResponse.cfc
+++ b/system/handlers/rules/expressions/question/HasResponse.cfc
@@ -36,9 +36,7 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  question
-		,          boolean _has               = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _has = true
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionHasResponded( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/HasUploaded.cfc
+++ b/system/handlers/rules/expressions/question/HasUploaded.cfc
@@ -37,9 +37,7 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  question
-		,          boolean _has               = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _has = true
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionHasResponded( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/MatrixAllRowsMatch.cfc
+++ b/system/handlers/rules/expressions/question/MatrixAllRowsMatch.cfc
@@ -37,9 +37,7 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _all = false
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionMatrixAllRowsMatch( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/MatrixAnyRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/MatrixAnyRowMatches.cfc
@@ -37,9 +37,7 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _all = false
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionMatrixAnyRowMatches( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/MatrixRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/MatrixRowMatches.cfc
@@ -42,9 +42,7 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _all = false
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionMatrixRowMatches( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/MultiChoiceFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/MultiChoiceFieldMatches.cfc
@@ -38,9 +38,7 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _all = false
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionResponseMatchesChoiceOptions( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/NumericFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/NumericFieldMatches.cfc
@@ -38,8 +38,6 @@ component {
 		  required string question
 		, required string value
 		,          string _numericOperator = "eq"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionResponseMatchesNumber( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/SingleChoiceFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/SingleChoiceFieldMatches.cfc
@@ -37,8 +37,6 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 	) {
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionResponseMatchesChoiceOptions( argumentCollection=arguments, _all=false );
 	}

--- a/system/handlers/rules/expressions/question/StarRatingMatches.cfc
+++ b/system/handlers/rules/expressions/question/StarRatingMatches.cfc
@@ -39,8 +39,6 @@ component {
 		  required string question
 		, required string value
 		,          string _numericOperator = "eq"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	){
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionResponseMatchesNumber( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/TextFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/TextFieldMatches.cfc
@@ -40,8 +40,6 @@ component {
 		  required string question
 		, required string value
 		,          string _stringOperator = "contains"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	){
 		return formBuilderFilterService.prepareFilterForSubmissionQuestionResponseMatchesText( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserHasResponse.cfc
+++ b/system/handlers/rules/expressions/question/UserHasResponse.cfc
@@ -36,10 +36,8 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string  question
-		,          string  formId             = ""
-		,          boolean _has               = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId = ""
+		,          boolean _has   = true
 	) {
 		return formBuilderFilterService.prepareFilterForUserHasRespondedToQuestion( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToDate.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToDate.cfc
@@ -38,10 +38,8 @@ component {
 	 */
 	private array function prepareFilters(
 		  required string question
-		,          string formId              = ""
-		,          struct _time               = {}
-		,          string parentPropertyName  = ""
-		,          string filterPrefix        = ""
+		,          string formId = ""
+		,          struct _time  = {}
 	){
 		return formBuilderFilterService.prepareFilterForUserLatestResponseToDateField( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAllRowsMatch.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAllRowsMatch.cfc
@@ -41,10 +41,8 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          string  formId             = ""
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId = ""
+		,          boolean _all   = false
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseMatrixAllRowsMatch( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAnyRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAnyRowMatches.cfc
@@ -43,8 +43,6 @@ component {
 		, required string  value
 		,          string  formId             = ""
 		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseMatrixAnyRowMatches( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMatrixRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMatrixRowMatches.cfc
@@ -42,10 +42,8 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          string  formId             = ""
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId = ""
+		,          boolean _all   = false
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseMatrixRowMatches( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMultiChoice.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMultiChoice.cfc
@@ -40,10 +40,8 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required string  value
-		,          string  formId             = ""
-		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId = ""
+		,          boolean _all   = false
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseToChoiceField( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToNumber.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToNumber.cfc
@@ -39,10 +39,8 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required numeric value
-		,          string  formId             = ""
-		,          string  _numericOperator   = "eq"
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId           = ""
+		,          string  _numericOperator = "eq"
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseToNumberField( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToSingleChoice.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToSingleChoice.cfc
@@ -40,8 +40,6 @@ component {
 		  required string question
 		, required string value
 		,          string formId
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseToChoiceField( argumentCollection=arguments, _all=false );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToStarRating.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToStarRating.cfc
@@ -40,10 +40,8 @@ component {
 	private array function prepareFilters(
 		  required string  question
 		, required numeric value
-		,          string  formId             = ""
-		,          string  _numericOperator   = "eq"
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId           = ""
+		,          string  _numericOperator = "eq"
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseToNumberField( argumentCollection=arguments );
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToTextField.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToTextField.cfc
@@ -39,10 +39,8 @@ component {
 	private array function prepareFilters(
 		  required string question
 		, required string value
-		,          string formId             = ""
-		,          string _stringOperator    = "contains"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          string formId          = ""
+		,          string _stringOperator = "contains"
 	) {
 		return formBuilderFilterService.prepareFilterForUserLatestResponseToTextField( argumentCollection=arguments );
 	}

--- a/system/services/formbuilder/FormBuilderFilterService.cfc
+++ b/system/services/formbuilder/FormBuilderFilterService.cfc
@@ -52,10 +52,8 @@ component {
 	public array function prepareFilterForUserLatestResponseMatrixAnyRowMatches(
 		  required string question
 		, required string value
-		,          string formId             = ""
-		,          boolean _all              = false
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          string formId = ""
+		,          boolean _all  = false
 	) {
 		var paramSuffix         = _getRandomFilterParamSuffix();
 		var responseQueryAlias  = "responseCount" & paramSuffix;
@@ -73,18 +71,14 @@ component {
 			, initialParams      = params
 			, paramSuffix        = paramSuffix
 			, overallFilter      = overallFilter
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
 		);
 	}
 
 	public array function prepareFilterForUserLatestResponseMatrixAllRowsMatch(
 		  required string question
 		, required string value
-		,          string formId             = ""
-		,          boolean _all              = false
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          string formId = ""
+		,          boolean _all  = false
 	) {
 
 		var theQuestion         = _getFormBuilderService().getQuestion( question );
@@ -107,18 +101,14 @@ component {
 			, initialParams      = params
 			, paramSuffix        = paramSuffix
 			, overallFilter      = overallFilter
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
 		);
 	}
 	public array function prepareFilterForUserLatestResponseMatrixRowMatches(
  		  required string question
 		, required string row
 		, required string value
-		,          string formId             = ""
-		,          boolean _all              = false
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          string formId = ""
+		,          boolean _all  = false
 	) {
 		var paramSuffix         = _getRandomFilterParamSuffix();
 		var responseQueryAlias  = "responseCount" & paramSuffix;
@@ -138,17 +128,13 @@ component {
 			, paramSuffix        = paramSuffix
 			, overallFilter      = overallFilter
 			, row                = arguments.row
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
 		);
 	}
 	public array function prepareFilterForSubmissionQuestionMatrixRowMatches(
 		  required string question
 		, required string row
 		, required string value
-		,          boolean _all              = false
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          boolean _all = false
 	) {
 		var paramSuffix    = _getRandomFilterParamSuffix();
 		var subqueryAlias  = "responseCount" & paramSuffix;
@@ -166,17 +152,13 @@ component {
 			, paramSuffix        = paramSuffix
 			, overallFilter      = overallFilter
 			, row                = arguments.row
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
 		);
 	}
 
 	public array function prepareFilterForSubmissionQuestionMatrixAnyRowMatches(
 		  required string question
 		, required string value
-		,          boolean _all              = false
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          boolean _all = false
 	) {
 		var paramSuffix    = _getRandomFilterParamSuffix();
 		var subqueryAlias  = "responseCount" & paramSuffix;
@@ -184,23 +166,19 @@ component {
 		var params         = { "question#paramSuffix#" = { value=arguments.question, type="cf_sql_varchar" } };
 
 		return _prepareFilterForSubmissionQuestionMatrixMatches(
-			  value              = arguments.value
-			, _all               = arguments._all
-			, subqueryAlias      = subqueryAlias
-			, initialParams      = params
-			, paramSuffix        = paramSuffix
-			, overallFilter      = overallFilter
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  value         = arguments.value
+			, _all          = arguments._all
+			, subqueryAlias = subqueryAlias
+			, initialParams = params
+			, paramSuffix   = paramSuffix
+			, overallFilter = overallFilter
 		);
 	}
 
 	public array function prepareFilterForSubmissionQuestionMatrixAllRowsMatch(
 		  required string question
 		, required string value
-		,          boolean _all              = false
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          boolean _all = false
 	) {
 
 		var theQuestion    = _getFormBuilderService().getQuestion( question );
@@ -212,26 +190,21 @@ component {
 		var overallFilter  = "#subqueryAlias#.response_count >= #totalRows# ";
 		var params         = { "question#paramSuffix#" = { value=arguments.question, type="cf_sql_varchar" } };
 
-
 		return _prepareFilterForSubmissionQuestionMatrixMatches(
-			  value              = arguments.value
-			, _all               = arguments._all
-			, subqueryAlias      = subqueryAlias
-			, initialParams      = params
-			, paramSuffix        = paramSuffix
-			, overallFilter      = overallFilter
-			, filterPrefix       = arguments.filterPrefix
-			, parentPropertyName = arguments.parentPropertyName
+			  value         = arguments.value
+			, _all          = arguments._all
+			, subqueryAlias = subqueryAlias
+			, initialParams = params
+			, paramSuffix   = paramSuffix
+			, overallFilter = overallFilter
 		);
 	}
 
 	public array function prepareFilterForUserLatestResponseToChoiceField(
 		  required string  question
 		, required string  value
-		,          string  formId             = ""
-		,          boolean _all               = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId = ""
+		,          boolean _all   = true
 	) {
 		var paramSuffix    = _getRandomFilterParamSuffix();
 		var values         = arguments.value.listToArray();
@@ -298,8 +271,6 @@ component {
 		  required string  question
 		, required string  value
 		,          boolean _all               = false
-		,          string  parentPropertyName = ""
-		,
 	) {
 		var filters        = [];
 		var paramSuffix    = _getRandomFilterParamSuffix();
@@ -329,7 +300,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
 
@@ -413,9 +384,7 @@ component {
 
 	public array function prepareFilterForSubmissionQuestionHasResponded(
 		  required string  question
-		,          boolean _has               = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          boolean _has = true
 	) {
 		var filters        = [];
 		var paramSuffix    = _getRandomFilterParamSuffix();
@@ -442,7 +411,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
 
@@ -454,8 +423,6 @@ component {
 		  required string  question
 		, required string  filetype
 		,          boolean _is = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
 	) {
 		var paramSuffix       = _getRandomFilterParamSuffix();
 		var subqueryAlias     = "responseCount" & paramSuffix;
@@ -489,7 +456,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
 
@@ -500,8 +467,6 @@ component {
 		  required string question
 		, required string value
 		,          string _stringOperator = "contains"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	) {
 		var filters        = [];
 		var paramSuffix    = _getRandomFilterParamSuffix();
@@ -562,7 +527,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
 
@@ -671,10 +636,8 @@ component {
 
 	public array function prepareFilterForUserHasRespondedToQuestion(
 		  required string  question
-		,          string  formId             = ""
-		,          boolean _has               = true
-		,          string  parentPropertyName = ""
-		,          string  filterPrefix       = ""
+		,          string  formId = ""
+		,          boolean _has   = true
 	) {
 		var filters        = [];
 		var paramSuffix    = _getRandomFilterParamSuffix();
@@ -724,10 +687,8 @@ component {
 	public array function prepareFilterForUserLatestResponseToTextField(
 		  required string question
 		, required string value
-		,          string formId             = ""
-		,          string _stringOperator    = "contains"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          string formId          = ""
+		,          string _stringOperator = "contains"
 	) {
 		var filters        = [];
 		var paramSuffix    = _getRandomFilterParamSuffix();
@@ -805,10 +766,8 @@ component {
 
 	public array function prepareFilterForUserLatestResponseToDateField(
 		  required string question
-		,          string formId             = ""
-		,          struct _time              = {}
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
+		,          string formId = ""
+		,          struct _time  = {}
 	) {
 		var overallFilter      = "1=1";
 		var paramSuffix        = _getRandomFilterParamSuffix();
@@ -860,8 +819,6 @@ component {
 	public array function prepareFilterForSubmissionQuestionResponseDateComparison (
 		  required string question
 		, required struct _time
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	) {
 		var paramSuffix    = _getRandomFilterParamSuffix();
 		var subqueryAlias  = "responseCount" & paramSuffix;
@@ -896,10 +853,9 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
-
 
 		return response;
 	}
@@ -909,8 +865,6 @@ component {
 		, required string value
 		,          string formId             = ""
 		,          string _numericOperator   = "eq"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	) {
 		var filters        = [];
 		var paramSuffix    = _getRandomFilterParamSuffix();
@@ -996,8 +950,6 @@ component {
 		  required string question
 		, required string value
 		,          string _numericOperator = "eq"
-		,          string parentPropertyName = ""
-		,          string filterPrefix       = ""
 	) {
 		var responseField = "";
 		var cast          = "int"
@@ -1077,7 +1029,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
 
@@ -1120,8 +1072,6 @@ component {
 		, boolean has    = true
 		, date    from
 		, date    to
-		, string  filterPrefix       = ""
-		, string  parentPropertyName = ""
 		, numeric qty
 		, string  qtyOperator
 	) {
@@ -1202,7 +1152,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "submitted_by"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "website_user" )
+			, joinToTable    = "website_user"
 			, joinToColumn   = "id"
 		} ] } ];
 	}
@@ -1252,8 +1202,6 @@ component {
 		  required string value
 		, required string formId
 		, required string _all
-		, required string filterPrefix
-		, required string parentPropertyName
 		, required string responseQueryAlias
 		, required struct initialParams
 		, required string paramSuffix
@@ -1331,8 +1279,6 @@ component {
 	private array function _prepareFilterForSubmissionQuestionMatrixMatches(
 		  required string value
 		, required string _all
-		, required string filterPrefix
-		, required string parentPropertyName
 		, required string subqueryAlias
 		, required struct initialParams
 		, required string paramSuffix
@@ -1381,7 +1327,7 @@ component {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = arguments.subqueryAlias
 			, subQueryColumn = "submission"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "formbuilder_formsubmission" )
+			, joinToTable    = "formbuilder_formsubmission"
 			, joinToColumn   = "id"
 		} ] } ];
 

--- a/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
+++ b/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
@@ -679,7 +679,7 @@ component {
 
 		var properties = $getPresideObjectService().getObjectProperties( currentObjectName );
 		for( var propName in properties ) {
-			expressions.append( generateExpressionsForProperty(
+			ArrayAppend( expressions, generateExpressionsForProperty(
 				  objectName         = currentObjectName
 				, propertyDefinition = properties[ propName ]
 				, parentObjectName   = arguments.objectName

--- a/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
+++ b/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
@@ -31,8 +31,8 @@ component {
 		for( var propName in properties ) {
 			expressions.append( generateExpressionsForProperty( arguments.objectName, properties[ propName ] ), true );
 		}
-		for( var relatedObjectPath in relatedObjectsForAutoGeneration.listToArray() ) {
-			expressions.append( _createExpressionsForRelatedObjectProperties( arguments.objectName, relatedObjectPath.trim() ), true );
+		for( var relatedObjectPath in ListToArray( relatedObjectsForAutoGeneration ) ) {
+			ArrayAppend( expressions, _createExpressionsForRelatedObjectProperties( arguments.objectName, Trim( relatedObjectPath ) ), true );
 		}
 
 		return expressions;
@@ -642,33 +642,61 @@ component {
 		};
 	}
 
+	/**
+	 * In addition to auto expressions being generated per property on an object,
+	 * developers can specify additional relationship properties + property *chains*
+	 * to have a related object's auto generated rules also applied to the source
+	 * object. This logic deals with creating those
+	 */
 	private array function _createExpressionsForRelatedObjectProperties(
 		  required string objectName
-		, required string propertyName
+		, required string relatedObjectPath
 	) {
-		var poService          = $getPresideObjectService();
-		var propertyChain      = arguments.propertyName.listToArray( "." );
-		var currentObjectName  = arguments.objectName;
-		var parentPropertyName = arguments.propertyName.listChangeDelims( "$", "." );
-		var expressions        = [];
+		var poService              = $getPresideObjectService();
+		var currentObjectName      = arguments.objectName;
+		var parentPropertyName     = ListChangeDelims( arguments.relatedObjectPath, "$", "." );
+		var supportedRelationships = [ "many-to-one", "many-to-many", "one-to-many" ];
+		var relationshipHelpers    = [];
+		var expressions            = [];
 
-		for( var propName in propertyChain ) {
-			var prop = poService.getObjectProperty( currentObjectName, propName );
+		for( var propName in ListToArray( arguments.relatedObjectPath, "." ) ) {
+			var prop    = poService.getObjectProperty( currentObjectName, propName );
+			var isValid = Len( prop.relatedTo ?: "" ) && ArrayFindNoCase( supportedRelationships, prop.relationship ?: "" );
 
-			currentObjectName = prop.relatedto ?: "";
+			if ( !isValid ) {
+				return [];
+			}
+
+			ArrayAppend( relationshipHelpers,  _prepareRelatedObjectRelationshipHelpers(
+				  objectName         = prop.relatedTo
+				, parentObjectName   = currentObjectName
+				, parentPropertyName = propName
+				, parentProperty     = prop
+			) );
+
+			currentObjectName = prop.relatedto;
 		}
 
-		if ( currentObjectName.len() ) {
-			var properties = $getPresideObjectService().getObjectProperties( currentObjectName );
+		var properties = $getPresideObjectService().getObjectProperties( currentObjectName );
+		for( var propName in properties ) {
+			expressions.append( generateExpressionsForProperty(
+				  objectName         = currentObjectName
+				, propertyDefinition = properties[ propName ]
+				, parentObjectName   = arguments.objectName
+				, parentPropertyName = parentPropertyName
+			), true );
+		}
 
-			for( var propName in properties ) {
-				expressions.append( generateExpressionsForProperty(
-					  objectName         = currentObjectName
-					, propertyDefinition = properties[ propName ]
-					, parentObjectName   = objectName
-					, parentPropertyName = parentPropertyName
-				), true );
-			}
+		// wrap expressions using a handler designed for related property filtering
+		for( var expression in expressions ) {
+			expression.expressionHandlerArgs.originalFilterHandler = expression.filterHandler;
+			expression.expressionHandlerArgs.relationshipHelpers   = relationshipHelpers;
+
+			expression.filterHandlerArgs.originalFilterHandler = expression.filterHandler;
+			expression.filterHandlerArgs.relationshipHelpers   = relationshipHelpers;
+
+			expression.expressionHandler = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.evaluateExpression";
+			expression.filterHandler     = "rules.dynamic.presideObjectExpressions._relatedObjectExpressions.prepareFilters";
 		}
 
 		return expressions;
@@ -691,6 +719,71 @@ component {
 		}
 
 		return defaultVariety;
+	}
+
+	private struct function _prepareRelatedObjectRelationshipHelpers(
+		  required string objectName
+		, required string parentObjectName
+		, required string parentPropertyName
+		, required struct parentProperty
+	) {
+		var helpers = {
+			  objectName = arguments.objectName
+		};
+		switch( arguments.parentProperty.relationship ) {
+			case "many-to-one":
+				helpers.filterArgs = _getOuterJoinForManyToOne( argumentCollection=arguments );
+			break;
+
+			case "one-to-many":
+				helpers.filterArgs = _getOuterJoinForOneToMany( argumentCollection=arguments );
+			break;
+
+			case "many-to-many":
+				helpers.filterArgs = _getFilterJoinsForManyToMany( argumentCollection=arguments );
+			break;
+		}
+
+		return helpers;
+	}
+
+
+	private struct function _getOuterJoinForManyToOne() {
+		var idField    = $getPresideObjectService().getIdField( arguments.objectName );
+		var innerField = "#arguments.objectName#.#idField#";
+		var outerField = "#arguments.parentObjectName#.#arguments.parentPropertyName#";
+
+		return { filter = $helpers.obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
+	}
+
+	private struct function _getOuterJoinForOneToMany() {
+		var relationshipKey = $getPresideObjectService().getObjectPropertyAttribute( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName, attributeName="relationshipKey", defaultValue=arguments.parentObjectName );
+		var idField = $getPresideObjectService().getIdField( arguments.parentObjectName );
+		var innerField = "#arguments.objectName#.#relationshipKey#";
+		var outerField = "#arguments.parentObjectName#.#idField#";
+
+		return { filter = $helpers.obfuscateSqlForPreside( "#innerField# = #outerField#" ) };
+	}
+
+	private struct function _getFilterJoinsForManyToMany() {
+		var idField    = $getPresideObjectService().getIdField( arguments.parentObjectName );
+		var outerField = "#arguments.parentObjectName#.#idField#";
+
+		var prop       = $getPresideObjectService().getObjectProperty( objectName=arguments.parentObjectName, propertyName=arguments.parentPropertyName );
+		var relatedVia = prop.relatedVia           ?: "";
+		var outerFk    = "";
+
+		if ( $helpers.isTrue( prop.relationshipIsSource ?: true ) ) {
+			outerFk = prop.relatedViaSourceFk ?: arguments.parentObjectName;
+		} else {
+			outerFk = prop.relatedViaTargetFk ?: arguments.parentObjectName;
+		}
+		var innerField = "#relatedVia#.#outerFk#"
+
+		return {
+			  filter     = "#innerField# = #$helpers.obfuscateSqlForPreside( outerField )#"
+			, forceJoins = "inner"
+		};
 	}
 
 

--- a/system/services/rulesEngine/RulesEngineExpressionService.cfc
+++ b/system/services/rulesEngine/RulesEngineExpressionService.cfc
@@ -323,10 +323,6 @@ component displayName="RulesEngine Expression Service" {
 		eventArgs.append( expression.expressionHandlerArgs ?: {} );
 		eventArgs.append( preProcessConfiguredFields( arguments.expressionId, arguments.configuredFields ) );
 
-		if ( Len( Trim( eventArgs.parentPropertyName ?: "" ) ) ) {
-			eventArgs.filterPrefix = ListAppend( eventArgs.filterPrefix ?: "", eventArgs.parentPropertyName, "$" );
-		}
-
 		var result = $getColdbox().runEvent(
 			  event          = handlerAction
 			, private        = true
@@ -345,13 +341,11 @@ component displayName="RulesEngine Expression Service" {
 	 * @expressionId.hint     The ID of the expression whose filters you wish to prepare
 	 * @objectName.hint       The object whose records are to be filtered
 	 * @configuredFields.hint A structure of fields configured for the expression instance whose filter we are preparing
-	 * @filterPrefix.hint     An optional prefix to prepend to any property filters. This is useful when you are traversing the relationship tree and building filters within filters!
 	 */
 	public array function prepareExpressionFilters(
 		  required string expressionId
 		, required string objectName
 		, required struct configuredFields
-		,          string filterPrefix = ""
 	) {
 		_lazyLoadDynamicExpressions( filterObject=arguments.objectName );
 
@@ -366,14 +360,10 @@ component displayName="RulesEngine Expression Service" {
 		}
 
 		var handlerAction = expression.filterHandler ?: "rules.expressions." & arguments.expressionId & ".prepareFilters";
-		var eventArgs     = { objectName=arguments.objectName, filterPrefix=arguments.filterPrefix };
+		var eventArgs     = { objectName=arguments.objectName };
 
 		eventArgs.append( expression.filterHandlerArgs ?: {} );
 		eventArgs.append( preProcessConfiguredFields( arguments.expressionId, arguments.configuredFields ) );
-
-		if ( Len( Trim( eventArgs.parentPropertyName ?: "" ) ) ) {
-			eventArgs.filterPrefix = ListAppend( eventArgs.filterPrefix, eventArgs.parentPropertyName, "$" );
-		}
 
 		var result = $getColdbox().runEvent(
 			  event          = handlerAction

--- a/system/services/rulesEngine/RulesEngineFilterService.cfc
+++ b/system/services/rulesEngine/RulesEngineFilterService.cfc
@@ -30,7 +30,6 @@ component displayName="Rules Engine Filter Service" {
 	 * @objectName.hint      The name of the object that the filter is for
 	 * @filterId.hint        ID of the saved filter (from rules_engine_condition object) to prepare filters for. Not required if using expressionArray
 	 * @expressionArray.hint Configured expression array of the condition to prepare a filter for. Not required if using filterId.
-	 * @filterPrefix.hint    An optional prefix to prepend to any property filters. This is useful when you are traversing the relationship tree and building filters within filters!
 	 *
 	 */
 	public struct function prepareFilter(
@@ -38,7 +37,6 @@ component displayName="Rules Engine Filter Service" {
 		,          string  filterId           = ""
 		,          array   expressionArray
 		,          boolean ignoreSegmentation = false
-		,          string  filterPrefix       = ""
 	) {
 		if ( Len( arguments.filterId ) && isSegmentionFilter( arguments.filterId ) && !arguments.ignoreSegmentation ) {
 			return prepareSegmentationFilter( arguments.objectName, arguments.filterId );
@@ -60,7 +58,7 @@ component displayName="Rules Engine Filter Service" {
 			if ( isJoin ) {
 				join = expressionArray[i] == "and" ? "and" : "or";
 			} else if ( IsArray( expressionArray[i] ) ) {
-				var subFilter = prepareFilter( objectName=objectName, expressionArray=expressionArray[i], filterPrefix=arguments.filterPrefix );
+				var subFilter = prepareFilter( objectName=objectName, expressionArray=expressionArray[i] );
 
 				if ( StructKeyExists( subFilter, "having" ) ) {
 					isHaving = true;
@@ -76,7 +74,6 @@ component displayName="Rules Engine Filter Service" {
 					  expressionId     = expressionArray[i].expression ?: ""
 					, configuredFields = expressionArray[i].fields     ?: {}
 					, objectName       = arguments.objectName
-					, filterPrefix     = arguments.filterPrefix
 				);
 
 				if ( rawFilters.len() ) {

--- a/system/services/websiteUsers/WebsiteUserActionService.cfc
+++ b/system/services/websiteUsers/WebsiteUserActionService.cfc
@@ -244,8 +244,6 @@ component displayName="Website user action service" {
 		,          boolean allIdentifiers     = false
 		,          numeric qty
 		,          string  qtyOperator        = "gt"
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
 	) {
 		if ( arguments.identifiers.len() > 1 && arguments.allIdentifiers ) {
 			var filters = [];
@@ -327,7 +325,7 @@ component displayName="Website user action service" {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "id"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "website_user" )
+			, joinToTable    = "website_user"
 			, joinToColumn   = "id"
 		} ] } ];
 	}
@@ -338,8 +336,6 @@ component displayName="Website user action service" {
 		,          string  dateFrom           = ""
 		,          string  dateTo             = ""
 		,          string  identifier         = ""
-		,          string  filterPrefix       = ""
-		,          string  parentPropertyName = ""
 	) {
 		var paramSuffix    = _getRandomFilterParamSuffix();
 		var subqueryFilter = "actions.action = :action#paramSuffix# and actions.type = :type#paramSuffix#";
@@ -378,7 +374,7 @@ component displayName="Website user action service" {
 			, subQuery       = subquery.sql
 			, subQueryAlias  = subqueryAlias
 			, subQueryColumn = "id"
-			, joinToTable    = arguments.filterPrefix.len() ? arguments.filterPrefix : ( arguments.parentPropertyName.len() ? arguments.parentPropertyName : "website_user" )
+			, joinToTable    = "website_user"
 			, joinToColumn   = "id"
 		} ] } ];
 	}

--- a/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
@@ -553,7 +553,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var dummyFilters = [ 1, 2, 3, "test", CreateUUId() ];
 				var fields       = { _is = false, test=CreateUUId() };
 				var expressionId = "userGroup.user";
-				var eventArgs    = { objectName = objectName, filterPrefix="" };
+				var eventArgs    = { objectName = objectName };
 
 				eventArgs.append( fields );
 
@@ -586,46 +586,10 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var objectName   = "usergroup";
 				var dummyFilters = [ 1, 2, 3, "test", CreateUUId() ];
 				var fields       = { _is = false, test=CreateUUId() };
-				var eventArgs    = { objectName = objectName, filterPrefix="" };
-
-				eventArgs.append( expressions[ expressionId ].filterHandlerArgs );
-				eventArgs.append( fields );
-
-				mockColdboxController.$( "runEvent" ).$args(
-					  event          = expressions[ expressionId ].filterHandler
-					, private        = true
-					, prepostExempt  = true
-					, eventArguments = eventArgs
-				).$results( dummyFilters );
-
-				service.$( "preProcessConfiguredFields" ).$args( expressionId, fields ).$results( fields );
-
-				expect( service.prepareExpressionFilters(
-					  expressionId     = expressionId
-					, objectName       = objectName
-					, configuredFields = fields
-				) ).toBe( dummyFilters );
-			} );
-
-			it( "should pass through a 'filterPrefix' argument to the handler when supplied to the method", function(){
-				var expressions  = _getDefaultTestExpressions();
-				var service      = _getService( expressions );
-				var expressionId = "userGroup.user";
-				var filterPrefix = CreateUUId();
-
-				expressions[ expressionId ].filterHandlerArgs = {
-					  test = CreateUUId()
-					, tea  = Now()
-				};
-
-				var objectName   = "usergroup";
-				var dummyFilters = [ 1, 2, 3, "test", CreateUUId() ];
-				var fields       = { _is = false, test=CreateUUId() };
 				var eventArgs    = { objectName = objectName };
 
 				eventArgs.append( expressions[ expressionId ].filterHandlerArgs );
 				eventArgs.append( fields );
-				eventArgs.filterPrefix = filterPrefix
 
 				mockColdboxController.$( "runEvent" ).$args(
 					  event          = expressions[ expressionId ].filterHandler
@@ -640,45 +604,6 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					  expressionId     = expressionId
 					, objectName       = objectName
 					, configuredFields = fields
-					, filterPrefix     = filterPrefix
-				) ).toBe( dummyFilters );
-			} );
-
-			it( "should append 'parentPropertyName' to the 'filterPrefix' when present in the filter args", function(){
-				var expressions  = _getDefaultTestExpressions();
-				var service      = _getService( expressions );
-				var expressionId = "userGroup.user";
-				var filterPrefix = CreateUUId();
-
-				expressions[ expressionId ].filterHandlerArgs = {
-					  test               = CreateUUId()
-					, tea                = Now()
-					, parentPropertyName = "test"
-				};
-
-				var objectName   = "usergroup";
-				var dummyFilters = [ 1, 2, 3, "test", CreateUUId() ];
-				var fields       = { _is = false, test=CreateUUId() };
-				var eventArgs    = { objectName = objectName };
-
-				eventArgs.append( expressions[ expressionId ].filterHandlerArgs );
-				eventArgs.append( fields );
-				eventArgs.filterPrefix = filterPrefix & "$test";
-
-				mockColdboxController.$( "runEvent" ).$args(
-					  event          = expressions[ expressionId ].filterHandler
-					, private        = true
-					, prepostExempt  = true
-					, eventArguments = eventArgs
-				).$results( dummyFilters );
-
-				service.$( "preProcessConfiguredFields" ).$args( expressionId, fields ).$results( fields );
-
-				expect( service.prepareExpressionFilters(
-					  expressionId     = expressionId
-					, objectName       = objectName
-					, configuredFields = fields
-					, filterPrefix     = filterPrefix
 				) ).toBe( dummyFilters );
 			} );
 

--- a/tests/integration/api/rulesEngine/RulesEngineFilterServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineFilterServiceTest.cfc
@@ -42,10 +42,10 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					]
 				];
 
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[1].expression, objectName=dummyObject, configuredFields = dummyCondition[1].fields, filterPrefix="" ).$results( dummyFilters[1] );
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][1].fields, filterPrefix="" ).$results( dummyFilters[2] );
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][1].fields, filterPrefix="" ).$results( dummyFilters[3] );
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][3].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][3].fields, filterPrefix="" ).$results( dummyFilters[4] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[1].expression, objectName=dummyObject, configuredFields = dummyCondition[1].fields ).$results( dummyFilters[1] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][1].fields ).$results( dummyFilters[2] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][1].fields ).$results( dummyFilters[3] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][3].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][3].fields ).$results( dummyFilters[4] );
 
 				mockDbAdapter.$( "getClauseSql" ).$args( filter=dummyFilters[1][1].filter, tableAlias=dummyObject ).$results( dummySqlFilters[1] );
 				mockDbAdapter.$( "getClauseSql" ).$args( filter=dummyFilters[1][2].filter, tableAlias=dummyObject ).$results( dummySqlFilters[2] );
@@ -78,7 +78,6 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					, "filter5"
 				];
 				var expectedSql = "( ( filter1 and filter2 ) and #dummyFilters[2][1].having# )";
-				var filterPrefix = CreateUUId();
 				var expectedParams = {
 					  param1 = dummyFilters[1][1].filterParams.param1
 					, param2 = dummyFilters[1][2].filterParams.param2
@@ -103,10 +102,10 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					]
 				];
 
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[1].expression, objectName=dummyObject, configuredFields = dummyCondition[1].fields, filterPrefix=filterPrefix ).$results( dummyFilters[1] );
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][1].fields, filterPrefix=filterPrefix ).$results( dummyFilters[2] );
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][1].fields, filterPrefix=filterPrefix ).$results( dummyFilters[3] );
-				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][3].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][3].fields, filterPrefix=filterPrefix ).$results( dummyFilters[4] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[1].expression, objectName=dummyObject, configuredFields = dummyCondition[1].fields ).$results( dummyFilters[1] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][1].fields ).$results( dummyFilters[2] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][1].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][1].fields ).$results( dummyFilters[3] );
+				mockExpressionService.$( "prepareExpressionFilters" ).$args( expressionId=dummyCondition[3][3][3].expression, objectName=dummyObject, configuredFields = dummyCondition[3][3][3].fields ).$results( dummyFilters[4] );
 
 				mockDbAdapter.$( "getClauseSql" ).$args( filter=dummyFilters[1][1].filter, tableAlias=dummyObject ).$results( dummySqlFilters[1] );
 				mockDbAdapter.$( "getClauseSql" ).$args( filter=dummyFilters[1][2].filter, tableAlias=dummyObject ).$results( dummySqlFilters[2] );
@@ -117,7 +116,6 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var result = service.prepareFilter(
 					  objectName      = dummyObject
 					, expressionArray = dummyCondition
-					, filterPrefix    = filterPrefix
 				);
 
 				expect( result.having ?: "" ).toBe( "" );


### PR DESCRIPTION
To fix [PRESIDECMS-2448](https://presidecms.atlassian.net/browse/PRESIDECMS-2448), we need to re-visit how we achieve the auto filter expression generation for related objects via the `@autoGenerateFilterExpressionsFor` property on objects that takes a list of either:

* bare property names of relationship properties on this object
* a _chain_ of property names traversing relationships across object to some other target (yikes)

The original implementation of this caused an addition of complexity to **all expressions** that are ever created, namely, having to deal with `filterPrefix` and `parentPropertyName` / `parentObjectName` arguments and dynamically changing filter names depending on these. This was both incredibly difficult to comprehend and also, buggy as of 10.18.

So here we isolate individual expressions and handle the `autoGenerateFilterExpressionsFor` via a proxy handler that takes care of wrapping any natural filters in a potential chain of `exists (subquery)` style filters.

This makes for easier to write & maintain filters, faster executing queries and squashing the bug reported in PRESIDECMS-2448 (and potentially others along the way)!

In this PR, we implement the refactoring of the logic _and_ tidying up all core rules to stop expecting `filterPrefix`, `parentObjectName` and `parentPropertyName` arguments.

[PRESIDECMS-2448]: https://presidecms.atlassian.net/browse/PRESIDECMS-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ