### PR TITLE
PRESIDECMS-2517 Micro optimisations: heavy getObject and getApplicationSettings usage

### DIFF
--- a/system/coldboxModifications/Bootstrap.cfc
+++ b/system/coldboxModifications/Bootstrap.cfc
@@ -314,10 +314,9 @@ component extends="coldbox.system.Bootstrap" {
 	}
 
 	private boolean function areSessionsEnabled() {
-		var appSettings              = getApplicationSettings();
-		var sessionManagement        = IsBoolean( appSettings.sessionManagement        ?: "" ) && appSettings.sessionManagement;
-		var presideSessionManagement = IsBoolean( appSettings.presideSessionManagement ?: "" ) && appSettings.presideSessionManagement;
-		var statelessRequest         = IsBoolean( appSettings.statelessRequest         ?: "" ) && appSettings.statelessRequest;
+		var sessionManagement        = IsBoolean( request._sessionSettings.sessionManagement        ?: "" ) && request._sessionSettings.sessionManagement;
+		var presideSessionManagement = IsBoolean( request._sessionSettings.presideSessionManagement ?: "" ) && request._sessionSettings.presideSessionManagement;
+		var statelessRequest         = IsBoolean( request._sessionSettings.statelessRequest         ?: "" ) && request._sessionSettings.statelessRequest;
 
 		return sessionManagement || ( presideSessionManagement && !statelessRequest );
 	}

