### PR TITLE
Feature presidecms 2712 mediumtext not using richedior for editable page field

### DIFF
--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -2128,6 +2128,7 @@ component displayName="Preside Object Service" {
 		switch( arguments.dbType ){
 			case "text":
 			case "longtext":
+			case "mediumtext":
 			case "clob":
 				return "richeditor";
 			case "date":


### PR DESCRIPTION
Allow mediumtext to use richEditor formcontrol