### PR TITLE
PRESIDECMS-2700 Optional CSRF validation only for authenticated users

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -961,7 +961,8 @@ component {
 		};
 
 		settings.csrf = {
-			tokenExpiryInSeconds = 1200
+			  tokenExpiryInSeconds      = 1200
+			, authenticatedSessionsOnly = IsBoolean( settings.env.CSRF_AUTHENTICATED_ONLY ?: "" ) && settings.env.CSRF_AUTHENTICATED_ONLY
 		};
 	}
 

--- a/system/services/security/CsrfProtectionService.cfc
+++ b/system/services/security/CsrfProtectionService.cfc
@@ -1,23 +1,33 @@
 /**
- * @singleton
- *
+ * @singleton      true
+ * @presideService true
  */
 component {
 
 // CONSTRUCTOR
 	/**
-	 * @sessionStorage.inject       sessionStorage
-	 * @tokenExpiryInSeconds.inject coldbox:setting:csrf.tokenExpiryInSeconds
+	 * @sessionStorage.inject           sessionStorage
+	 * @tokenExpiryInSeconds.inject     coldbox:setting:csrf.tokenExpiryInSeconds
+	 * @authenticatedSessionOnly.inject coldbox:setting:csrf.authenticatedSessionsOnly
 	 */
-	public any function init( required any sessionStorage, required numeric tokenExpiryInSeconds ) {
+	public any function init(
+		  required any     sessionStorage
+		, required numeric tokenExpiryInSeconds
+		, required boolean authenticatedSessionOnly
+	) {
 		_setSessionStorage( arguments.sessionStorage );
 		_setTokenExpiryInSeconds( arguments.tokenExpiryInSeconds );
+		_setAuthenticatedSessionOnly( arguments.authenticatedSessionOnly );
 
 		return this;
 	}
 
 // PUBLIC API
 	public string function generateToken( boolean force=false ) {
+		if ( skipCsrfValidation() ) {
+			return "";
+		}
+
 		var generate = arguments.force;
 		var token    = "";
 
@@ -35,6 +45,10 @@ component {
 	}
 
 	public boolean function validateToken( required string token, boolean regenerate=true ) {
+		if ( skipCsrfValidation() ) {
+			return true;
+		}
+
 		if ( !Len( Trim( arguments.token ) ) ) {
 			return false;
 		}
@@ -62,6 +76,10 @@ component {
 		return false;
 	}
 
+	public boolean function skipCsrfValidation() {
+		return _getAuthenticatedSessionOnly() && !$isWebsiteUserLoggedIn() && !$isAdminUserLoggedIn() && StructIsEmpty( _getToken() );
+	}
+
 // PRIVATE HELPERS
 	private struct function _getToken() {
 		return _getSessionStorage().getVar( name="_csrfToken", default={} );
@@ -84,5 +102,12 @@ component {
 	}
 	private void function _setTokenExpiryInSeconds( required numeric tokenExpiryInSeconds ) {
 		_tokenExpiryInSeconds = arguments.tokenExpiryInSeconds;
+	}
+
+	private boolean function _getAuthenticatedSessionOnly() {
+	    return _authenticatedSessionOnly;
+	}
+	private void function _setAuthenticatedSessionOnly( required boolean authenticatedSessionOnly ) {
+	    _authenticatedSessionOnly = arguments.authenticatedSessionOnly;
 	}
 }

--- a/system/services/security/CsrfProtectionService.cfc
+++ b/system/services/security/CsrfProtectionService.cfc
@@ -24,7 +24,7 @@ component {
 
 // PUBLIC API
 	public string function generateToken( boolean force=false ) {
-		if ( skipCsrfValidation() ) {
+		if ( !arguments.force && skipCsrfValidation() ) {
 			return "";
 		}
 
@@ -44,8 +44,8 @@ component {
 		return token.value;
 	}
 
-	public boolean function validateToken( required string token, boolean regenerate=true ) {
-		if ( skipCsrfValidation() ) {
+	public boolean function validateToken( required string token, boolean regenerate=true, boolean force=false ) {
+		if ( !arguments.force && skipCsrfValidation() ) {
 			return true;
 		}
 

--- a/tests/integration/api/security/CsrfProtectionServiceTest.cfc
+++ b/tests/integration/api/security/CsrfProtectionServiceTest.cfc
@@ -4,30 +4,28 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 	function setup() {
 		variables.tokenExpiryInSeconds = 5;
 		variables.sessionStorage       = new tests.resources.HelperObjects.TestSessionStorage();
-		variables.csrfSvc              = new preside.system.services.security.CsrfProtectionService(
-			  sessionStorage       = sessionStorage
-			, tokenExpiryInSeconds = tokenExpiryInSeconds
-		);
 	}
 
 // TESTS
 	function test01_generateToken_shouldReturnARandomlyGeneratedToken(){
-		super.assert( Len( csrfSvc.generateToken() ) );
+		super.assert( Len( _getSvc().generateToken() ) );
 	}
 
 	function test02_validateToken_shouldReturnFalse_whenNoCallToGenerateATokenHasBeenMade(){
-		super.assertFalse( csrfSvc.validateToken( CreateUUId() ) );
+		super.assertFalse( _getSvc().validateToken( CreateUUId() ) );
 	}
 
 	function test03_validateToken_shouldReturnTrue_whenPassedATokenThatWasGeneratedUsingGetToken(){
-		var token = csrfSvc.generateToken();
-		var i     = 0;
+		var csrfSvc = _getSvc();
+		var token   = csrfSvc.generateToken();
+		var i       = 0;
 
 		super.assert( csrfSvc.validateToken( token ) );
 	}
 
 	function test04_validateToken_shouldRepeatedlyReturnTrue_whenValidatingAGeneratedTokenWithinItsExpiryLimit(){
-		var token = csrfSvc.generateToken();
+		var csrfSvc = _getSvc();
+		var token   = csrfSvc.generateToken();
 
 		csrfSvc.validateToken( token );
 
@@ -37,11 +35,13 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 	}
 
 	function test05_validateToken_shouldReturnFalse_whenPassedARandomInvalidToken(){
+		var csrfSvc = _getSvc();
 		super.assertFalse( csrfSvc.validateToken( "sometoken" ) );
 	}
 
 	function test06_validateToken_shouldReturnFalse_whenPassedTokenHasExpiredDueToTime(){
-		var token = csrfSvc.generateToken();
+		var csrfSvc = _getSvc();
+		var token   = csrfSvc.generateToken();
 
 		sleep( ( tokenExpiryInSeconds + 1 ) * 1000 ); // milliseconds
 
@@ -49,7 +49,8 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 	}
 
 	function test07_generateToken_shouldReturnSameToken_whenItsTimeoutHasNotExpired(){
-		var token = csrfSvc.generateToken();
+		var csrfSvc = _getSvc();
+		var token   = csrfSvc.generateToken();
 
 		super.assertEquals( token, csrfSvc.generateToken() );
 		super.assertEquals( token, csrfSvc.generateToken() );
@@ -58,12 +59,81 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 	}
 
 	function test08_generateToken_shouldReturnANewToken_whenOriginalTokenExpires(){
-		var token = csrfSvc.generateToken();
+		var csrfSvc = _getSvc();
+		var token   = csrfSvc.generateToken();
 
 		sleep( ( tokenExpiryInSeconds + 1 ) * 1000 ); // milliseconds
 
 		super.assertNotEquals( token, csrfSvc.generateToken() );
 	}
 
+	function test09_generateToken_shouldReturnEmptyString_whenAuthenticatedSessionsOnly_andNoUserSession() {
+		var csrfSvc = _getSvc( authenticatedSessionOnly=true );
+
+		csrfSvc.$( "$isWebsiteUserLoggedIn", false );
+		csrfSvc.$( "$isAdminUserLoggedIn", false );
+		csrfSvc.$( "_getToken", {} );
+
+		super.assertEquals( "", csrfSvc.generateToken() );
+	}
+
+	function test10_generateToken_shouldReturnToken_whenAuthenticatedSessionsOnly_andNoUserSession_butForceTruePassed() {
+		var csrfSvc = _getSvc( authenticatedSessionOnly=true );
+
+		csrfSvc.$( "$isWebsiteUserLoggedIn", false );
+		csrfSvc.$( "$isAdminUserLoggedIn", false );
+		csrfSvc.$( "_getToken", {} );
+
+		super.assertNotEquals( "", csrfSvc.generateToken( true ) );
+	}
+
+	function test11_generateToken_shouldReturnToken_whenAuthenticatedSessionsOnly_andThereIsAUserSession() {
+		var csrfSvc = _getSvc( authenticatedSessionOnly=true );
+
+		csrfSvc.$( "$isWebsiteUserLoggedIn", true );
+		csrfSvc.$( "$isAdminUserLoggedIn", true );
+
+		super.assertNotEquals( "", csrfSvc.generateToken( true ) );
+	}
+
+	function test12_validateToken_shouldReturnTrue_whenSkippingAnonymousRequest() {
+		var csrfSvc = _getSvc( authenticatedSessionOnly=true );
+
+		csrfSvc.$( "$isWebsiteUserLoggedIn", false );
+		csrfSvc.$( "$isAdminUserLoggedIn", false );
+		csrfSvc.$( "_getToken", {} );
+
+		super.assertEquals( true, csrfSvc.validateToken( CreateUUId() ) );
+	}
+
+	function test13_validateToken_shouldReturnFalse_whenSkippingAnonymousRequest_butForcePassedWithInvalidToken() {
+		var csrfSvc = _getSvc( authenticatedSessionOnly=true );
+
+		csrfSvc.$( "$isWebsiteUserLoggedIn", false );
+		csrfSvc.$( "$isAdminUserLoggedIn", false );
+		csrfSvc.$( "_getToken", {} );
+
+		super.assertEquals( false, csrfSvc.validateToken( token=CreateUUId(), force=true ) );
+	}
+
+	function test14_validateToken_shouldReturnFalse_whenSkippingAnonymousRequest_butRequestNotAnonymousAndHasBadToken() {
+		var csrfSvc = _getSvc( authenticatedSessionOnly=true );
+
+		csrfSvc.$( "$isWebsiteUserLoggedIn", false );
+		csrfSvc.$( "$isAdminUserLoggedIn", true );
+		csrfSvc.$( "_getToken", {} );
+
+		super.assertEquals( false, csrfSvc.validateToken( token=CreateUUId(), force=true ) );
+	}
+
+	private function _getSvc(
+		  sessionStorage           = sessionStorage
+		, tokenExpiryInSeconds     = tokenExpiryInSeconds
+		, authenticatedSessionOnly = false
+	) {
+		return super.createMock( object=new preside.system.services.security.CsrfProtectionService(
+			  argumentCollection=arguments
+		) );
+	}
 }
 


### PR DESCRIPTION
CSRF attack mitigations are great and all. However, blanket mitigation on forms can lead to issues with performance, reducing the chance of caching pages for anonymous visitors, for example. 

This change provides the _option_, disabled by default, to only output CSRF tokens and validate CSRF tokens for authenticated users, or visitors that already have a token. This can be safe in many/most scenarios as the aim of a CSRF attack is to act on behalf of an authenticated user in most cases. Acting on behalf of an anonymous user usually poses little or no threat to security.

See: https://www.section.io/blog/csrf-and-caching/ for more background.