### PR TITLE
PRESIDECMS-2506 heap space issue with fk calculation cache

### DIFF
--- a/system/helpers/queryUtils.cfm
+++ b/system/helpers/queryUtils.cfm
@@ -56,7 +56,9 @@
 </cffunction>
 
 <cffunction name="obfuscateSqlForPreside" access="public" returntype="any" output="false">
-	<cfargument name="sql" type="any" required="true" default="" />
+	<cfreturn getSingleton( "sqlRunner" ).obfuscateSqlForPreside( argumentCollection=arguments ) />
+</cffunction>
 
-	<cfreturn "{{base64:#toBase64( arguments.sql )#}}" />
+<cffunction name="deObfuscateSql" access="public" returntype="any" output="false">
+	<cfreturn getSingleton( "sqlRunner" ).deObfuscateSql( argumentCollection=arguments ) />
 </cffunction>

--- a/system/services/PresideSuperClass.cfc
+++ b/system/services/PresideSuperClass.cfc
@@ -30,6 +30,7 @@ component displayName="Preside Super Class" {
 	 * @i18n.inject                       delayedInjector:i18n
 	 * @htmlHelper.inject                 delayedInjector:HTMLHelper@coldbox
 	 * @healthcheckService.inject         delayedInjector:healthcheckService
+	 * @sqlRunner.inject                  delayedInjector:sqlRunner
 	 * @presideHelperClass.inject         presideHelperClass
 	 *
 	 */
@@ -56,6 +57,7 @@ component displayName="Preside Super Class" {
 		, required any i18n
 		, required any htmlHelper
 		, required any healthcheckService
+		, required any sqlRunner
 		, required any presideHelperClass
 	) {
 		$presideObjectService       = arguments.presideObjectService;
@@ -80,13 +82,14 @@ component displayName="Preside Super Class" {
 		$i18n                       = arguments.i18n;
 		$htmlHelper                 = arguments.htmlHelper;
 		$healthcheckService         = arguments.healthcheckService;
+		$sqlRunner                  = arguments.sqlRunner;
 
 		this.$helpers = arguments.presideHelperClass;
 
 		return this;
 	}
 
-// PRESIDE OBJECTS
+// PRESIDE OBJECTS & DB THINGS
 	/**
 	 * Returns an instance of the [[api-presideobjectservice]]. For example:
      * \n
@@ -117,6 +120,14 @@ component displayName="Preside Super Class" {
 	 */
 	public any function $getPresideObject() {
 		return $presideObjectService.getObject( argumentCollection=arguments );
+	}
+
+	public string function $obfuscateSqlForPreside() {
+		return $sqlRunner.obfuscateSqlForPreside( argumentCollection=arguments );
+	}
+
+	public string function $deObfuscateSql() {
+		return $sqlRunner.deObfuscateSql( argumentCollection=arguments );
 	}
 
 // SYSTEM CONFIG SERVICE

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -2968,7 +2968,7 @@ component displayName="Preside Object Service" {
 	}
 
 	private string function _removeDynamicElementsFromForeignObjectsCacheKey( required string cacheKey ) {
-		var staticCacheKey = arguments.cacheKey;
+		var staticCacheKey = _getSqlRunner().deObfuscateSql( arguments.cacheKey );
 
 		staticCacheKey = staticCacheKey.reReplaceNoCase( "[0-9a-f]{32}", "", "all" );
 		staticCacheKey = staticCacheKey.reReplaceNoCase( "[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{16}", "", "all" );


### PR DESCRIPTION
Deobfuscate sql from arguments used in cache key before removing dynamic elements.
    
While here, also refactor to make more centralised and sensible placement of the logic that obfuscates and deobfuscates the SQL. + add helpers to preside super class.