### PR TITLE
PRESIDECMS-2560 Allow extensions to easily provide cachebox definitions

### DIFF
--- a/system/config/Cachebox.cfc
+++ b/system/config/Cachebox.cfc
@@ -165,5 +165,23 @@ component {
 				}
 			}
 		};
+
+		_configureExtensions();
+	}
+
+// PRIVATE HELPERS
+	private function _configureExtensions() {
+		var extensions     = application.activeExtensions ?: [];
+		var appMappingPath = application.appMappingPath   ?: "app";
+
+		for( var ext in extensions ) {
+			var cacheboxConfigFile = ReReplace( ext.directory, "/$", "" ) & "/config/Cachebox.cfc";
+
+			if ( FileExists( cacheboxConfigFile ) ) {
+				var mappedPath = appMappingPath & ".extensions.#ListLast( ext.directory, '\/' )#.config.Cachebox";
+
+				CreateObject( "component", mappedPath ).configure( cachebox );
+			}
+		}
 	}
 }

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -61,13 +61,13 @@ component {
 	}
 
 	private void function __setupMappings() {
-		settings.appMapping    = ( request._presideMappings.appMapping ?: "app" ).reReplace( "^/", "" );
-		settings.assetsMapping = request._presideMappings.assetsMapping ?: "/assets";
-		settings.logsMapping   = request._presideMappings.logsMapping   ?: "/logs";
+		settings.appMapping    = application.appMapping    = ( request._presideMappings.appMapping ?: "app" ).reReplace( "^/", "" );
+		settings.assetsMapping = application.assetsMapping = request._presideMappings.assetsMapping ?: "/assets";
+		settings.logsMapping   = application.logsMapping   = request._presideMappings.logsMapping   ?: "/logs";
 
-		settings.appMappingPath    = Replace( settings.appMapping, "/", ".", "all" );
-		settings.assetsMappingPath = Replace( ReReplace( settings.assetsMapping, "^/", "" ), "/", ".", "all" );
-		settings.logsMappingPath   = Replace( ReReplace( settings.logsMapping  , "^/", "" ), "/", ".", "all" );
+		settings.appMappingPath    = application.appMappingPath    = Replace( settings.appMapping, "/", ".", "all" );
+		settings.assetsMappingPath = application.assetsMappingPath = Replace( ReReplace( settings.assetsMapping, "^/", "" ), "/", ".", "all" );
+		settings.logsMappingPath   = application.logsMappingPath   = Replace( ReReplace( settings.logsMapping  , "^/", "" ), "/", ".", "all" );
 	}
 
 	private void function __setupExtensions() {
@@ -80,7 +80,7 @@ component {
 			, "preside-ext-db-perf-enhancements"
 		];
 
-		settings.activeExtensions = new preside.system.services.devtools.ExtensionManagerService(
+		settings.activeExtensions = application.activeExtensions = new preside.system.services.devtools.ExtensionManagerService(
 			  appMapping       = settings.appMapping
 			, ignoreExtensions = settings.legacyExtensionsNowInCore
 		).listExtensions();


### PR DESCRIPTION
This works in the same way as Wirebox works in extensions. With this change, extensions can provide a file `/my-extension/config/Cachebox.cfc` and use it like so:

```cfc
component {

    function configure( required struct cachebox ) {
        arguments.cachebox.caches.myExtensionSpecificCache = { /* ... */ };
    }

}
```