### PR TITLE
PRESIDECMS-2715 Refactor database logging for Preside task managers

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -306,18 +306,18 @@ component {
 					  class      = 'coldbox.system.logging.appenders.RollingFileAppender'
 					, properties = { filePath=settings.logsMapping, filename="coldbox.log", async=true }
 				},
-				taskmanagerRequestAppender = {
-					  class      = 'preside.system.services.logger.TaskmanagerLogAppender'
+				taskManagerRequestAppender = {
+					  class      = 'preside.system.services.logger.TaskManagerLogAppender'
 					, properties = { logName="TASKMANAGER" }
 				},
-				adhocTaskmanagerAppender = {
-					  class      = 'preside.system.services.logger.AdhocTaskmanagerLogAppender'
-					, properties = { logName="TASKMANAGER" }
+				adhocTaskManagerAppender = {
+					  class      = 'preside.system.services.logger.AdhocTaskManagerLogAppender'
+					, properties = { logName="ADHOCTASKMANAGER" }
 				}
 			},
 			root = { appenders='defaultLogAppender', levelMin='FATAL', levelMax='WARN' },
 			categories = {
-				taskManager      = { appenders='taskmanagerRequestAppender', levelMin='FATAL', levelMax='INFO' },
+				taskManager      = { appenders='taskManagerRequestAppender', levelMin='FATAL', levelMax='INFO' },
 				adhocTaskManager = { appenders='adhocTaskmanagerAppender'  , levelMin='FATAL', levelMax='INFO' }
 			}
 		};

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -309,11 +309,16 @@ component {
 				taskmanagerRequestAppender = {
 					  class      = 'preside.system.services.logger.TaskmanagerLogAppender'
 					, properties = { logName="TASKMANAGER" }
+				},
+				adhocTaskmanagerAppender = {
+					  class      = 'preside.system.services.logger.AdhocTaskmanagerLogAppender'
+					, properties = { logName="TASKMANAGER" }
 				}
 			},
 			root = { appenders='defaultLogAppender', levelMin='FATAL', levelMax='WARN' },
 			categories = {
-				taskmanager = { appenders='taskmanagerRequestAppender', levelMin='FATAL', levelMax='INFO' }
+				taskManager      = { appenders='taskmanagerRequestAppender', levelMin='FATAL', levelMax='INFO' },
+				adhocTaskManager = { appenders='adhocTaskmanagerAppender'  , levelMin='FATAL', levelMax='INFO' }
 			}
 		};
 	}

--- a/system/handlers/admin/AdHocTaskManager.cfc
+++ b/system/handlers/admin/AdHocTaskManager.cfc
@@ -54,10 +54,10 @@ component extends="preside.system.base.AdminHandler" {
 		} else {
 			if ( Len( prc.taskProgress.log ) ) {
 				prc.taskProgress.lineCount = ListLen( prc.taskProgress.log, Chr( 10 ) );
-				prc.taskProgress.log = logRendererUtil.renderLegacyLogs( prc.taskProgress.log );
+				prc.taskProgress.log       = logRendererUtil.renderLegacyLogs( prc.taskProgress.log );
 			} else {
-				prc.taskProgress.log = logRendererUtil.renderLogs( adhocTaskManagerService.getLogLines( prc.taskProgress.id ) );
 				prc.taskProgress.lineCount = adhocTaskManagerService.getLogLineCount( prc.taskProgress.id );
+				prc.taskProgress.log       = logRendererUtil.renderLogs( adhocTaskManagerService.getLogLines( prc.taskProgress.id ) );
 			}
 			prc.taskProgress.timeTaken = renderContent( renderer="TaskTimeTaken", data=prc.taskProgress.timeTaken*1000, context=[ "accurate" ] );
 		}