--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -655,9 +655,7 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 	}
 
 	public boolean function isStatelessRequest() {
-		var appSettings = GetApplicationSettings();
-
-		return IsBoolean( appSettings.statelessRequest ?: "" ) && appSettings.statelessRequest;
+		return IsBoolean( request._sessionSettings.statelessRequest ?: "" ) && request._sessionSettings.statelessRequest;
 	}
 
 	public void function setXFrameOptionsHeader( string value ) {

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1428,9 +1428,7 @@ component {
 	}
 
 	private boolean function _usePresideSessionManagement() {
-		var applicationSettings = getApplicationSettings();
-
-		return IsBoolean( applicationSettings.presideSessionManagement ?: "" ) && applicationSettings.presideSessionManagement;
+		return IsBoolean( request._sessionSettings.presideSessionManagement ?: "" ) && request._sessionSettings.presideSessionManagement;
 	}
 
 	/**

--- a/system/services/cfmlscopes/SessionStorage.cfc
+++ b/system/services/cfmlscopes/SessionStorage.cfc
@@ -64,9 +64,7 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 				_deleteSessionRecord( currentSessionId );
 			}
 		} else {
-			var appSettings = getApplicationSettings();
-
-			if ( ( appSettings.sessionType ?: "cfml" ) != "j2ee" ) {
+			if ( ( request._sessionSettings.sessionType ?: "cfml" ) != "j2ee" ) {
 				SessionRotate();
 			}
 		}
@@ -146,15 +144,11 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 
 // PRIVATE HELPERS
 	private boolean function _areSessionsEnabled() output=false {
-		var appSettings = getApplicationSettings();
-
-		return IsBoolean( appSettings.sessionManagement ?: "" ) && appSettings.sessionManagement;
+		return IsBoolean( request._sessionSettings.sessionManagement ?: "" ) && request._sessionSettings.sessionManagement;
 	}
 
 	private boolean function _usePresideSessionManagement() output=false {
-		var appSettings = getApplicationSettings();
-
-		return IsBoolean( appSettings.presideSessionManagement ?: "" ) && appSettings.presideSessionManagement;
+		return IsBoolean( request._sessionSettings.presideSessionManagement ?: "" ) && request._sessionSettings.presideSessionManagement;
 	}
 
 	private struct function _createStorage() {
@@ -168,8 +162,7 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 	}
 
 	private numeric function _getSessionTimeoutInSeconds() {
-		var appSettings   = getApplicationSettings();
-		var timeout       = appSettings.sessionTimeout ?: CreateTimeSpan( 0, 0, 20, 0 );
+		var timeout       = request._sessionSettings.sessionTimeout ?: CreateTimeSpan( 0, 0, 20, 0 );
 		var secondsInADay = 86400;
 
 		return Round( Val( timeout ) * secondsInADay );

--- a/system/services/maintenanceMode/MaintenanceModeService.cfc
+++ b/system/services/maintenanceMode/MaintenanceModeService.cfc
@@ -135,17 +135,15 @@ component {
 	}
 
 	private boolean function _areSessionsEnabled() {
-		var appSettings              = getApplicationSettings( true );
-		var sessionManagement        = IsBoolean( appSettings.sessionManagement        ?: "" ) && appSettings.sessionManagement;
-		var presideSessionManagement = IsBoolean( appSettings.presideSessionManagement ?: "" ) && appSettings.presideSessionManagement;
-		var statelessRequest         = IsBoolean( appSettings.statelessRequest         ?: "" ) && appSettings.statelessRequest;
+		var sessionManagement        = IsBoolean( request._sessionSettings.sessionManagement        ?: "" ) && request._sessionSettings.sessionManagement;
+		var presideSessionManagement = IsBoolean( request._sessionSettings.presideSessionManagement ?: "" ) && request._sessionSettings.presideSessionManagement;
+		var statelessRequest         = IsBoolean( request._sessionSettings.statelessRequest         ?: "" ) && request._sessionSettings.statelessRequest;
 
 		return sessionManagement || ( presideSessionManagement && !statelessRequest );
 	}
 
 	private boolean function _areLuceeSessionsEnabled() {
-		var appSettings       = getApplicationSettings( true );
-		var sessionManagement = IsBoolean( appSettings.sessionManagement ?: "" ) && appSettings.sessionManagement;
+		var sessionManagement = IsBoolean( request._sessionSettings.sessionManagement ?: "" ) && request._sessionSettings.sessionManagement;
 
 		return sessionManagement;
 	}

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -4039,10 +4039,12 @@ component displayName="Preside Object Service" {
 		var newArgs = {};
 
 		for( var key in arguments.args ) {
-			if ( IsSimpleValue( arguments.args[ key ] ) || IsObject( arguments.args[ key ] ) ) {
-				newArgs[ key ] = arguments.args[ key ];
-			} else {
+			if ( IsNull( arguments.args[ key ] ) ){
+				continue;
+			} else if ( IsStruct( arguments.args[ key ] ) || IsArray( arguments.args[ key ] ) ) {
 				newArgs[ key ] = Duplicate( arguments.args[ key ] );
+			} else {
+				newArgs[ key ] = arguments.args[ key ];
 			}
 		}
 

--- a/system/services/websiteUsers/WebsiteUserActionService.cfc
+++ b/system/services/websiteUsers/WebsiteUserActionService.cfc
@@ -381,10 +381,9 @@ component displayName="Website user action service" {
 
 // PRIVATE HELPERS
 	private boolean function _sessionsAreEnabled() {
-		var appSettings              = getApplicationSettings( true );
-		var sessionManagement        = IsBoolean( appSettings.sessionManagement        ?: "" ) && appSettings.sessionManagement;
-		var presideSessionManagement = IsBoolean( appSettings.presideSessionManagement ?: "" ) && appSettings.presideSessionManagement;
-		var statelessRequest         = IsBoolean( appSettings.statelessRequest         ?: "" ) && appSettings.statelessRequest;
+		var sessionManagement        = IsBoolean( request._sessionSettings.sessionManagement        ?: "" ) && request._sessionSettings.sessionManagement;
+		var presideSessionManagement = IsBoolean( request._sessionSettings.presideSessionManagement ?: "" ) && request._sessionSettings.presideSessionManagement;
+		var statelessRequest         = IsBoolean( request._sessionSettings.statelessRequest         ?: "" ) && request._sessionSettings.statelessRequest;
 
 		return sessionManagement || ( presideSessionManagement && !statelessRequest );
 	}

--- a/system/services/websiteUsers/WebsiteVisitorService.cfc
+++ b/system/services/websiteUsers/WebsiteVisitorService.cfc
@@ -64,10 +64,9 @@ component displayName="Website visitor service" {
 
 // PRIVATE HELPERS
 	private boolean function _sessionsAreEnabled() {
-		var appSettings              = getApplicationSettings( true );
-		var sessionManagement        = IsBoolean( appSettings.sessionManagement        ?: "" ) && appSettings.sessionManagement;
-		var presideSessionManagement = IsBoolean( appSettings.presideSessionManagement ?: "" ) && appSettings.presideSessionManagement;
-		var statelessRequest         = IsBoolean( appSettings.statelessRequest         ?: "" ) && appSettings.statelessRequest;
+		var sessionManagement        = IsBoolean( request._sessionSettings.sessionManagement        ?: "" ) && request._sessionSettings.sessionManagement;
+		var presideSessionManagement = IsBoolean( request._sessionSettings.presideSessionManagement ?: "" ) && request._sessionSettings.presideSessionManagement;
+		var statelessRequest         = IsBoolean( request._sessionSettings.statelessRequest         ?: "" ) && request._sessionSettings.statelessRequest;
 
 		return sessionManagement || ( presideSessionManagement && !statelessRequest );
 	}

--- a/tests/integration/api/websiteUsers/WebsiteUserActionServiceTest.cfc
+++ b/tests/integration/api/websiteUsers/WebsiteUserActionServiceTest.cfc
@@ -27,7 +27,8 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 					, identifier = identifier
 				} ).$results( dbId );
 
-				service.$( "_getSessionId", sessionId )
+				service.$( "_sessionsAreEnabled", true );
+				service.$( "_getSessionId", sessionId );
 
 				var mockRc = CreateStub();
 				service.$( "$getRequestContext", mockRc );


### PR DESCRIPTION
Eliminate particularly unnecessary uses of `getObject()` and `getApplicationSetitngs()` that are leading to wasted cpu cycles.