### PR TITLE
PRESIDECMS-2510 improve recordcountOnly performance

### DIFF
--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -2019,6 +2019,7 @@ component extends="preside.system.base.AdminHandler" {
 		,          boolean distinct        = true
 		,          boolean forceDistinct   = false
 		,          boolean includeActions  = true
+		,          boolean forceFullCount  = false
 		,          array   extraFilters    = []
 		,          array   searchFields
 

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -2019,7 +2019,6 @@ component extends="preside.system.base.AdminHandler" {
 		,          boolean distinct        = true
 		,          boolean forceDistinct   = false
 		,          boolean includeActions  = true
-		,          boolean forceFullCount  = false
 		,          array   extraFilters    = []
 		,          array   searchFields
 

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -411,10 +411,12 @@ component {
 		,          string  treeViewParent = ""
 		,          boolean distinct       = false
 		,          boolean forceDistinct  = false
+		,          boolean forceFullCount = false
 	) {
 
 		var result = { totalRecords = 0, records = "" };
 		var args   = Duplicate( arguments );
+		var idField = _getPresideObjectService().getIdField( arguments.objectName );
 
 		args.selectFields       = _prepareGridFieldsForSqlSelect( gridFields=arguments.gridFields, objectName=arguments.objectName, draftsEnabled=arguments.draftsEnabled );
 		args.orderBy            = _prepareOrderByForObject( arguments.objectName, arguments.orderBy );
@@ -467,7 +469,7 @@ component {
 				, subQueryAlias  = "childRecords"
 				, subQueryColumn = parentField
 				, joinToTable    = arguments.objectName
-				, joinToColumn   = _getPresideObjectService().getIdField( arguments.objectName )
+				, joinToColumn   = idField
 			} );
 			args.extraFilters.append( { filter={ "#parentField#"=arguments.treeViewParent } } );
 			args.selectFields.append( "Count( childRecords.#parentField# ) as child_count" );
@@ -492,7 +494,16 @@ component {
 		} else if ( dbAdapter.supportsCountOverWindowFunction() ) {
 			result.totalRecords = result.records.recordCount ? result.records._total_recordcount : 0;
 		} else {
-			result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args, recordCountOnly=true, maxRows=0 );
+			args.maxRows  = 0;
+			args.startRow = 1;
+
+			if ( arguments.forceFullCount ) {
+				result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args, recordCountOnly=true );
+			} else {
+				args.selectFields = [ "count( distinct #dbAdapter.escapeEntity( "#arguments.objectName#.#idField#" )# ) as _total_recordcount" ];
+				result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args )._total_recordcount;
+			}
+
 		}
 
 		return result;

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -492,7 +492,7 @@ component {
 		} else if ( dbAdapter.supportsCountOverWindowFunction() ) {
 			result.totalRecords = result.records.recordCount ? result.records._total_recordcount : 0;
 		} else {
-			result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args, recordCountOnly=true, maxRows=0 );
+			result.totalRecords = _getPresideObjectService().selectData( argumentCollection=args, recordCountOnly=true, maxRows=0, startRow=1 );
 		}
 
 		return result;

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -231,6 +231,9 @@ component displayName="Preside Object Service" {
 
 		args.selectFields   = expandHavingClauses( argumentCollection=args );
 		args.selectFields   = parseSelectFields( argumentCollection=args );
+		if ( args.recordCountOnly ) {
+			args.selectFields = simplifySelectFieldsForRecordCount( argumentCollection=args );
+		}
 		args.preparedFilter = _prepareFilter(
 			  argumentCollection = args
 			, adapter            = adapter
@@ -2362,6 +2365,28 @@ component displayName="Preside Object Service" {
 		_announceInterception( "postParseSelectFields", arguments );
 
 		return fields;
+	}
+
+	public array function simplifySelectFieldsForRecordCount(
+		  required string  objectName
+		, required array   selectFields
+		,          string  groupBy     = ""
+		,          boolean autoGroupBy = false
+	) {
+		if ( Len( Trim( arguments.groupBy ) ) ) {
+			return ListToArray( arguments.groupBy, ", " );
+		}
+
+		if ( arguments.autoGroupBy ) {
+			var aggregateRegex = "(group_concat|avg|corr|count|count|covar_pop|covar_samp|cume_dist|dense_rank|min|max|percent_rank|percentile_cont|percentile_disc|rank|regr_avgx|regr_avgy|regr_count|regr_intercept|regr_r2|regr_slope|regr_sxx|regr_sxy|regr_syy|stddev_pop|stddev_samp|sum|var_pop|var_sam)\s?\(";
+			for( var i=ArrayLen( arguments.selectFields ); i>0; i-- ) {
+				if ( ReFindNoCase( aggregateRegex, arguments.selectFields[ i ] ) ) {
+					ArrayDeleteAt( arguments.selectFields, i );
+				}
+			}
+		}
+
+		return arguments.selectFields;
 	}
 
 	public array function expandHavingClauses(

--- a/tests/integration/api/presideObjects/PresideObjectServiceQuickAndModernTest.cfc
+++ b/tests/integration/api/presideObjects/PresideObjectServiceQuickAndModernTest.cfc
@@ -34,6 +34,42 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 			} );
 		} );
 
