### PR TITLE
PRESIDECMS-2717 Permanent redirect to inline assets with a public URL

### DIFF
--- a/system/handlers/core/AssetDownload.cfc
+++ b/system/handlers/core/AssetDownload.cfc
@@ -121,7 +121,7 @@ component {
 				if ( !ReFindNoCase( "^/asset/", assetPublicUrl ) && event.getCurrentUrl() != UrlDecode( assetPublicUrl ) ) {
 					setNextEvent(
 						  url        = assetPublicUrl
-						, statusCode = "302"
+						, statusCode = type.serveAsAttachment ? 302 : 301
 					);
 				}
 


### PR DESCRIPTION
Permanent redirect can then be cached more agressively by proxies, etc. which will save on traffic being processed by the application unnecessarily.

We still need a **temporary** redirect for assets like PDFs that are served as attachments in order to first record download actions for users. We do NOT want to do this for inline images in pages!