### PR TITLE
PRESIDECMS-2694 configurable async/sync SMTP sending

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -803,6 +803,8 @@ component {
 
 	private void function __setupEmailCenter() {
 		settings.email = _getEmailSettings(); // seems silly, but need to keep this for backward compat
+		settings.email.smtp = {};
+		settings.email.smtp.async = IsBoolean( settings.env.SMTP_ASYNC ?: "" ) ? settings.env.SMTP_ASYNC : true;
 	}
 
 	private void function __setupRicheditor() {

--- a/system/handlers/email/serviceProvider/Smtp.cfc
+++ b/system/handlers/email/serviceProvider/Smtp.cfc
@@ -3,7 +3,8 @@
  *
  */
 component {
-	property name="emailService" inject="emailService";
+	property name="emailService"  inject="emailService";
+	property name="asyncSmtp"     inject="coldbox:setting:email.smtp.async";
 
 	private boolean function send( struct sendArgs={}, struct settings={} ) {
 		var m           = new Mail();
@@ -19,6 +20,7 @@ component {
 		m.setFrom( sendArgs.from );
 		m.setSubject( sendArgs.subject );
 		m.setUseTls( useTls );
+		m.setAsync( asyncSmtp );
 
 		if ( sendArgs.cc.len()  ) {
 			m.setCc( sendArgs.cc.toList( ";" ) );
@@ -50,6 +52,7 @@ component {
 		if ( Len( Trim( password ) ) ) {
 			m.setPassword( password );
 		}
+
 
 		for( var param in params ){
 			m.addParam( argumentCollection=sendArgs.params[ param ] );

--- a/system/preside-objects/email/email_template_send_log_activity.cfc
+++ b/system/preside-objects/email/email_template_send_log_activity.cfc
@@ -18,7 +18,7 @@ component extends="preside.system.base.SystemPresideObject" {
 	property name="link_title"    type="string" dbtype="text";
 	property name="link_body"     type="string" dbtype="text";
 	property name="code"          type="string" dbtype="varchar" maxlength=20  indexes="errorcode";
-	property name="reason"        type="string" dbtype="varchar" maxlength=800;
+	property name="reason"        type="string" dbtype="text";
 
 	property name="link_summary" formula="case when ${prefix}link_title is null and ${prefix}link_body is null then ${prefix}link else concat( coalesce( ${prefix}link_title, ${prefix}link_body ), ' (', ${prefix}link, ')' ) end";
 }


### PR DESCRIPTION
Add a configurable option to turn off asynchronous SMTP sending using Lucee mail spool.

Our default behaviour remains the same: we will use Lucee's SMTP mail spool to background send SMTP messages.
However, if the setting `settings.email.smtp.async` is set to `false` in Config.cfc (can be achieved by
setting a `SMTP_ASYNC` environment variable), then SMTP sending will be synchronous.

In addition, we needed to increase the `reason` field in activity database to safely record failure reasons
that may now be much larger due to catching SMTP connection errors.