### PR TITLE
PRESIDECMS-2663 better dynamic find and replace

### DIFF
--- a/system/services/rendering/ContentRendererService.cfc
+++ b/system/services/rendering/ContentRendererService.cfc
@@ -411,7 +411,7 @@ component {
 	}
 
 	public string function renderEmbeddedWidgets( required string richContent, string context="", string postProcessor="", struct postProcessorArgs={} ) {
-		var widgetPattern = "\{\{widget:([a-z\$_][a-z0-9\$_]*):(.*?):widget\}\}";
+		var widgetPattern = "\{\{widget:([a-zA-Z\$_][a-zA-Z0-9\$_]*):(.*?):widget\}\}";
 		var outerargs     = arguments;
 
 		return _getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.richContent, regexPattern=widgetPattern, recurse=true, processor=function( captureGroups ){

--- a/system/services/rendering/ContentRendererService.cfc
+++ b/system/services/rendering/ContentRendererService.cfc
@@ -8,12 +8,13 @@ component {
 // CONSTRUCTOR
 
 	/**
-	 * @coldbox.inject              coldbox
-	 * @assetRendererService.inject AssetRendererService
-	 * @widgetsService.inject       WidgetsService
-	 * @presideObjectService.inject PresideObjectService
-	 * @labelRendererService.inject labelRendererService
-	 * @renderedAssetCache.inject   cachebox:renderedAssetCache
+	 * @coldbox.inject                      coldbox
+	 * @assetRendererService.inject         AssetRendererService
+	 * @widgetsService.inject               WidgetsService
+	 * @presideObjectService.inject         PresideObjectService
+	 * @labelRendererService.inject         labelRendererService
+	 * @renderedAssetCache.inject           cachebox:renderedAssetCache
+	 * @dynamicFindAndReplaceService.inject dynamicFindAndReplaceService
 	 */
 	public any function init(
 		  required any coldbox
@@ -22,6 +23,7 @@ component {
 		, required any presideObjectService
 		, required any labelRendererService
 		, required any renderedAssetCache
+		, required any dynamicFindAndReplaceService
 	) {
 		_setColdbox( arguments.coldbox );
 		_setAssetRendererService( arguments.assetRendererService );
@@ -29,6 +31,7 @@ component {
 		_setPresideObjectService( arguments.presideObjectService );
 		_setLabelRendererService( arguments.labelRendererService );
 		_setRenderedAssetCache( arguments.renderedAssetCache );
+		_setDynamicFindAndReplaceService( arguments.dynamicFindAndReplaceService );
 
 		_setCache( {} );
 		_setRenderers( {} );
@@ -299,98 +302,103 @@ component {
 	}
 
 	public string function renderEmbeddedImages( required string richContent, string context="richeditor", string postProcessor="", struct postProcessorArgs={} ) {
-		var embeddedImage   = "";
-		var renderedImage   = "";
-		var renderedContent = arguments.richContent;
+		var imgpattern = "\{\{image:(.*?):image\}\}";
+		var outerargs  = arguments;
 
-		do {
-			embeddedImage = _findNextEmbeddedImage( renderedContent );
+		return _getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.richContent, regexPattern=imgPattern, recurse=false, processor=function( captureGroups ){
+			var img    = { placeholder=arguments.captureGroups[ 1 ] ?: "" };
+			var config = UrlDecode( arguments.captureGroups[ 2 ] ?: "" );
 
-			if ( Len( Trim( embeddedImage.asset ?: "" ) ) && Len( Trim( embeddedImage.placeholder ?: "" ) ) ) {
-				var cacheKey = "asset-#embeddedImage.asset#-" & Serialize( embeddedImage );
+			try {
+				config = DeserializeJson( config );
+				StructAppend( img, config );
+			} catch( any e ){};
 
-				renderedImage = _getRenderedAssetCache().get( cacheKey );
+			if ( Len( Trim( img.asset ?: "" ) ) && Len( Trim( img.placeholder ?: "" ) ) ) {
+				var cacheKey = "asset-#img.asset#-" & Serialize( img );
+				var renderedImage = _getRenderedAssetCache().get( cacheKey );
 
 				if ( IsNull( renderedImage ) ) {
-					var args       = Duplicate( embeddedImage );
+					var args       = StructCopy( img );
 					var derivative = args.derivative ?: "";
 
-					args.delete( "asset" );
-					args.delete( "placeholder" );
-					args.delete( "derivative" );
+					StructDelete( args, "asset" );
+					StructDelete( args, "placeholder" );
+					StructDelete( args, "derivative" );
 
 					if( Len( Trim( derivative ) ) && derivative NEQ "none" ){
-						args.delete( "width" );
-						args.delete( "height" );
-						args.delete( "quality" );
-						args.delete( "dimensions" );
+						StructDelete( args, "width" );
+						StructDelete( args, "height" );
+						StructDelete( args, "quality" );
+						StructDelete( args, "dimensions" );
 
 						args.derivative = derivative;
 					}
 
 					renderedImage = _getAssetRendererService().renderAsset(
-						  assetId = embeddedImage.asset
-						, context = arguments.context
+						  assetId = img.asset
+						, context = outerargs.context
 						, args    = args
 					);
 
 					_getRenderedAssetCache().set( cacheKey, renderedImage );
 				}
 
-				if ( Len( Trim( postProcessor ) ) ) {
-					postProcessorArgs.html = renderedImage;
+				if ( Len( Trim( outerargs.postProcessor ) ) ) {
+					outerargs.postProcessorArgs.html = renderedImage;
 					renderedImage = $runEvent(
-						  event          = postProcessor
-						, eventArguments = { args=postProcessorArgs }
+						  event          = outerargs.postProcessor
+						, eventArguments = { args=outerargs.postProcessorArgs }
 						, private        = true
 						, prepostExempt  = true
 					);
 				}
 
-				renderedContent = Replace( renderedContent, embeddedImage.placeholder, renderedImage, "all" );
+				return renderedImage;
 			}
-
-		} while ( StructCount( embeddedImage ) );
-
-		return renderedContent;
+			return "";
+		} );
 	}
 
 	public string function renderEmbeddedAttachments( required string richContent, string context="richeditor", string postProcessor="", struct postProcessorArgs={} ) {
-		var embeddedAttachment   = "";
-		var renderedAttachment   = "";
-		var renderedContent = arguments.richContent;
+		var attachPattern = "\{\{attachment:(.*?):attachment\}\}";
+		var outerargs  = arguments;
 
-		do {
-			embeddedAttachment = _findNextEmbeddedAttachment( renderedContent );
+		return _getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.richContent, regexPattern=attachPattern, recurse=false, processor=function( captureGroups ){
+			var embeddedAttachment = "";
 
-			if ( Len( Trim( embeddedAttachment.asset ?: "" ) ) && Len( Trim( embeddedAttachment.placeholder ?: "" ) ) ) {
-				var args = Duplicate( embeddedAttachment );
+			try {
+				embeddedAttachment = DeserializeJson( UrlDecode( arguments.captureGroups[ 2 ] ?: "" ) );
+			} catch ( any e ) {
+				return "";
+			}
 
-				args.delete( "asset" );
-				args.delete( "placeholder" );
+			if ( Len( Trim( embeddedAttachment.asset ?: "" ) ) ) {
+				var args = StructCopy( embeddedAttachment );
 
-				renderedAttachment = _getAssetRendererService().renderAsset(
+				StructDelete( args, "asset" );
+
+				var renderedAttachment = _getAssetRendererService().renderAsset(
 					  assetId = embeddedAttachment.asset
-					, context = arguments.context
+					, context = outerargs.context
 					, args    = args
 				);
 
-				if ( Len( Trim( postProcessor ) ) ) {
-					postProcessorArgs.html = renderedAttachment;
+				if ( Len( Trim( outerargs.postProcessor ) ) ) {
+					outerargs.postProcessorArgs.html = renderedAttachment;
 					renderedAttachment = $runEvent(
-						  event          = postProcessor
-						, eventArguments = { args=postProcessorArgs }
+						  event          = outerargs.postProcessor
+						, eventArguments = { args=outerargs.postProcessorArgs }
 						, private        = true
 						, prepostExempt  = true
 					);
 				}
 
-				renderedContent = Replace( renderedContent, embeddedAttachment.placeholder, renderedAttachment, "all" );
+				return renderedAttachment;
 			}
 
-		} while ( StructCount( embeddedAttachment ) );
-
-		return renderedContent;
+			return "";
+		} );
 	}
 
 	public void function renderCodeHighlighterIncludes( required string richContent, string context="richeditor" ) {
@@ -403,83 +411,86 @@ component {
 	}
 
 	public string function renderEmbeddedWidgets( required string richContent, string context="", string postProcessor="", struct postProcessorArgs={} ) {
-		var embeddedWidget      = "";
-		var renderedWidget      = "";
-		var renderedContent = arguments.richContent;
+		var widgetPattern = "\{\{widget:([a-z\$_][a-z0-9\$_]*):(.*?):widget\}\}";
+		var outerargs     = arguments;
 
-		do {
-			embeddedWidget = _findNextEmbeddedWidget( renderedContent );
+		return _getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.richContent, regexPattern=widgetPattern, recurse=true, processor=function( captureGroups ){
+			var embeddedWidget = {
+				  id          = arguments.captureGroups[ 2 ] ?: ""
+				, configJson  = arguments.captureGroups[ 3 ] ?: ""
+			};
 
-			if ( StructCount( embeddedWidget ) ) {
-				renderedWidget = _getWidgetsService().renderWidget(
+			if ( Len( embeddedWidget.id ) ) {
+				var renderedWidget = _getWidgetsService().renderWidget(
 					  widgetId   = embeddedWidget.id
 					, configJson = embeddedWidget.configJson
-					, context    = arguments.context
+					, context    = outerargs.context
 				);
 
-				if ( Len( Trim( postProcessor ) ) ) {
-					postProcessorArgs.html = renderedWidget;
+				if ( Len( Trim( outerargs.postProcessor ) ) ) {
+					outerargs.postProcessorArgs.html = renderedWidget;
 					renderedWidget = $runEvent(
-						  event          = postProcessor
-						, eventArguments = { args=postProcessorArgs }
+						  event          = outerargs.postProcessor
+						, eventArguments = { args=outerargs.postProcessorArgs }
 						, private        = true
 						, prepostExempt  = true
 					);
 				}
 
-				renderedContent = Replace( renderedContent, embeddedWidget.placeholder, renderedWidget, "all" );
+				return renderedWidget;
 			}
 
-		} while ( StructCount( embeddedWidget ) );
-
-		return renderedContent;
+			return "";
+		} );
 	}
 
 	public string function renderEmbeddedLinks( required string richContent, string postProcessor="", struct postProcessorArgs={} ) {
-		var renderedContent = arguments.richContent;
-		var embeddedLink    = "";
-		var renderedLink    = "";
+		var linkPattern = "\{\{(link|asset|custom):(.*?):(link|asset|custom)\}\}";
+		var outerargs  = arguments;
 
-		do {
-			embeddedLink = _findNextEmbeddedLink( renderedContent );
+		return _getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.richContent, regexPattern=linkPattern, recurse=false, processor=function( captureGroups ){
+			var renderedLink = "";
+			var linkContent = arguments.captureGroups[ 3 ] ?: "";
+			var type = arguments.captureGroups[ 2 ] ?: "";
+			    type = type == "link" ? "page" : type;
 
-			if ( Len( Trim( embeddedLink.page ?: "" ) ) ) {
-				renderedLink = _getColdbox().getRequestContext().buildLink( page=embeddedLink.page );
-			}
-			if ( Len( Trim( embeddedLink.asset ?: "" ) ) ) {
-				renderedLink = _getColdbox().getRequestContext().buildLink( assetId=embeddedLink.asset );
-			}
-			if ( Len( Trim( embeddedLink.custom ?: "" ) ) ) {
-				try {
-					var linkDetails = DeserializeJson( toString( toBinary( embeddedLink.custom ) ) );
-					var linkType    = linkDetails.type ?: "";
+			switch( type ) {
+				case "page":
+					renderedLink = _getColdbox().getRequestContext().buildLink( page=linkContent );
+				break;
+				case "asset":
+					renderedLink = _getColdbox().getRequestContext().buildLink( assetId=linkContent );
+				break;
+				case "custom":
+					try {
+						var linkDetails = DeserializeJson( toString( toBinary( linkContent ) ) );
+						var linkType    = linkDetails.type ?: "";
 
-					if ( Len( Trim( linkType ) ) ) {
-						try {
-							renderedLink = _getColdbox().renderViewlet( event="admin.linkpicker.#linkType#.getHref", args=linkDetails );
-						} catch( any e ) {}
-					} else {
-						renderedLink = _getColdbox().getRequestContext().buildLink( argumentCollection=linkDetails );
-					}
-				} catch( any e ) {}
-			}
-
-			if ( Len( Trim( embeddedLink.placeholder ?: "" ) ) ) {
-				if ( Len( Trim( postProcessor ) ) ) {
-					postProcessorArgs.html = renderedLink;
-					renderedLink = $runEvent(
-						  event          = postProcessor
-						, eventArguments = { args=postProcessorArgs }
-						, private        = true
-						, prepostExempt  = true
-					);
-				}
-				renderedContent = Replace( renderedContent, embeddedLink.placeholder, renderedLink, "all" );
+						if ( Len( Trim( linkType ) ) ) {
+							try {
+								renderedLink = _getColdbox().renderViewlet( event="admin.linkpicker.#linkType#.getHref", args=linkDetails );
+							} catch( any e ) {}
+						} else {
+							renderedLink = _getColdbox().getRequestContext().buildLink( argumentCollection=linkDetails );
+						}
+					} catch( any e ) {}
+				break;
+				default:
+					renderedLink = linkContent;
 			}
 
-		} while ( StructCount( embeddedLink ) );
+			if ( Len( Trim( renderedLink ) ) && Len( Trim( outerargs.postProcessor ) ) ) {
+				outerargs.postProcessorArgs.html = renderedLink;
+				renderedLink = $runEvent(
+					  event          = outerargs.postProcessor
+					, eventArguments = { args=outerargs.postProcessorArgs }
+					, private        = true
+					, prepostExempt  = true
+				);
+			}
 
-		return renderedContent;
+			return renderedLink;
+		} );
 	}
 
 // PRIVATE HELPERS
@@ -585,95 +596,6 @@ component {
 		return cache[ cacheKey ];
 	}
 
-	private struct function _findNextEmbeddedImage( required string richContent ) {
-		// The following regex is designed to match the following pattern that would be embedded in rich editor content:
-		// {{image:{asset:"assetId",option:"value",option2:"value"}:image}}
-
-
-		var regex  = "{{image:(.*?):image}}";
-		var match  = ReFindNoCase( regex, arguments.richContent, 1, true );
-		var img    = {};
-		var config = "";
-
-		if ( ArrayLen( match.len ) eq 2 and match.len[1] and match.len[2] ) {
-			img.placeHolder = Mid( arguments.richContent, match.pos[1], match.len[1] );
-
-			config = Mid( arguments.richContent, match.pos[2], match.len[2] );
-			config = UrlDecode( config );
-
-			try {
-				config = DeserializeJson( config );
-				StructAppend( img, config );
-			} catch ( any e ) {}
-		}
-
-		return img;
-	}
-
-	private struct function _findNextEmbeddedAttachment( required string richContent ) {
-		// The following regex is designed to match the following pattern that would be embedded in rich editor content:
-		// {{attachment:{asset:"assetId",option:"value",option2:"value"}:attachment}}
-
-
-		var regex      = "{{attachment:(.*?):attachment}}";
-		var match      = ReFindNoCase( regex, arguments.richContent, 1, true );
-		var attachment = {};
-		var config     = "";
-
-		if ( ArrayLen( match.len ) eq 2 and match.len[1] and match.len[2] ) {
-			attachment.placeHolder = Mid( arguments.richContent, match.pos[1], match.len[1] );
-
-			config = Mid( arguments.richContent, match.pos[2], match.len[2] );
-			config = UrlDecode( config );
-
-			try {
-				config = DeserializeJson( config );
-				StructAppend( attachment, config );
-			} catch ( any e ) {}
-		}
-
-		return attachment;
-	}
-
-	private struct function _findNextEmbeddedWidget( required string richContent ) {
-		// The following regex is designed to match the following pattern that would be embedded in rich editor content:
-		// {{widget:myWidgetId:{option:"value",option2:"value"}:widget}}
-
-
-		var regex = "{{widget:([a-z\$_][a-z0-9\$_]*):(.*?):widget}}";
-		var match = ReFindNoCase( regex, arguments.richContent, 1, true );
-		var widget    = {};
-
-		if ( ArrayLen( match.len ) eq 3 and match.len[1] and match.len[2] and match.len[3] ) {
-			widget.placeHolder = Mid( arguments.richContent, match.pos[1], match.len[1] );
-			widget.id          = Mid( arguments.richContent, match.pos[2], match.len[2] );
-			widget.configJson  = Mid( arguments.richContent, match.pos[3], match.len[3] );
-		}
-
-		return widget;
-	}
-
-	private struct function _findNextEmbeddedLink( required string richContent ) {
-		// The following regex is designed to match the following patterns that would be embedded in rich editor content:
-		// {{link:pageid:link}}
-		// {{asset:assetid:asset}}
-
-
-		var regex = "{{(link|asset|custom):(.*?):(link|asset|custom)}}";
-		var match = ReFindNoCase( regex, arguments.richContent, 1, true );
-		var link  = {};
-		var type  = "";
-
-		if ( ArrayLen( match.len ) eq 4 and match.len[1] and match.len[3] ) {
-			type             = Mid( arguments.richContent, match.pos[2], match.len[2] );
-			type             = type == "link" ? "page" : type;
-			link.placeHolder = Mid( arguments.richContent, match.pos[1], match.len[1] );
-			link[ type ]     = Mid( arguments.richContent, match.pos[3], match.len[3] );
-		}
-
-		return link;
-	}
-
 	private boolean function _containsCodeSnippets( required string content ) {
 		return ReFind( '<code class="language-.*"', content );
 	}
@@ -733,5 +655,12 @@ component {
 	}
 	private void function _setRenderedAssetCache( required any renderedAssetCache ) {
 	    _renderedAssetCache = arguments.renderedAssetCache;
+	}
+
+	private any function _getDynamicFindAndReplaceService() {
+	    return _dynamicFindAndReplaceService;
+	}
+	private void function _setDynamicFindAndReplaceService( required any dynamicFindAndReplaceService ) {
+	    _dynamicFindAndReplaceService = arguments.dynamicFindAndReplaceService;
 	}
 }

--- a/system/services/rendering/DynamicFindAndReplaceService.cfc
+++ b/system/services/rendering/DynamicFindAndReplaceService.cfc
@@ -1,0 +1,61 @@
+/**
+ * @singleton true
+ */
+component {
+
+// CONSTRUCTOR
+	public any function init() {
+		variables._patterns = {};
+		return this;
+	}
+
+// PUBLIC API METHODS
+	public string function dynamicFindAndReplace( required string source, required string regexPattern, required any processor, required boolean recurse ) {
+		var matcher = _getMatcher( arguments.regexPattern, arguments.source );
+		var builder     = [];
+		var simpleCache = {};
+		var sourceLen   = Len( arguments.source );
+		var currentPos  = 1;
+
+		while( matcher.find() ) {
+			var pos = matcher.start() + 1;
+
+			if ( currentPos < pos ) {
+				ArrayAppend( builder, Mid( arguments.source, currentPos, pos-currentPos ) );
+			}
+			currentPos = matcher.end() + 1;
+
+			var fullText = matcher.group( 0 );
+			if ( !StructKeyExists( simpleCache, fullText ) ) {
+				var captureGroups = [];
+				for( var i=0; i <= matcher.groupCount(); i++ ) {
+					ArrayAppend( captureGroups, matcher.group( i ) );
+				}
+				simpleCache[ fullText ] = arguments.processor( captureGroups );
+				if ( arguments.recurse && simpleCache[ fullText ] != fullText ) {
+					simpleCache[ fullText ] = dynamicFindAndReplace( argumentCollection=arguments, source=simpleCache[ fullText ] );
+				}
+			}
+
+			ArrayAppend( builder, simpleCache[ fullText ] );
+		}
+		if ( !ArrayLen( builder ) ) {
+			return arguments.source;
+		}
+
+		if ( sourceLen > currentPos ) {
+			ArrayAppend( builder, Right( arguments.source, sourceLen-(currentPos-1) ) );
+		}
+
+		return ArrayToList( builder, "" );
+	}
+
+// PRIVATE HELPERS
+	private function _getMatcher( pattern, source ) {
+		if ( !StructKeyExists( variables._patterns, arguments.pattern ) ) {
+			variables._patterns[ arguments.pattern ] = CreateObject( "java", "java.util.regex.Pattern" ).compile( arguments.pattern );
+		}
+		return variables._patterns[ arguments.pattern ].matcher( arguments.source );
+	}
+
+}

--- a/system/services/rendering/DynamicFindAndReplaceService.cfc
+++ b/system/services/rendering/DynamicFindAndReplaceService.cfc
@@ -11,7 +11,7 @@ component {
 
 // PUBLIC API METHODS
 	public string function dynamicFindAndReplace( required string source, required string regexPattern, required any processor, required boolean recurse ) {
-		var matcher = _getMatcher( arguments.regexPattern, arguments.source );
+		var matcher     = _getMatcher( arguments.regexPattern, arguments.source );
 		var builder     = [];
 		var simpleCache = {};
 		var sourceLen   = Len( arguments.source );
@@ -39,6 +39,7 @@ component {
 
 			ArrayAppend( builder, simpleCache[ fullText ] );
 		}
+
 		if ( !ArrayLen( builder ) ) {
 			return arguments.source;
 		}

--- a/tests/integration/api/rendering/ContentRendererServiceTest.cfc
+++ b/tests/integration/api/rendering/ContentRendererServiceTest.cfc
@@ -283,6 +283,7 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 			, assetRendererService = getMockBox().createEmptyMock( "preside.system.services.assetManager.assetRendererService" )
 			, widgetsService       = getMockBox().createEmptyMock( "preside.system.services.widgets.widgetsService" )
 			, labelRendererService = getMockBox().createEmptyMock( "preside.system.services.rendering.LabelRendererService" )
+			, dynamicFindAndReplaceService = new preside.system.services.rendering.DynamicFindAndReplaceService()
 		) );
 
 		svc.$( "$announceInterception" );

--- a/tests/integration/api/rendering/DelayedStickerRendererServiceTest.cfc
+++ b/tests/integration/api/rendering/DelayedStickerRendererServiceTest.cfc
@@ -75,7 +75,9 @@ proident, sunt in #replacements[ tags[2] ]# culpa qui officia deserunt mollit an
 		variables.mockColdbox         = CreateStub();
 		variables.requestContext      = CreateStub();
 
-		var service = CreateMock( object=new preside.system.services.rendering.DelayedStickerRendererService() );
+		var service = CreateMock( object=new preside.system.services.rendering.DelayedStickerRendererService(
+			dynamicFindAndReplaceService = new preside.system.services.rendering.DynamicFindAndReplaceService()
+		) );
 
 		mockColdbox.$( "getRequestContext" ).$results( requestContext );
 		requestContext.$( "include" ).$results( nullValue() );

--- a/tests/integration/api/rendering/DelayedViewletRendererServiceTest.cfc
+++ b/tests/integration/api/rendering/DelayedViewletRendererServiceTest.cfc
@@ -147,6 +147,7 @@ proident, sunt in Test #replacements[ dvs[3] ]#==RICHRENDERED==RICHRENDERED culp
 		var service = CreateMock( object=new preside.system.services.rendering.DelayedViewletRendererService(
 			  defaultHandlerAction = "index"
 			, contentRendererService = mockContentRenderer
+			, dynamicFindAndReplaceService = new preside.system.services.rendering.DynamicFindAndReplaceService()
 		) );
 
 		service.$( "$getColdbox", mockColdbox );

--- a/tests/integration/api/rendering/DynamicFindAndReplaceServiceTest.cfc
+++ b/tests/integration/api/rendering/DynamicFindAndReplaceServiceTest.cfc
@@ -1,0 +1,80 @@
+component extends="tests.resources.HelperObjects.PresideBddTestCase"{
+
+	function run(){
+		var sut = new preside.system.services.rendering.DynamicFindAndReplaceService();
+
+		describe( "dynamicFindAndReplace()", function(){
+			it( "should leave string untouched when there are no matches", function(){
+				var source = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+				var pattern = "\{\{widget:blah:test\}\}";
+
+				var result = sut.dynamicFindAndReplace( source=source, regexPattern=pattern, recurse=false, processor=function( captureGroups ){
+					return "replacement";
+				} );
+
+				expect( result  ).toBe( source );
+			} );
+
+
+			it( "should replace all matches with logic from the provided processor", function(){
+				var source = "Lorem {{test1:value}} ipsum dolor {{test2:value2}} sit {{blah:empty}}amet.{{test3:value3}}";
+				var expected = "Lorem Test 1 ipsum dolor Testing is fun sit amet.Testing is easy (is it?)";
+				var pattern = "\{\{(.*?):(.*?)\}\}";
+
+				var result = sut.dynamicFindAndReplace( source=source, regexPattern=pattern, recurse=false, processor=function( captureGroups ){
+					switch( captureGroups[ 2 ] ) {
+						case "test1":
+							return "Test 1";
+						break;
+						case "test2":
+							return "Testing is fun";
+						break;
+						case "test3":
+							return "Testing is easy (is it?)"
+						break;
+					}
+					return "";
+				} );
+
+				expect( result  ).toBe( expected );
+			} );
+
+			it( "should recurse when asked to", function(){
+				var source = "Lorem {{test1:value}} ipsum dolor {{test2:value2}} sit {{blah:empty}}amet.{{test3:value3}} some other text.";
+				var expected = "Lorem Test 1 Testing is fun Testing is easy (is it?) ipsum dolor Testing is fun Testing is easy (is it?) sit amet.Testing is easy (is it?) some other text.";
+				var pattern = "\{\{(.*?):(.*?)\}\}";
+
+				var result = sut.dynamicFindAndReplace( source=source, regexPattern=pattern, recurse=true, processor=function( captureGroups ){
+					switch( captureGroups[ 2 ] ) {
+						case "test1":
+							return "Test 1 {{test2:whatever}}";
+						break;
+						case "test2":
+							return "Testing is fun {{test3:meh}}";
+						break;
+						case "test3":
+							return "Testing is easy (is it?)"
+						break;
+					}
+					return "";
+				} );
+
+				expect( result  ).toBe( expected );
+			} );
+
+			it( "should pass all capture groups through to the processor", function(){
+				var source  = "Lorem {{test1:value}}";
+				var pattern = "\{\{(.*?):(.*?)\}\}";
+				var groups  = "";
+
+				var result = sut.dynamicFindAndReplace( source=source, regexPattern=pattern, recurse=false, processor=function( captureGroups ){
+					groups = arguments.captureGroups;
+					return "whatever";
+				} );
+
+				expect( result  ).toBe( "Lorem whatever" );
+				expect( groups ).toBe( [ "{{test1:value}}", "test1", "value" ] );
+			} );
+		} );
+	}
+}


### PR DESCRIPTION
For aspects such as widgets, embedded links, delayed viewlets, etc. we do a find and replace - looping over found matches.

This can have some unecessary overheads and an approach where you first break down the target string into an array and then replace the elements that match (before building a new string at the end) can work better.

In addition, in a shared lib function, we can prevent endless recursion in these F&R operations.
