### PR TITLE
PRESIDECMS-2489 Refactor auto formula field filter expressions

### DIFF
--- a/system/handlers/rules/dynamic/presideObjectExpressions/BooleanFormulaPropertyIsTrue.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/BooleanFormulaPropertyIsTrue.cfc
@@ -5,7 +5,8 @@
  */
 component extends="preside.system.base.AutoObjectExpressionHandler" {
 
-	property name="presideObjectService" inject="presideObjectService";
+	property name="presideObjectService"     inject="presideObjectService";
+	property name="rulesEngineFilterService" inject="rulesEngineFilterService";
 
 	private boolean function evaluateExpression(
 		  required string  objectName
@@ -24,14 +25,14 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		, required string  propertyName
 		,          boolean _is = true
 	){
-		var paramName           = "booleanFormulaPropertyIsTrue" & CreateUUId().lCase().replace( "-", "", "all" );
-		var formulaPropertyName = "#arguments.objectName#.#propertyName#";
+		var paramName = "booleanFormulaPropertyIsTrue" & CreateUUId().lCase().replace( "-", "", "all" );
 
-		return [ {
-			  having       = "#formulaPropertyName# = :#paramName#"
-			, filterParams = { "#paramName#" = { value=arguments._is, type="cf_sql_boolean" } }
-			, propertyName = formulaPropertyName
-		} ];
+		return [ rulesEngineFilterService.prepareAutoFormulaFilter(
+			  objectName   = arguments.objectName
+			, propertyName = arguments.propertyName
+			, filter       = "#arguments.propertyName# = :#paramName#"
+			, filterParams = { "#paramName#" ={ type="cf_sql_boolean", value=arguments._is }}
+		) ];
 	}
 
 	private string function getLabel(

--- a/system/handlers/rules/dynamic/presideObjectExpressions/DateFormulaPropertyInRange.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/DateFormulaPropertyInRange.cfc
@@ -42,12 +42,16 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 			params[ toParam ] = { value=_time.to, type="cf_sql_timestamp" };
 		}
 
-		return [ rulesEngineFilterService.prepareAutoFormulaFilter(
-			  objectName   = arguments.objectName
-			, propertyName = arguments.propertyName
-			, filter       = filter
-			, filterParams = params
-		) ];
+		if ( Len( filter ) ) {
+			return [ rulesEngineFilterService.prepareAutoFormulaFilter(
+				  objectName   = arguments.objectName
+				, propertyName = arguments.propertyName
+				, filter       = filter
+				, filterParams = params
+			) ];
+		}
+
+		return [];
 	}
 
 	private string function getLabel(

--- a/system/handlers/rules/dynamic/presideObjectExpressions/EnumFormulaPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/EnumFormulaPropertyMatches.cfc
@@ -5,7 +5,8 @@
  */
 component extends="preside.system.base.AutoObjectExpressionHandler" {
 
-	property name="presideObjectService" inject="presideObjectService";
+	property name="presideObjectService"     inject="presideObjectService";
+	property name="rulesEngineFilterService" inject="rulesEngineFilterService";
 
 	private boolean function evaluateExpression(
 		  required string  objectName
@@ -27,16 +28,13 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  enumValue    = ""
 	){
 		var paramName = "enumFormulaPropertyMatches" & CreateUUId().lCase().replace( "-", "", "all" );
-		var filterSql = "#arguments.propertyName# ${operator} (:#paramName#)";
-		var params    = { "#paramName#"={ value=arguments.enumValue, type="cf_sql_varchar", list=true } };
 
-		if ( _is ) {
-			filterSql = filterSql.replace( "${operator}", "in" );
-		} else {
-			filterSql = filterSql.replace( "${operator}", "not in" );
-		}
-
-		return [ { filterParams=params, having=filterSql, propertyName="#arguments.objectName#.#arguments.propertyName#" } ];
+		return [ rulesEngineFilterService.prepareAutoFormulaFilter(
+			  objectName   = arguments.objectName
+			, propertyName = arguments.propertyName
+			, filter       = "#arguments.propertyName# #( arguments._is ? 'in' : 'not in' )# (:#paramName#)"
+			, filterParams = { "#paramName#"={ value=arguments.enumValue, type="cf_sql_varchar", list=true } }
+		) ];
 	}
 
 	private string function getLabel(

--- a/system/handlers/rules/dynamic/presideObjectExpressions/NumericFormulaPropertyCompares.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/NumericFormulaPropertyCompares.cfc
@@ -5,7 +5,8 @@
  */
 component extends="preside.system.base.AutoObjectExpressionHandler" {
 
-	property name="presideObjectService" inject="presideObjectService";
+	property name="presideObjectService"     inject="presideObjectService";
+	property name="rulesEngineFilterService" inject="rulesEngineFilterService";
 
 	private boolean function evaluateExpression(
 		  required string  objectName
@@ -26,10 +27,8 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  _numericOperator = "eq"
 		,          numeric value            = 0
 	){
-		var paramName           = "numericFormulaPropertyCompares" & CreateUUId().lCase().replace( "-", "", "all" );
-		var formulaPropertyName = "#arguments.objectName#.#propertyName#";
-		var filterSql           = "#formulaPropertyName# ${operator} :#paramName#";
-		var params              = { "#paramName#" = { value=arguments.value, type="cf_sql_number" } };
+		var paramName = "numericFormulaPropertyCompares" & CreateUUId().lCase().replace( "-", "", "all" );
+		var filterSql = "#arguments.propertyName# ${operator} :#paramName#";
 
 		switch ( _numericOperator ) {
 			case "eq":
@@ -52,7 +51,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 			break;
 		}
 
-		return [ { filterParams=params, having=filterSql, propertyName=formulaPropertyName } ];
+		return [ rulesEngineFilterService.prepareAutoFormulaFilter(
+			  objectName   = arguments.objectName
+			, propertyName = arguments.propertyName
+			, filter       = filterSql
+			, filterParams = { "#paramName#" = { value=arguments.value, type="cf_sql_number" } }
+		) ];
 	}
 
 	private string function getLabel(

--- a/system/handlers/rules/dynamic/presideObjectExpressions/TextFormulaPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/TextFormulaPropertyMatches.cfc
@@ -4,7 +4,9 @@
  *
  */
 component extends="preside.system.base.AutoObjectExpressionHandler" {
-	property name="presideObjectService" inject="presideObjectService";
+
+	property name="presideObjectService"     inject="presideObjectService";
+	property name="rulesEngineFilterService" inject="rulesEngineFilterService";
 
 	private boolean function evaluateExpression(
 		  required string  objectName
@@ -25,10 +27,9 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	){
-		var paramName           = "textFormulaPropertyMatches" & CreateUUId().lCase().replace( "-", "", "all" );
-		var formulaPropertyName = "#arguments.objectName#.#propertyName#";
-		var filterSql           = "#formulaPropertyName# ${operator} :#paramName#";
-		var params              = { "#paramName#" = { value=arguments.value, type="cf_sql_varchar" } };
+		var paramName = "textFormulaPropertyMatches" & CreateUUId().lCase().replace( "-", "", "all" );
+		var filterSql = "#arguments.propertyName# ${operator} :#paramName#";
+		var params    = { "#paramName#" = { value=arguments.value, type="cf_sql_varchar" } };
 
 		switch ( _stringOperator ) {
 			case "eq":
@@ -63,7 +64,12 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 			break;
 		}
 
-		return [ { having=filterSql, filterParams=params, propertyName=formulaPropertyName } ];
+		return [ rulesEngineFilterService.prepareAutoFormulaFilter(
+			  objectName   = arguments.objectName
+			, propertyName = arguments.propertyName
+			, filter       = filterSql
+			, filterParams = params
+		) ];
 	}
 
 	private string function getLabel(

--- a/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
+++ b/system/services/rulesEngine/RulesEngineAutoPresideObjectExpressionGenerator.cfc
@@ -64,6 +64,10 @@ component {
 		var isFormula    = Len( Trim( propertyDefinition.formula ?: "" ) );
 		var excludedKeys = listToArray( propertyDefinition.excludeAutoExpressions ?: "" );
 
+		if ( isFormula && !Len( $getPresideObjectService().getIdField( arguments.objectName ) ) ) {
+			return [];
+		}
+
 		if ( !isRequired && !( [ "many-to-many", "one-to-many" ] ).findNoCase( relationship ) && !isFormula ) {
 			switch( propType ) {
 				case "string":


### PR DESCRIPTION
Use exists() subqueries so that any having clauses and/or aggregates with joins have no effect on the parent query. This keeps the filters consistent and flexible as per the other refactored auto filters that do joins.