+		describe( "simplifySelectFieldsForRecordCount()", function(){
+			it( "should strip out all aggregate select fields that would be grouped by autogroupby", function(){
+				var poService = _getPresideObjectService();
+				var selectFields = [ "id", "name", "count( distinct send_logs.id ) as send_log_count", "group_concat( send_logs.id ) as logIds", "sum( send_logs.click_count ) as total_clicks" ]
+
+				expect( poService.simplifySelectFieldsForRecordCount(
+					  objectName   = "email_template"
+					, autoGroupBy  = true
+					, selectFields = selectFields
+				) ).toBe( [ "id", "name"] );
+
+			} );
+
+			it( "should use the group by argument when it is set", function(){
+				var poService = _getPresideObjectService();
+				var selectFields = [ "id", "name", "datecreated", "count( distinct send_logs.id ) as send_log_count", "group_concat( send_logs.id ) as logIds", "sum( send_logs.click_count ) as total_clicks" ]
+
+				expect( poService.simplifySelectFieldsForRecordCount(
+					  objectName   = "email_template"
+					, selectFields = selectFields
+					, groupBy = "id, name"
+				) ).toBe( [ "id", "name"] );
+			} );
+
+			it( "should do nothing when autogroupby is false and groupby is not set", function(){
+				var poService = _getPresideObjectService();
+				var selectFields = [ "id", "name", "datecreated", "count( distinct send_logs.id ) as send_log_count", "group_concat( send_logs.id ) as logIds", "sum( send_logs.click_count ) as total_clicks" ]
+
+				expect( poService.simplifySelectFieldsForRecordCount(
+					  objectName   = "email_template"
+					, selectFields = selectFields
+					, autoGroupBy = false
+				) ).toBe( selectFields );
+			} );
+		} );
+
 	}
 
 }

--- a/tests/integration/api/presideObjects/PresideObjectServiceTest.cfc
+++ b/tests/integration/api/presideObjects/PresideObjectServiceTest.cfc
@@ -2903,7 +2903,7 @@
 				, getSqlAndParamsOnly = true
 			);
 
-			super.assertEquals( "select count(1) as `record_count` from ( select `obj_a`.`label`, `obj_a`.`id`, `obj_a`.`datecreated`, `obj_a`.`datemodified` from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :bees_count) and (Count( lots_of_bees.id ) = :bees_count_2) ) `original_statement`", result.sql ?: "" );
+			super.assertEquals( "select count(1) as `record_count` from ( select obj_a.id from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :bees_count) and (Count( lots_of_bees.id ) = :bees_count_2) ) `original_statement`", result.sql ?: "" );
 			super.assertEquals( [ { name="bees_count", type="cf_sql_int", value=2 }, { name="bees_count_2", type="cf_sql_int", value=4 } ], result.params ?: [] );
 
 		</cfscript>
@@ -2937,7 +2937,7 @@
 				, formatSqlParams     = true
 			);
 
-			super.assertEquals( "select count(1) as `record_count` from ( select `obj_a`.`label`, `obj_a`.`id`, `obj_a`.`datecreated`, `obj_a`.`datemodified` from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :bees_count) and (Count( lots_of_bees.id ) = :bees_count_2) ) `original_statement`", result.sql ?: "" );
+			super.assertEquals( "select count(1) as `record_count` from ( select obj_a.id from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :bees_count) and (Count( lots_of_bees.id ) = :bees_count_2) ) `original_statement`", result.sql ?: "" );
 			super.assertEquals( { bees_count={ type="cf_sql_int", value=2 }, bees_count_2={ type="cf_sql_int", value=4 } }, result.params ?: {} );
 
 		</cfscript>
@@ -2971,7 +2971,7 @@
 				, sqlAndParamsPrefix  = "test_prefix__"
 			);
 
-			super.assertEquals( "select count(1) as `record_count` from ( select `obj_a`.`label`, `obj_a`.`id`, `obj_a`.`datecreated`, `obj_a`.`datemodified` from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :test_prefix__bees_count) and (Count( lots_of_bees.id ) = :test_prefix__bees_count_2) ) `original_statement`", result.sql ?: "" );
+			super.assertEquals( "select count(1) as `record_count` from ( select obj_a.id from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :test_prefix__bees_count) and (Count( lots_of_bees.id ) = :test_prefix__bees_count_2) ) `original_statement`", result.sql ?: "" );
 			super.assertEquals( [ { name="test_prefix__bees_count", type="cf_sql_int", value=2 }, { name="test_prefix__bees_count_2", type="cf_sql_int", value=4 } ], result.params ?: [] );
 
 		</cfscript>
@@ -3006,7 +3006,7 @@
 				, sqlAndParamsPrefix  = "test_prefix__"
 			);
 
-			super.assertEquals( "select count(1) as `record_count` from ( select `obj_a`.`label`, `obj_a`.`id`, `obj_a`.`datecreated`, `obj_a`.`datemodified` from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :test_prefix__bees_count) and (Count( lots_of_bees.id ) = :test_prefix__bees_count_2) ) `original_statement`", result.sql ?: "" );
+			super.assertEquals( "select count(1) as `record_count` from ( select obj_a.id from `ptest_obj_a` `obj_a` left join `ptest_obj_a__join__obj_b` `obj_a__join__obj_b` on (`obj_a__join__obj_b`.`obj_a` = `obj_a`.`id`) left join `ptest_obj_b` `lots_of_bees` on (`lots_of_bees`.`id` = `obj_a__join__obj_b`.`obj_b`) group by obj_a.id having (Count( lots_of_bees.id ) >= :test_prefix__bees_count) and (Count( lots_of_bees.id ) = :test_prefix__bees_count_2) ) `original_statement`", result.sql ?: "" );
 			super.assertEquals( { test_prefix__bees_count={ type="cf_sql_int", value=2 }, test_prefix__bees_count_2={ type="cf_sql_int", value=4 } }, result.params ?: {} );
 
 		</cfscript>


### PR DESCRIPTION
Especially in grid fields where we always just pass all the gridfields as selectfields in the recordCountOnly query.

What we can and should do is strip out any fields that would not be included in a groupBy list. This avoids joining on one-to-many relationships to calculate counts and other aggregates when the results of these aggregates are not used and do not contribute any difference to the overall recordcount.