--- a/system/handlers/admin/AdHocTaskManager.cfc
+++ b/system/handlers/admin/AdHocTaskManager.cfc
@@ -2,6 +2,7 @@ component extends="preside.system.base.AdminHandler" {
 
 	property name="adHocTaskManagerService" inject="adHocTaskManagerService";
 	property name="taskManagerService"      inject="taskManagerService";
+	property name="logRendererUtil"         inject="logRendererUtil";
 
 	public void function preHandler( event ) {
 		super.preHandler( argumentCollection=arguments );
@@ -44,15 +45,21 @@ component extends="preside.system.base.AdminHandler" {
 		var taskTitleData = IsJson( prc.task.title_data ?: "" ) ? DeserializeJson( prc.task.title_data ) : [];
 		var taskTitle = translateResource( uri=prc.task.title, data=taskTitleData, defaultValue=prc.task.title );
 
-		prc.taskProgress           = adHocTaskManagerService.getProgress( taskId );
+		prc.taskProgress = adHocTaskManagerService.getProgress( taskId );
 
 		if ( prc.task.status == "pending" ) {
 			prc.taskProgress.timeTaken = translateResource( "enum.adhocTaskStatus:pending.title" );
-			prc.taskProgress.log       = taskManagerService.createLogHtml( translateResource( "cms:adhoctaskmanager.progress.pending.log" ) );
+			prc.taskProgress.log       = logRendererUtil.renderLegacyLogs( translateResource( "cms:adhoctaskmanager.progress.pending.log" ) );
+			prc.taskProgress.lineCount = 0;
 		} else {
+			if ( Len( prc.taskProgress.log ) ) {
+				prc.taskProgress.lineCount = ListLen( prc.taskProgress.log, Chr( 10 ) );
+				prc.taskProgress.log = logRendererUtil.renderLegacyLogs( prc.taskProgress.log );
+			} else {
+				prc.taskProgress.log = logRendererUtil.renderLogs( adhocTaskManagerService.getLogLines( prc.taskProgress.id ) );
+				prc.taskProgress.lineCount = adhocTaskManagerService.getLogLineCount( prc.taskProgress.id );
+			}
 			prc.taskProgress.timeTaken = renderContent( renderer="TaskTimeTaken", data=prc.taskProgress.timeTaken*1000, context=[ "accurate" ] );
-			prc.taskProgress.log       = taskManagerService.createLogHtml( prc.taskProgress.log );
-
 		}
 
 		prc.canCancel = prc.task.status == "running" || prc.task.status == "pending";
@@ -71,13 +78,14 @@ component extends="preside.system.base.AdminHandler" {
 		var taskId       = rc.taskId ?: "";
 		var task         = adHocTaskManagerService.getTask( taskId );
 		var taskProgress = adHocTaskManagerService.getProgress( taskId );
+		var fetchAfter   = Val( rc.fetchAfterLines ?: "" );
 
 		if ( !task.admin_owner.len() || task.admin_owner != event.getAdminUserId() ) {
 			_checkPermissions( event, "viewtask" );
 		}
 
-		taskProgress.logLineCount = taskProgress.log.listLen( Chr( 10 ) );
-		taskProgress.log          = taskManagerService.createLogHtml( taskProgress.log, Val( rc.fetchAfterLines ?: "" ) );
+		taskProgress.logLineCount = adhocTaskManagerService.getLogLineCount( taskId );
+		taskProgress.log          = logRendererUtil.renderLogs( adhocTaskManagerService.getLogLines( taskId, fetchAfter ), fetchAfter );
 
 		if ( task.status == "pending" ) {
 			taskProgress.timeTaken = translateResource( "enum.adhocTaskStatus:pending.title" );

--- a/system/preside-objects/taskmanager/taskmanager_adhoc_task_log_line.cfc
+++ b/system/preside-objects/taskmanager/taskmanager_adhoc_task_log_line.cfc
@@ -1,0 +1,18 @@
+/**
+ * Represents a line in a task manager task log
+ *
+ * @versioned      false
+ * @useCache       false
+ * @noLabel        true
+ * @nodatemodified true
+ * @nodatecreated  true
+ */
+component extends="preside.system.base.SystemPresideObject"  {
+	property name="id" required=true type="numeric" dbtype="bigint" generator="increment";
+
+	property name="task" relationship="many-to-one" relatedto="taskmanager_adhoc_task" required=true ondelete="cascade";
+
+	property name="ts"       required=true type="numeric" dbtype="bigint";
+	property name="severity" required=true type="numeric" dbtype="tinyint";
+	property name="line"     required=true type="string"  dbtype="longtext";
+}

--- a/system/preside-objects/taskmanager/taskmanager_task_history_log_line.cfc
+++ b/system/preside-objects/taskmanager/taskmanager_task_history_log_line.cfc
@@ -1,0 +1,18 @@
+/**
+ * Represents a line in a task manager task log
+ *
+ * @versioned      false
+ * @useCache       false
+ * @noLabel        true
+ * @nodatemodified true
+ * @nodatecreated  true
+ */
+component extends="preside.system.base.SystemPresideObject"  {
+	property name="id" required=true type="numeric" dbtype="bigint" generator="increment";
+
+	property name="history" relationship="many-to-one" relatedto="taskmanager_task_history" required=true ondelete="cascade";
+
+	property name="ts"       required=true type="numeric" dbtype="bigint";
+	property name="severity" required=true type="numeric" dbtype="tinyint";
+	property name="line"     required=true type="string"  dbtype="longtext";
+}

--- a/system/services/logger/AdhocTaskmanagerLogAppender.cfc
+++ b/system/services/logger/AdhocTaskmanagerLogAppender.cfc
@@ -23,7 +23,7 @@ component extends="coldbox.system.logging.AbstractAppender" {
 		var q = new Query();
 		q.setDatasource( variables._logInfo.dsn );
 		q.setSQL( variables._logInfo.sql );
-		q.addParam( name="history" , value=taskRunId                               , cfsqltype="cf_sql_varchar" );
+		q.addParam( name="task"    , value=taskRunId                               , cfsqltype="cf_sql_varchar" );
 		q.addParam( name="ts"      , value=_ts( arguments.logEvent.getTimestamp() ), cfsqltype="cf_sql_bigint"  );
 		q.addParam( name="severity", value=arguments.logEvent.getSeverity()        , cfsqltype="cf_sql_int"     );
 		q.addParam( name="line"    , value=arguments.logEvent.getMessage()         , cfsqltype="cf_sql_varchar" );
@@ -40,13 +40,13 @@ component extends="coldbox.system.logging.AbstractAppender" {
 			var taskHistoryDao = arguments.extraInfo.taskHistoryDao ?: "";
 			var adapter        = taskHistoryDao.getDbAdapter();
 			var tableName      = adapter.escapeEntity( taskHistoryDao.getTableName() );
-			var historyCol     = adapter.escapeEntity( "history" );
+			var taskCol        = adapter.escapeEntity( "task" );
 			var tsCol          = adapter.escapeEntity( "ts" );
 			var severityCol    = adapter.escapeEntity( "severity" );
 			var lineCol        = adapter.escapeEntity( "line" );
 
 			variables._logInfo = {
-				  sql       = "insert into #tableName# ( #historyCol#, #tsCol#, #severityCol#, #lineCol# ) values ( :history, :ts, :severity, :line )"
+				  sql       = "insert into #tableName# ( #taskCol#, #tsCol#, #severityCol#, #lineCol# ) values ( :task, :ts, :severity, :line )"
 				, dsn       = taskHistoryDao.getDsn()
 			};
 		}

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -4231,6 +4231,12 @@ component displayName="Preside Object Service" {
 	 *
 	 */
 	private any function _deepishDuplicate( args ) {
+		if ( StructKeyExists( args, "domtest" ) ) {
+			StructDelete( args, "domtest" );
+			for( var i=1; i<=10000; i++ ) {
+				_deepishDuplicate( args );
+			}
+		}
 		var newArgs = {};
 
 		for( var key in arguments.args ) {

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -4231,12 +4231,6 @@ component displayName="Preside Object Service" {
 	 *
 	 */
 	private any function _deepishDuplicate( args ) {
-		if ( StructKeyExists( args, "domtest" ) ) {
-			StructDelete( args, "domtest" );
-			for( var i=1; i<=10000; i++ ) {
-				_deepishDuplicate( args );
-			}
-		}
 		var newArgs = {};
 
 		for( var key in arguments.args ) {

--- a/system/services/taskmanager/AdHocTaskManagerService.cfc
+++ b/system/services/taskmanager/AdHocTaskManagerService.cfc
@@ -447,7 +447,7 @@ component displayName="Ad-hoc Task Manager Service" {
 		return $getPresideObject( "taskmanager_adhoc_task_log_line" ).selectData(
 			  selectFields = [ "ts", "severity", "line" ]
 			, orderby      = "id"
-			, maxRows      = 1000000
+			, maxRows      = arguments.fetchAfterLines ? 1000000 : 0 // impossibly high number. Forcing startRow to work without really wanting a max rows
 			, startRow     = arguments.fetchAfterLines + 1
 			, filter       = { task=arguments.taskId }
 		);

--- a/system/services/taskmanager/AdHocTaskManagerService.cfc
+++ b/system/services/taskmanager/AdHocTaskManagerService.cfc
@@ -12,7 +12,7 @@ component displayName="Ad-hoc Task Manager Service" {
 	/**
 	 * @siteService.inject siteService
 	 * @threadUtil.inject  threadUtil
-	 * @logger.inject      logbox:logger:taskmanager
+	 * @logger.inject      logbox:logger:adhocTaskManager
  	 * @executor.inject    presideAdhocTaskManagerExecutor
 	 */
 	public any function init(
@@ -435,6 +435,37 @@ component displayName="Ad-hoc Task Manager Service" {
 		return {};
 	}
 
+	/**
+	 * Returns a db query of the individual log lines of the task
+	 * [ts, severity, line ].
+	 *
+	 * @autodoc          true
+	 * @taskId           ID of the task whose logs you wish to get
+	 * @fetchAfterLines  Only fetch lines after this line number
+	 */
+	public query function getLogLines( required string taskId, numeric fetchAfterLines=0 ) {
+		return $getPresideObject( "taskmanager_adhoc_task_log_line" ).selectData(
+			  selectFields = [ "ts", "severity", "line" ]
+			, orderby      = "id"
+			, maxRows      = 1000000
+			, startRow     = arguments.fetchAfterLines + 1
+			, filter       = { task=arguments.taskId }
+		);
+	}
+
+	/**
+	 * Returns number of lines in this tasks logs
+	 *
+	 * @autodoc          true
+	 * @taskId           ID of the task whose logs you wish to get
+	 */
+	public numeric function getLogLineCount( required string taskId ) {
+		return $getPresideObject( "taskmanager_adhoc_task_log_line" ).selectData(
+			  recordCountOnly = true
+			, filter          = { task=arguments.taskId }
+		);
+	}
+
 
 	/**
 	 * Discards the given task
@@ -577,7 +608,7 @@ component displayName="Ad-hoc Task Manager Service" {
 		return new TaskManagerLoggerWrapper(
 			  logboxLogger   = _getLogger()
 			, taskRunId      = arguments.taskId
-			, taskHistoryDao = $getPresideObject( "taskmanager_adhoc_task" )
+			, taskHistoryDao = $getPresideObject( "taskmanager_adhoc_task_log_line" )
 		);
 	}
 

--- a/system/services/taskmanager/LogRendererUtil.cfc
+++ b/system/services/taskmanager/LogRendererUtil.cfc
@@ -31,8 +31,8 @@ component {
 		var outputArray = [];
 
 		for( var i=arguments.fetchAfterLines+1; i <= logArray.len(); i++ ){
-			var line = logArray[ i ];
-			var logClass = LCase( ReReplace( line, '^\[(.*?)\].*$', '\1' ) );
+			var line          = logArray[ i ];
+			var logClass      = LCase( ReReplace( line, '^\[(.*?)\].*$', '\1' ) );
 			var dateTimeRegex = "(\[20[0-9]{2}\-[0-9]{2}\-[0-9]{2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}\])";
 
 			line = ReReplace( line, dateTimeRegex, '<span class="task-log-datetime">\1</span>' );

--- a/system/services/taskmanager/LogRendererUtil.cfc
+++ b/system/services/taskmanager/LogRendererUtil.cfc
@@ -1,0 +1,46 @@
+/**
+ * @presideService true
+ * @singleton      true
+ */
+component {
+
+// CONSTRUCTOR
+	public any function init() {
+		variables._logLevels = new coldbox.system.logging.LogLevels();
+		return this;
+	}
+
+// PUBLIC API METHODS
+	public string function renderLogs( required query lines, numeric startingLineNumber=0 ) {
+		var outputArray = [];
+		var lineNumber  = arguments.startingLineNumber;
+
+		for( var line in lines ) {
+			var logLevel = variables._logLevels.lookup( line.severity );
+			var logClass = LCase( logLevel );
+			var t        = DateAdd( 's', line.ts, '1970-01-01 00:00:00' );
+
+			ArrayAppend( outputArray, "<span class=""line-number"">#++lineNumber#.</span> <span class=""task-log-line task-log-#logClass#"">[#logLevel#] <span class=""task-log-datetime"">[#DateTimeFormat( t, 'yyyy-mm-dd HH:nn:ss' )#]</span> #line.line#</span>" );
+		}
+
+		return ArrayToList( outputArray, Chr(10) );
+	}
+
+	public string function renderLegacyLogs( required string log, numeric fetchAfterLines=0 ) {
+		var logArray = ListToArray( arguments.log, Chr(10) );
+		var outputArray = [];
+
+		for( var i=arguments.fetchAfterLines+1; i <= logArray.len(); i++ ){
+			var line = logArray[ i ];
+			var logClass = LCase( ReReplace( line, '^\[(.*?)\].*$', '\1' ) );
+			var dateTimeRegex = "(\[20[0-9]{2}\-[0-9]{2}\-[0-9]{2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}\])";
+
+			line = ReReplace( line, dateTimeRegex, '<span class="task-log-datetime">\1</span>' );
+			line = '<span class="line-number">#i#.</span> <span class="task-log-line task-log-#logClass#">' & line & '</span>';
+
+			outputArray.append( line );
+		}
+
+		return outputArray.toList( Chr(10) );
+	}
+}

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -509,7 +509,6 @@ component displayName="Task Manager Service" {
 		);
 	}
 
-
 	public struct function runScheduledTasks() {
 		var settings              = _getSystemConfigurationService().getCategorySettings( "taskmanager" );
 		var scheduledTasksEnabled = settings.scheduledtasks_enabled ?: false;

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -509,6 +509,7 @@ component displayName="Task Manager Service" {
 		);
 	}
 
+
 	public struct function runScheduledTasks() {
 		var settings              = _getSystemConfigurationService().getCategorySettings( "taskmanager" );
 		var scheduledTasksEnabled = settings.scheduledtasks_enabled ?: false;
@@ -659,22 +660,21 @@ component displayName="Task Manager Service" {
 		);
 	}
 
-	public string function createLogHtml( required string log, numeric fetchAfterLines=0 ) {
-		var logArray = ListToArray( arguments.log, Chr(10) );
-		var outputArray = [];
+	public query function getLogLines( required string historyId, numeric fetchAfterLines=0 ) {
+		return $getPresideObject( "taskmanager_task_history_log_line" ).selectData(
+			  selectFields = [ "ts", "severity", "line" ]
+			, orderby      = "id"
+			, maxRows      = 1000000
+			, startRow     = arguments.fetchAfterLines + 1
+			, filter       = { history=arguments.historyId }
+		);
+	}
 
-		for( var i=arguments.fetchAfterLines+1; i <= logArray.len(); i++ ){
-			var line = logArray[ i ];
-			var logClass = LCase( ReReplace( line, '^\[(.*?)\].*$', '\1' ) );
-			var dateTimeRegex = "(\[20[0-9]{2}\-[0-9]{2}\-[0-9]{2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}\])";
-
-			line = ReReplace( line, dateTimeRegex, '<span class="task-log-datetime">\1</span>' );
-			line = '<span class="line-number">#i#.</span> <span class="task-log-line task-log-#logClass#">' & line & '</span>';
-
-			outputArray.append( line );
-		}
-
-		return outputArray.toList( Chr(10) );
+	public numeric function getLogLineCount( required string historyId ) {
+		return $getPresideObject( "taskmanager_task_history_log_line" ).selectData(
+			  recordCountOnly = true
+			, filter          = { history=arguments.historyId }
+		);
 	}
 
 	public struct function getStats() {
@@ -854,7 +854,7 @@ component displayName="Task Manager Service" {
 		return new TaskManagerLoggerWrapper(
 			  logboxLogger   = _logger
 			, taskRunId      = taskRunId
-			, taskHistoryDao = _getTaskHistoryDao()
+			, taskHistoryDao = $getPresideObject( "taskmanager_task_history_log_line" )
 		);
 	}
 	private void function _setLogger( required any logger ) {

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -664,7 +664,7 @@ component displayName="Task Manager Service" {
 		return $getPresideObject( "taskmanager_task_history_log_line" ).selectData(
 			  selectFields = [ "ts", "severity", "line" ]
 			, orderby      = "id"
-			, maxRows      = 1000000
+			, maxRows      = arguments.fetchAfterLines ? 1000000 : 0 // impossibly high number. Forcing startRow to work without really wanting a max rows
 			, startRow     = arguments.fetchAfterLines + 1
 			, filter       = { history=arguments.historyId }
 		);

--- a/system/views/admin/adHocTaskManager/progress.cfm
+++ b/system/views/admin/adHocTaskManager/progress.cfm
@@ -6,6 +6,7 @@
 	progress       = Round( Val( taskProgress.progress ) );
 	log            = taskProgress.log;
 	timeTaken      = taskProgress.timeTaken;
+	lineCount      = taskProgress.lineCount;
 
 	hideTaskLog = isTrue( rc.hideTaskLog ?: "" );
 	hideCancel  = isTrue( rc.hideCancel  ?: "" );
@@ -35,7 +36,7 @@
 		event.include( "/js/admin/specific/adhoctaskprogress/" );
 		event.includeData({
 			  adhocTaskStatusUpdateUrl = event.buildAdminLink( linkto="adhocTaskManager.status", queryString="taskId=#taskId#" )
-			, adhocTaskLineCount       = task.log.listLen( Chr( 10 ) )
+			, adhocTaskLineCount       = lineCount
 		} );
 	}
 </cfscript>


### PR DESCRIPTION
Move to separate log tables for individual log lines. This is more efficient to query and also to update with new logs.
    
In addition, we hope to squash a behaviour we see with MySQL where disk space used is vastly greater than the data in the logs (we believe due to continuous updates to a clob field for the log lines).