### PR TITLE
PRESSYNCED-2435: Text is not visible in preside admin toolbar when viewing a frontend page

### DIFF
--- a/system/assets/css/admin/frontend/toolbar.less
+++ b/system/assets/css/admin/frontend/toolbar.less
@@ -47,4 +47,8 @@ html {
 			}
 		}
 	}
+
+	.dropdown-menu {
+	    color : @text-color;
+	}
 }


### PR DESCRIPTION
Declare a font color to non-link text of preside admin toolbar's dropdown-menu.