### PR TITLE
PRESIDECMS-2665 better indexes on email logs

### DIFF
--- a/system/handlers/admin/EmailCenter.cfc
+++ b/system/handlers/admin/EmailCenter.cfc
@@ -62,19 +62,11 @@ component extends="preside.system.base.AdminHandler" {
 		args.statsAvailable = IsDate( args.minDate ) && IsDate( args.maxDate );
 
 		if ( args.statsAvailable ) {
-			var timepoints = Round( DateDiff( "h", args.dateFrom, args.dateTo ) );
-
-			if ( timepoints > 20 ) {
-				timepoints = 20;
-			} else if ( timepoints < 5 ) {
-				timepoints = 5;
-			}
-
 			args.interactionStats = emailTemplateService.getStats(
 				  templateId = args.templateId
-				, timePoints = timepoints
 				, dateFrom   = args.dateFrom
 				, dateTo     = args.dateTo
+				, timepoints = 0
 			);
 
 			event.include( "/js/admin/lib/plotly/" );

--- a/system/preside-objects/email/email_template_send_log.cfc
+++ b/system/preside-objects/email/email_template_send_log.cfc
@@ -8,9 +8,10 @@
  * @datamanagerEnabled          true
  */
 component extends="preside.system.base.SystemPresideObject" {
-	property name="email_template"  relationship="many-to-one" relatedto="email_template" required=false indexes="template_sent|1,template_opened|1,template_failed|1,template_delivered|1,template_hard_bounced|1,template_marked_as_spam|1,template_unsubscribed|1,template_click_count|1";
+	property name="email_template"  relationship="many-to-one" relatedto="email_template" required=false indexes="template,template_created|1";
 	property name="layout_override" type="string" dbtype="varchar" maxlength=200 required=false;
 	property name="custom_layout"   type="string" dbtype="varchar" maxlength=200 required=false;
+	property name="datecreated" indexes="datecreated,template_created|2";
 
 	property name="website_user_recipient"  relationship="many-to-one" relatedto="website_user"  required=false;
 	property name="security_user_recipient" relationship="many-to-one" relatedto="security_user" required=false;
@@ -23,13 +24,13 @@ component extends="preside.system.base.SystemPresideObject" {
 	property name="resend_of" type="string" dbtype="varchar" maxlength=35                indexes="resendof";
 	property name="send_args" type="string" dbtype="text" autofilter=false;
 
-	property name="sent"           type="boolean" dbtype="boolean" default=false indexes="sent,template_sent|2";
-	property name="failed"         type="boolean" dbtype="boolean" default=false indexes="failed,template_failed|2" renderer="booleanBadge";
-	property name="delivered"      type="boolean" dbtype="boolean" default=false indexes="delivered,template_delivered|2";
-	property name="hard_bounced"   type="boolean" dbtype="boolean" default=false indexes="hard_bounced,template_hard_bounced|2";
-	property name="opened"         type="boolean" dbtype="boolean" default=false indexes="opened,template_opened|2";
-	property name="marked_as_spam" type="boolean" dbtype="boolean" default=false indexes="marked_as_spam,template_marked_as_spam|2";
-	property name="unsubscribed"   type="boolean" dbtype="boolean" default=false indexes="unsubscribed,template_unsubscribed|2";
+	property name="sent"           type="boolean" dbtype="boolean" default=false indexes="sent";
+	property name="failed"         type="boolean" dbtype="boolean" default=false indexes="failed" renderer="booleanBadge";
+	property name="delivered"      type="boolean" dbtype="boolean" default=false indexes="delivered";
+	property name="hard_bounced"   type="boolean" dbtype="boolean" default=false indexes="hard_bounced";
+	property name="opened"         type="boolean" dbtype="boolean" default=false indexes="opened";
+	property name="marked_as_spam" type="boolean" dbtype="boolean" default=false indexes="marked_as_spam";
+	property name="unsubscribed"   type="boolean" dbtype="boolean" default=false indexes="unsubscribed";
 
 	property name="sent_date"           type="date" dbtype="datetime" indexes="sent_date";
 	property name="failed_date"         type="date" dbtype="datetime" indexes="failed_date";

--- a/system/preside-objects/email/email_template_send_log_activity.cfc
+++ b/system/preside-objects/email/email_template_send_log_activity.cfc
@@ -7,9 +7,9 @@
  * @datamanagerSearchFields     message.recipient,message$email_template.name,activity_type,link,link_title,link_body,reason
  */
 component extends="preside.system.base.SystemPresideObject" {
-	property name="message" relationship="many-to-one" relatedto="email_template_send_log" required=true indexes="logdatecreated|1,logactivitytype|1";
+	property name="message" relationship="many-to-one" relatedto="email_template_send_log" required=true indexes="message,logdatecreated|1,logactivitytype|1";
 
-	property name="datecreated" indexes="logdatecreated|2";
+	property name="datecreated" indexes="datecreated,logdatecreated|2";
 	property name="activity_type" type="string" dbtype="varchar" maxlength=15   required=true enum="emailActivityType" indexes="activitytype,logactivitytype|2";
 	property name="user_ip"       type="string" dbtype="varchar" maxLength=255  required=true;
 	property name="user_agent"    type="string" dbtype="text"                   required=false;

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -809,22 +809,22 @@ component {
 		,          string dateTo   = ""
 	) {
 		var extraFilters = [];
+
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs.sent_date >= :dateFrom"
+				  filter = "sent_date >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs.sent_date <= :dateTo"
+				  filter       = "sent_date <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( send_logs.id ) as sent_count" ]
-			, filter       = { id=arguments.templateId, "send_logs.sent"=true }
-			, forceJoins   = "inner"
+		var result = $getPresideObject( "email_template_send_log" ).selectData(
+			  selectFields = [ "Count( 1 ) as sent_count" ]
+			, filter       = { "email_template"=arguments.templateId, sent=true }
 			, extraFilters = extraFilters
 			, useCache     = false
 		);
@@ -845,26 +845,24 @@ component {
 		  required string templateId
 		,          string dateFrom = ""
 		,          string dateTo   = ""
-		,          numeric timePoints = 1
 	) {
 		var extraFilters = [];
 
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs.delivered_date >= :dateFrom"
+				  filter = "delivered_date >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs.delivered_date <= :dateTo"
+				  filter       = "delivered_date <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( send_logs.id ) as delivered_count" ]
-			, filter       = { id=arguments.templateId, "send_logs.delivered"=true }
-			, forceJoins   = "inner"
+		var result = $getPresideObject( "email_template_send_log" ).selectData(
+			  selectFields = [ "Count( 1 ) as delivered_count" ]
+			, filter       = { email_template=arguments.templateId, delivered=true }
 			, extraFilters = extraFilters
 			, useCache     = false
 		);
@@ -890,20 +888,19 @@ component {
 
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs.opened_date >= :dateFrom"
+				  filter = "opened_date >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs.opened_date <= :dateTo"
+				  filter       = "opened_date <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( send_logs.id ) as opened_count" ]
-			, filter       = { id=arguments.templateId, "send_logs.opened"=true }
-			, forceJoins   = "inner"
+		var result = $getPresideObject( "email_template_send_log" ).selectData(
+			  selectFields = [ "Count( 1 ) as opened_count" ]
+			, filter       = { email_template=arguments.templateId, opened=true }
 			, extraFilters = extraFilters
 		);
 
@@ -928,19 +925,19 @@ component {
 
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs$activities.datecreated >= :dateFrom"
+				  filter = "email_template_send_log_activity.datecreated >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs$activities.datecreated <= :dateTo"
+				  filter       = "email_template_send_log_activity.datecreated <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( send_logs$activities.id ) as opened_count" ]
-			, filter       = { id=arguments.templateId, "send_logs$activities.activity_type"="open" }
+		var result = $getPresideObject( "email_template_send_log_activity" ).selectData(
+			  selectFields = [ "Count( 1 ) as opened_count" ]
+			, filter       = { "message.email_template"=arguments.templateId, activity_type="open" }
 			, forceJoins   = "inner"
 			, extraFilters = extraFilters
 		);
@@ -966,19 +963,19 @@ component {
 
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs$activities.datecreated >= :dateFrom"
+				  filter = "email_template_send_log_activity.datecreated >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs$activities.datecreated <= :dateTo"
+				  filter       = "email_template_send_log_activity.datecreated <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( send_logs$activities.id ) as click_count" ]
-			, filter       = { id=arguments.templateId, "send_logs$activities.activity_type"="click" }
+		var result = $getPresideObject( "email_template_send_log_activity" ).selectData(
+			  selectFields = [ "Count( 1 ) as click_count" ]
+			, filter       = { "message.email_template"=arguments.templateId, activity_type="click" }
 			, forceJoins   = "inner"
 			, extraFilters = extraFilters
 		);
@@ -1004,20 +1001,19 @@ component {
 
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs.failed_date >= :dateFrom"
+				  filter = "failed_date >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs.failed_date <= :dateTo"
+				  filter       = "failed_date <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( send_logs.id ) as failed_count" ]
-			, filter       = { id=arguments.templateId, "send_logs.failed"=true }
-			, forceJoins   = "inner"
+		var result = $getPresideObject( "email_template_send_log" ).selectData(
+			  selectFields = [ "Count( 1 ) as failed_count" ]
+			, filter       = { email_template=arguments.templateId, failed=true }
 			, extraFilters = extraFilters
 		);
 
@@ -1034,10 +1030,9 @@ component {
 	public numeric function getQueuedCount(
 		  required string templateId
 	) {
-		var result = $getPresideObject( "email_template" ).selectData(
-			  selectFields = [ "Count( queued_emails.id ) as queued_count" ]
-			, filter       = { id=arguments.templateId }
-			, forceJoins   = "inner"
+		var result = $getPresideObject( "email_mass_send_queue" ).selectData(
+			  selectFields = [ "Count( 1 ) as queued_count" ]
+			, filter       = { template=arguments.templateId }
 			, useCache     = false
 		);
 
@@ -1185,28 +1180,28 @@ component {
 		,          string dateTo   = ""
 	) {
 		var extraFilters = [{
-			filter = { "send_logs$activities.activity_type"="click" }
+			filter = { activity_type="click" }
 		}];
 
-		extraFilters.append( { filter="send_logs$activities.link is not null" } );
+		extraFilters.append( { filter="email_template_send_log_activity.link is not null" } );
 
 		if ( IsDate( arguments.dateFrom ) ) {
 			extraFilters.append({
-				  filter = "send_logs$activities.datecreated >= :dateFrom"
+				  filter = "email_template_send_log_activity.datecreated >= :dateFrom"
 				, filterParams = { dateFrom={ type="cf_sql_timestamp", value=arguments.dateFrom } }
 			});
 		}
 		if ( IsDate( arguments.dateTo ) ) {
 			extraFilters.append({
-				  filter       = "send_logs$activities.datecreated <= :dateTo"
+				  filter       = "email_template_send_log_activity.datecreated <= :dateTo"
 				, filterParams = { dateTo={ type="cf_sql_timestamp", value=arguments.dateTo } }
 			});
 		}
 
 		var clickStats    = StructNew( "ordered" );
-		var rawClickStats = $getPresideObject( "email_template" ).selectData(
-			  id           = arguments.templateId
-			, selectFields = [ "count( 1 ) as click_count", "send_logs$activities.link", "send_logs$activities.link_title", "send_logs$activities.link_body" ]
+		var rawClickStats = $getPresideObject( "email_template_send_log_activity" ).selectData(
+			  filter       = { "message.email_template"=arguments.templateId }
+			, selectFields = [ "count( 1 ) as click_count", "link", "link_title", "link_body" ]
 			, extraFilters = extraFilters
 			, autoGroupBy  = true
 			, orderBy      = "click_count desc"

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -824,7 +824,7 @@ component {
 		}
 		var result = $getPresideObject( "email_template_send_log" ).selectData(
 			  selectFields = [ "Count( 1 ) as sent_count" ]
-			, filter       = { "email_template"=arguments.templateId, sent=true }
+			, filter       = { email_template=arguments.templateId, sent=true }
 			, extraFilters = extraFilters
 			, useCache     = false
 		);

--- a/system/services/metrics/TimeSeriesUtils.cfc
+++ b/system/services/metrics/TimeSeriesUtils.cfc
@@ -1,0 +1,276 @@
+/**
+ *
+ * @presideService true
+ * @singleton      true
+ */
+component {
+
+	variables._MINUTE = 60;
+	variables._HOUR   = variables._MINUTE * 60;
+	variables._DAY    = variables._HOUR * 24;
+	variables._WEEK   = variables._DAY * 7;
+	variables._MONTH  = variables._WEEK * 4;
+	variables._YEAR   = variables._WEEK * 52;
+
+	property name="sqlRunner" inject="sqlRunner";
+	property name="dsn"       inject="coldbox:setting:dsn";
+
+// CONSTRUCTOR
+	public any function init() {
+		return this;
+	}
+
+// PUBLIC API METHODS
+	public any function getTimeSeriesData(
+		  required string  sourceObject
+		, required date    startDate
+		, required date    endDate
+		,          struct  timeResolution      = calculateTimeResolution( arguments.startDate, arguments.endDate )
+		,          array   expectedTimes       = getExpectedTimes( timeResolution, arguments.startDate, arguments.endDate )
+		,          string  groupBy             = ""
+		,          string  secondaryGroupBy    = ""
+		,          string  aggregateFunction   = "count"
+		,          string  aggregateOver       = "1"
+		,          string  timeField           = "datecreated"
+		,          string  decimalPrecision    = ""
+		,          array   extraFilters        = []
+		,          boolean valuesOnly          = false
+	) {
+		var fullTimeSeries = { labels=[], datasets=[] };
+
+		if ( !Len( Trim( arguments.timeField ) ) ) {
+			arguments.timeField = $getPresideObjectService().getDateCreatedField( arguments.sourceObject );
+		}
+
+		var timeValue      = "from_unixtime(floor(UNIX_TIMESTAMP(#arguments.timeField#)/#timeResolution.seconds#)*#timeResolution.seconds#) as _time";
+		var aggOver        = arguments.aggregateFunction == "count" ? "1" : arguments.aggregateOver;
+		var valueField     = "";
+		var mapped         = StructNew( "linked" );
+		var groupedValues  = {};
+		var grouped        = Len( Trim( arguments.groupBy ) ) > 0;
+		var selectDataArgs = {
+			  selectFields = [ timeValue ]
+			, filter       = "#timeField# > :start and #timeField# < :end"
+			, filterParams = { start={ type="cf_sql_timestamp", value=arguments.startDate }, end={ type="cf_sql_timestamp", value=arguments.endDate } }
+			, groupBy      = "_time"
+			, orderBy      = "_time"
+			, extraFilters = Duplicate( arguments.extraFilters )
+		};
+
+		if ( $helpers.isRelationalAggregateField( aggOver ) ) {
+			var relationalJoin = _getSubqueryJoinForRelationalAggregate( arguments.sourceObject, aggOver );
+			selectDataArgs.extraJoins = [ relationalJoin.join ];
+			StructAppend( selectDataArgs.filterParams, relationalJoin.params );
+			ArrayAppend( selectDataArgs.selectFields, "#arguments.aggregateFunction#( ifnull( _relationalSubquery._value, 0 ) ) as _value" );
+		} else {
+			ArrayAppend( selectDataArgs.selectFields, "#arguments.aggregateFunction#( #aggOver# ) as _value" );
+		}
+
+		if ( grouped ) {
+			ArrayAppend( selectDataArgs.selectFields, arguments.groupBy & " as _groupval" );
+			selectDataArgs.groupBy &= ", _groupval";
+
+			if ( Len( Trim( arguments.secondaryGroupBy ) ) ) {
+				ArrayAppend( selectDataArgs.selectFields, arguments.secondaryGroupBy & " as _groupval2" );
+				selectDataArgs.groupBy &= ", _groupval, _groupval2";
+			}
+		} else {
+			ArrayAppend( fullTimeSeries.datasets, { label="_", values=[] } );
+		}
+
+		var rawResults = $getPresideObject( arguments.sourceObject ).selectData( argumentCollection=selectDataArgs );
+
+		for( var result in rawResults ) {
+			if ( grouped ) {
+				mapped[ result._time ] = mapped[ result._time ] ?: {};
+				var groupVal = result._groupval;
+				if ( Len( Trim( arguments.secondaryGroupBy ) ) ) {
+					groupVal &= "|" & result._groupval2;
+				}
+
+				groupedValues[ groupval ] = true;
+				mapped[ result._time ][ groupval ] = applyPrecision( result._value, arguments.decimalPrecision );
+			} else {
+				mapped[ result._time ] = applyPrecision( result._value, arguments.decimalPrecision );
+			}
+		}
+
+		if ( grouped ) {
+			for( var groupId in groupedValues ) {
+				var groupLabel = arguments.renderGroupLabels ? renderGroupByLabel( arguments.sourceObject, arguments.groupBy, ListFirst( groupId, "|" ) ) : ListFirst( groupId, "|" );
+
+				if ( Len( Trim( arguments.secondaryGroupBy ) ) ) {
+					groupLabel &= " / " & ( arguments.renderGroupLabels ? renderGroupByLabel( arguments.sourceObject, arguments.secondaryGroupBy, ListRest( groupId, "|" ) ) : ListRest( groupId, "|" ) );
+				}
+				ArrayAppend( fullTimeSeries.datasets, { label=groupLabel, values=[] } );
+			}
+		}
+
+		for( var t in arguments.expectedTimes ) {
+			if ( !arguments.valuesOnly && !ArrayFind( fullTimeSeries.labels, t ) ) {
+				ArrayAppend( fullTimeSeries.labels, t );
+			}
+
+			if ( grouped ) {
+				var n = 0;
+				for( var groupId in groupedValues ) {
+					ArrayAppend( fullTimeSeries.datasets[ ++n ].values, mapped[ t ][ groupId ] ?: 0 );
+				}
+			} else {
+				ArrayAppend( fullTimeSeries.datasets[ 1 ].values, mapped[ t ] ?: 0 );
+			}
+		}
+
+		if ( arguments.valuesOnly ) {
+			return fullTimeSeries.datasets[ 1 ].values;
+		}
+
+		return fullTimeSeries;
+	}
+
+	public struct function calculateTimeResolution( startDate, endDate ) {
+		var daysDiff  = DateDiff( 'd', arguments.startDate, arguments.endDate );
+		var hoursDiff = DateDiff( 'h', arguments.startDate, arguments.endDate );
+		var minsDiff  = DateDiff( 'n', arguments.startDate, arguments.endDate );
+
+		if ( daysDiff >= 300 ) {
+			return { seconds=variables._MONTH, hourStep=24, minStep=60 };
+		}
+
+		if ( daysDiff >= 90 ) {
+			return { seconds=variables._WEEK, hourStep=24, minStep=60 };
+		}
+
+		if ( daysDiff >= 30 ) {
+			return { seconds=variables._DAY * 2, hourStep=24, minStep=60 };
+		}
+
+		if ( daysDiff > 7 ) {
+			return { seconds=variables._DAY, hourStep=24, minStep=60 };
+		}
+
+		if ( daysDiff > 3 ) {
+			return { seconds=variables._HOUR * 12, hourStep=12, minStep=60 };
+		}
+
+		if ( daysDiff > 1 ) {
+			return { seconds=variables._HOUR * 8, hourStep=8, minStep=60 };
+		}
+
+		if ( hoursDiff > 20 ) {
+			return { seconds=variables._HOUR * 2, hourStep=2, minStep=60 };
+		}
+
+		if ( hoursDiff > 10 ) {
+			return { seconds=variables._HOUR, hourStep=1, minStep=60 };
+		}
+
+		if ( hoursDiff > 5 ) {
+			return { seconds=variables._HOUR / 2, hourStep=1, minStep=30 };
+		}
+
+		if ( hoursDiff > 2 ) {
+			return { seconds=variables._HOUR / 3, hourStep=1, minStep=20 };
+		}
+
+		if ( minsDiff > 80 ) {
+			return { seconds=variables._MINUTE * 10, hourStep=1, minStep=10 };
+		}
+
+		if ( minsDiff > 40 ) {
+			return { seconds=variables._MINUTE * 5, hourStep=1, minStep=5 };
+		}
+
+		if ( minsDiff > 20 ) {
+			return { seconds=variables._MINUTE * 2, hourStep=1, minStep=2 };
+		}
+
+		return { seconds=variables._MINUTE, hourStep=1, minStep=60 };
+	}
+
+	public array function getExpectedTimes( resolution, startDate, endDate ) {
+		var daysDiff  = DateDiff( "d", arguments.startDate, arguments.endDate );
+		var hoursDiff = DateDiff( "h", arguments.startDate, arguments.endDate );
+		var minsDiff  = DateDiff( "n", arguments.startDate, arguments.endDate );
+
+		var sql = "
+			select
+				distinct from_unixtime( floor( UNIX_TIMESTAMP( generated_date ) / ? ) * ? ) as expected_date
+			from (
+				select
+					addtime( adddate( from_unixtime( floor( UNIX_TIMESTAMP( ? ) / ? ) * ? ), t4*10000 + t3*1000 + t2*100 + t1*10 + t0 ), hrs*10000 + mins*100 ) generated_date
+				from
+					#sqlTempDataRange( "t0", 0, daysDiff > 10 ? 9 : daysDiff )#,
+					#sqlTempDataRange( "t1", 0, daysDiff > 100 ? 9 : daysDiff \ 10 )#,
+					#sqlTempDataRange( "t2", 0, daysDiff > 1000 ? 9 : daysDiff \ 100 )#,
+					#sqlTempDataRange( "t3", 0, daysDiff > 10000 ? 9 : daysDiff \ 1000 )#,
+					#sqlTempDataRange( "t4", 0, daysDiff \ 10000 )#,
+					#sqlTempDataRange( "hrs", 0, 23, arguments.resolution.hourStep )#,
+					#sqlTempDataRange( "mins", 0, 59, arguments.resolution.minStep )#
+			) v
+			where
+				generated_date between from_unixtime( floor( UNIX_TIMESTAMP( ? ) / ? ) * ? ) and ?
+			order by
+				generated_date";
+
+		var params = [
+			  { type="integer"  , value=arguments.resolution.seconds }
+			, { type="integer"  , value=arguments.resolution.seconds }
+			, { type="timestamp", value=arguments.startDate }
+			, { type="integer"  , value=arguments.resolution.seconds }
+			, { type="integer"  , value=arguments.resolution.seconds }
+			, { type="timestamp", value=arguments.startDate }
+			, { type="integer"  , value=arguments.resolution.seconds }
+			, { type="integer"  , value=arguments.resolution.seconds }
+			, { type="timestamp", value=arguments.endDate }
+		];
+
+		var expectedTimes = sqlRunner.runSql( sql=sql, dsn=dsn, params=params );
+
+		return ValueArray( expectedTimes, "expected_date" );
+	}
+
+	public string function sqlTempDataRange( required string alias, numeric from=0, numeric to=0, numeric step=1 ) {
+		var data = [];
+		for( var i=arguments.from; i<=arguments.to; i+=arguments.step ) {
+			ArrayAppend( data, "select #i# as #arguments.alias#" );
+		}
+		return "( " & ArrayToList( data, " union " ) & " ) #arguments.alias#";
+	}
+
+	public string function renderGroupByLabel( sourceObject, fieldName, value ) {
+		var objProps = $getPresideObjectService().getObjectProperties( arguments.sourceObject );
+		if ( !StructKeyExists( objProps, arguments.fieldname ) ) {
+			return arguments.value;
+		}
+
+		var rendered = "";
+		var relatedTo = objProps[ arguments.fieldname ].relatedTo ?: "none";
+		if ( relatedTo != "none" &&  $getPresideObjectService().objectExists( relatedTo ) ) {
+			rendered = $renderLabel( objProps[ arguments.fieldname ].relatedTo, arguments.value );
+		} else {
+			rendered = $renderField(
+				  object   = arguments.sourceObject
+				, property = arguments.fieldName
+				, data     = arguments.value
+				, context  = [ "datavizMetric", "adminView", "admin" ]
+			);
+		}
+		rendered = $helpers.stripTags( rendered );
+		rendered = ReReplaceNoCase( rendered, "\&[a-z]+;", "", "all" );
+
+		return Trim( rendered );
+	}
+
+	public string function applyPrecision( required numeric value, required string precision ) {
+		if ( IsNumeric( arguments.precision ) ) {
+			if ( arguments.precision > 0 ) {
+				return NumberFormat( arguments.value, "_.#RepeatString( "0", arguments.precision )#" );
+			} else {
+				return Round( arguments.value );
+			}
+		}
+
+		return arguments.value;
+	}
+}

--- a/tests/integration/api/email/EmailTemplateServiceTest.cfc
+++ b/tests/integration/api/email/EmailTemplateServiceTest.cfc
@@ -1433,10 +1433,9 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var templateId = CreateUUId();
 				var stats      = QueryNew( 'sent_count', 'int', [[635]] );
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as sent_count" ]
-					, filter       = { id=templateId, "send_logs.sent"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as sent_count" ]
+					, filter       = { email_template=templateId, sent=true }
 					, extraFilters = []
 					, useCache     = false
 				).$results( stats );
@@ -1451,13 +1450,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var dateFrom   = "1900-01-01";
 				var dateTo   = "1999-06-29";
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as sent_count" ]
-					, filter       = { id=templateId, "send_logs.sent"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as sent_count" ]
+					, filter       = { email_template=templateId, sent=true }
 					, extraFilters = [
-						  { filter="send_logs.sent_date >= :dateFrom", filterParams={ dateFrom = { type="cf_sql_timestamp", value=dateFrom } } }
-						, { filter="send_logs.sent_date <= :dateTo"  , filterParams={ dateTo   = { type="cf_sql_timestamp", value=dateTo   } } }
+						  { filter="sent_date >= :dateFrom", filterParams={ dateFrom = { type="cf_sql_timestamp", value=dateFrom } } }
+						, { filter="sent_date <= :dateTo"  , filterParams={ dateTo   = { type="cf_sql_timestamp", value=dateTo   } } }
 					]
 					, useCache     = false
 				).$results( stats );
@@ -1472,10 +1470,9 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var templateId = CreateUUId();
 				var stats      = QueryNew( 'delivered_count', 'int', [[635]] );
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as delivered_count" ]
-					, filter       = { id=templateId, "send_logs.delivered"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as delivered_count" ]
+					, filter       = { email_template=templateId, delivered=true }
 					, extraFilters = []
 					, useCache     = false
 				).$results( stats );
@@ -1490,13 +1487,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var dateFrom   = "1900-01-01";
 				var dateTo   = "1999-06-29";
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as delivered_count" ]
-					, filter       = { id=templateId, "send_logs.delivered"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as delivered_count" ]
+					, filter       = { email_template=templateId, delivered=true }
 					, extraFilters = [
-						  { filter="send_logs.delivered_date >= :dateFrom", filterParams={ dateFrom={ type="cf_sql_timestamp", value=dateFrom } } }
-						, { filter="send_logs.delivered_date <= :dateTo"  , filterParams={ dateTo={ type="cf_sql_timestamp", value=dateTo } } }
+						  { filter="delivered_date >= :dateFrom", filterParams={ dateFrom={ type="cf_sql_timestamp", value=dateFrom } } }
+						, { filter="delivered_date <= :dateTo"  , filterParams={ dateTo={ type="cf_sql_timestamp", value=dateTo } } }
 					]
 					, useCache     = false
 				).$results( stats );
@@ -1511,12 +1507,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var templateId = CreateUUId();
 				var stats      = QueryNew( 'opened_count', 'int', [[635]] );
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as opened_count" ]
-					, filter       = { id=templateId, "send_logs.opened"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as opened_count" ]
+					, filter       = { email_template=templateId, opened=true }
 					, extraFilters = []
 				).$results( stats );
+
 
 				expect( service.getUniqueOpenedCount( templateId ) ).toBe( 635 );
 			} );
@@ -1528,13 +1524,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var dateFrom   = "1900-01-01";
 				var dateTo   = "1999-06-29";
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as opened_count" ]
-					, filter       = { id=templateId, "send_logs.opened"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as opened_count" ]
+					, filter       = { email_template=templateId, opened=true }
 					, extraFilters = [
-						  { filter="send_logs.opened_date >= :dateFrom", filterParams={ dateFrom={ type="cf_sql_timestamp", value=dateFrom } } }
-						, { filter="send_logs.opened_date <= :dateTo"  , filterParams={ dateTo={ type="cf_sql_timestamp", value=dateTo } } }
+						  { filter="opened_date >= :dateFrom", filterParams={ dateFrom={ type="cf_sql_timestamp", value=dateFrom } } }
+						, { filter="opened_date <= :dateTo"  , filterParams={ dateTo={ type="cf_sql_timestamp", value=dateTo } } }
 					]
 				).$results( stats );
 
@@ -1548,10 +1543,9 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var templateId = CreateUUId();
 				var stats      = QueryNew( 'failed_count', 'int', [[635]] );
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as failed_count" ]
-					, filter       = { id=templateId, "send_logs.failed"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as failed_count" ]
+					, filter       = { email_template=templateId, failed=true }
 					, extraFilters = []
 				).$results( stats );
 
@@ -1565,13 +1559,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var dateFrom   = "1900-01-01";
 				var dateTo   = "1999-06-29";
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( send_logs.id ) as failed_count" ]
-					, filter       = { id=templateId, "send_logs.failed"=true }
-					, forceJoins   = "inner"
+				mockSendLogDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as failed_count" ]
+					, filter       = { email_template=templateId, failed=true }
 					, extraFilters = [
-						  { filter="send_logs.failed_date >= :dateFrom", filterParams={ dateFrom={ type="cf_sql_timestamp", value=dateFrom } } }
-						, { filter="send_logs.failed_date <= :dateTo"  , filterParams={ dateTo={ type="cf_sql_timestamp", value=dateTo } } }
+						  { filter="failed_date >= :dateFrom", filterParams={ dateFrom={ type="cf_sql_timestamp", value=dateFrom } } }
+						, { filter="failed_date <= :dateTo"  , filterParams={ dateTo={ type="cf_sql_timestamp", value=dateTo } } }
 					]
 				).$results( stats );
 
@@ -1585,10 +1578,9 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var templateId = CreateUUId();
 				var stats      = QueryNew( 'queued_count', 'int', [[459]] );
 
-				mockTemplateDao.$( "selectData" ).$args(
-					  selectFields = [ "Count( queued_emails.id ) as queued_count" ]
-					, filter       = { id=templateId }
-					, forceJoins   = "inner"
+				mockQueueDao.$( "selectData" ).$args(
+					  selectFields = [ "Count( 1 ) as queued_count" ]
+					, filter       = { template=templateId }
 					, useCache     = false
 				).$results( stats );
 
@@ -1641,6 +1633,8 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		var service = createMock( object=CreateObject( "preside.system.services.email.EmailTemplateService" ) );
 
 		mockTemplateDao          = createStub();
+		mockSendLogDao           = createStub();
+		mockSendLogActivityDao   = createStub();
 		mockQueueDao             = createStub();
 		mockBlueprintDao         = createStub();
 		mockViewOnlineContentDao = createStub();
@@ -1650,6 +1644,8 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		mockEmailSettings        = { defaultContentExpiry=30 };
 
 		service.$( "$getPresideObject" ).$args( "email_template" ).$results( mockTemplateDao );
+		service.$( "$getPresideObject" ).$args( "email_template_send_log" ).$results( mockSendLogDao );
+		service.$( "$getPresideObject" ).$args( "email_template_send_log_activity" ).$results( mockSendLogActivityDao );
 		service.$( "$getPresideObject" ).$args( "email_mass_send_queue" ).$results( mockQueueDao );
 		service.$( "$getPresideObject" ).$args( "email_blueprint" ).$results( mockBlueprintDao );
 		service.$( "$getPresideObject" ).$args( "email_template_view_online_content" ).$results( mockViewOnlineContentDao );

--- a/tests/integration/api/email/EmailTemplateServiceTest.cfc
+++ b/tests/integration/api/email/EmailTemplateServiceTest.cfc
@@ -1646,6 +1646,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		mockViewOnlineContentDao = createStub();
 		mockRequestContext       = createStub();
 		mockTemplateCache        = createStub();
+		mockTimeSeriesUtils      = createStub();
 		mockEmailSettings        = { defaultContentExpiry=30 };
 
 		service.$( "$getPresideObject" ).$args( "email_template" ).$results( mockTemplateDao );
@@ -1689,6 +1690,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				, emailStyleInliner          = mockEmailStyleInliner
 				, emailSettings              = mockEmailSettings
 				, templateCache              = mockTemplateCache
+				, timeSeriesUtils            = mockTimeSeriesUtils
 			);
 		}
 


### PR DESCRIPTION
To help performance when a system sends a lot of email - we need to optimize indexes, and other aspects. Here, we are improving the indexes on the send log and activity tables and refactoring the stats screen calculation to reduce repeated queries (i.e. do all the time series queries in a single query)