### PR TITLE
PRESIDECMS-2613 add complex feature enabled evaluation

### DIFF
--- a/system/services/features/FeatureService.cfc
+++ b/system/services/features/FeatureService.cfc
@@ -20,10 +20,13 @@ component singleton=true autodoc=true displayName="Feature service" {
 	/**
 	 * Returns whether or not the passed feature is currently enabled
 	 *
-	 * @feature.hint      name of the feature to check
+	 * @feature.hint      name of the feature to check, or logical expression containing features to check, e.g. "(featurex || featurey) && featurez"
 	 * @siteTemplate.hint current active site template - can be used to check features that can be site template specific
 	 */
 	public boolean function isFeatureEnabled( required string feature, string siteTemplate ) autodoc=true {
+		if ( _isComplexExpression( Trim( arguments.feature ) ) ) {
+			return _processComplexExpression( arguments.feature );
+		}
 		var features  = _getConfiguredFeatures();
 		var isEnabled = IsBoolean( features[ arguments.feature ].enabled ?: "" ) && features[ arguments.feature ].enabled;
 
@@ -72,6 +75,37 @@ component singleton=true autodoc=true displayName="Feature service" {
 		}
 
 		return "";
+	}
+
+// PRIVATE HELPERS
+	private boolean function _isComplexExpression( filter ) {
+		var evalChars        = "|&\(\)!\s";
+		var featureNameChars = "a-zA-Z0-9_\-";
+
+		// must contain one ore more special evaluation chars
+		// and must ONLY contain feature name chars + evaluation chars
+		return ReFind( "[#evalChars#]+", arguments.filter ) && ReFind( "^[#evalChars##featureNameChars#]+$", arguments.filter );
+	}
+
+	private boolean function _processComplexExpression( filter, siteTemplate ) {
+		var compiled = arguments.filter;
+		var features = ReMatch( "\b[a-zA-Z0-9_\-]+\b", arguments.filter );
+
+		ArraySort( features, function( a, b ){
+			var lena = Len( arguments.a );
+			var lenb = Len( arguments.b );
+			return lena == lenb ? 0 : ( lena < lenb ? 1 : -1 );
+		} );
+
+		for( var feature in features ) {
+			compiled = ReplaceNoCase( compiled, feature, isFeatureEnabled( feature, arguments.siteTemplate ) ? "true" : "false", "all" );
+		}
+
+		try {
+			return Evaluate( compiled );
+		} catch( any e ) {
+			throw( type="preside.feature.bad.expression", message="The feature name expression, [#arguments.filter#], could not be evaluated. Compiler error: [#e.message#]." );
+		}
 	}
 
 // GETTERS AND SETTERS

--- a/system/services/features/FeatureService.cfc
+++ b/system/services/features/FeatureService.cfc
@@ -25,7 +25,7 @@ component singleton=true autodoc=true displayName="Feature service" {
 	 */
 	public boolean function isFeatureEnabled( required string feature, string siteTemplate ) autodoc=true {
 		if ( _isComplexExpression( Trim( arguments.feature ) ) ) {
-			return _processComplexExpression( arguments.feature );
+			return _processComplexExpression( arguments.feature, arguments.siteTemplate );
 		}
 		var features  = _getConfiguredFeatures();
 		var isEnabled = IsBoolean( features[ arguments.feature ].enabled ?: "" ) && features[ arguments.feature ].enabled;

--- a/system/services/features/FeatureService.cfc
+++ b/system/services/features/FeatureService.cfc
@@ -98,7 +98,9 @@ component singleton=true autodoc=true displayName="Feature service" {
 		} );
 
 		for( var feature in features ) {
-			compiled = ReplaceNoCase( compiled, feature, isFeatureEnabled( feature, arguments.siteTemplate ) ? "true" : "false", "all" );
+			if ( feature != "not" && feature != "and" && feature != "or" ) {
+				compiled = ReplaceNoCase( compiled, feature, isFeatureEnabled( feature, arguments.siteTemplate ) ? "true" : "false", "all" );
+			}
 		}
 
 		try {

--- a/tests/integration/api/features/FeatureServiceTest.cfc
+++ b/tests/integration/api/features/FeatureServiceTest.cfc
@@ -42,6 +42,7 @@ component extends="testbox.system.BaseSpec"{
 				expect( svc.isFeatureEnabled( feature="(sites || what) && websiteusers", siteTemplate="" ) ).toBeTrue();
 				expect( svc.isFeatureEnabled( feature="((sites && what) && websiteusers)", siteTemplate="" ) ).toBeFalse();
 				expect( svc.isFeatureEnabled( feature="((sites && !what) && websiteusers)", siteTemplate="" ) ).toBeTrue();
+				expect( svc.isFeatureEnabled( feature="((sites and not what) and websiteusers)", siteTemplate="" ) ).toBeTrue();
 			} );
 
 			it( "should not attempt dynamic lucee execution with malicious input", function(){

--- a/tests/integration/api/features/FeatureServiceTest.cfc
+++ b/tests/integration/api/features/FeatureServiceTest.cfc
@@ -32,6 +32,27 @@ component extends="testbox.system.BaseSpec"{
 				expect( svc.isFeatureEnabled( feature="sites", siteTemplate="" ) ) .toBeTrue();
 			} );
 
+			it( "should multi-evaluate feature expressions using parenthesis and && and || characters", function(){
+				var svc = _getService();
+
+				expect( svc.isFeatureEnabled( feature="sites || websiteUsers", siteTemplate="" ) ).toBeTrue();
+				expect( svc.isFeatureEnabled( feature="sites && assetManager", siteTemplate="" ) ).toBeFalse();
+				expect( svc.isFeatureEnabled( feature="sites && websiteUsers", siteTemplate="" ) ).toBeTrue();
+				expect( svc.isFeatureEnabled( feature="(sites || what) && websiteusers", siteTemplate="" ) ).toBeTrue();
+				expect( svc.isFeatureEnabled( feature="((sites && what) && websiteusers)", siteTemplate="" ) ).toBeFalse();
+				expect( svc.isFeatureEnabled( feature="((sites && !what) && websiteusers)", siteTemplate="" ) ).toBeTrue();
+			} );
+
+			it( "should not attempt dynamic lucee execution with malicious input", function(){
+				var svc = _getService();
+
+				expect( svc.isFeatureEnabled( feature="http url='https://www.google.com';", siteTemplate="" ) ).toBeFalse();
+				expect( svc.isFeatureEnabled( feature="int( 45.0 )", siteTemplate="" ) ).toBeFalse();
+				expect( function(){
+					svc.isFeatureEnabled( feature="floor( something )", siteTemplate="" )
+				} ).toThrow( "preside.feature.bad.expression" ) ;
+			} );
+
 		} );
 
 		describe( "isFeatureDefined()", function(){

--- a/tests/integration/api/features/FeatureServiceTest.cfc
+++ b/tests/integration/api/features/FeatureServiceTest.cfc
@@ -36,8 +36,9 @@ component extends="testbox.system.BaseSpec"{
 				var svc = _getService();
 
 				expect( svc.isFeatureEnabled( feature="sites || websiteUsers", siteTemplate="" ) ).toBeTrue();
+				expect( svc.isFeatureEnabled( feature="sites or websiteUsers", siteTemplate="" ) ).toBeTrue();
 				expect( svc.isFeatureEnabled( feature="sites && assetManager", siteTemplate="" ) ).toBeFalse();
-				expect( svc.isFeatureEnabled( feature="sites && websiteUsers", siteTemplate="" ) ).toBeTrue();
+				expect( svc.isFeatureEnabled( feature="sites and websiteUsers", siteTemplate="" ) ).toBeTrue();
 				expect( svc.isFeatureEnabled( feature="(sites || what) && websiteusers", siteTemplate="" ) ).toBeTrue();
 				expect( svc.isFeatureEnabled( feature="((sites && what) && websiteusers)", siteTemplate="" ) ).toBeFalse();
 				expect( svc.isFeatureEnabled( feature="((sites && !what) && websiteusers)", siteTemplate="" ) ).toBeTrue();


### PR DESCRIPTION
In many scenarios, we need to be able to check whether or not multiple different features are enabled, or whether one feature is not enabled and another is, etc. This change adds support for using operators in our feature string to achieve this wherever we have feature specifications. e.g. in a form, you could now do:

```xml
<field name="myfield" feature="!( featureX and featureY ) or featureZ" />
```

Supports operators: `||`, `or`, `&&`, `and`, `!`, `not` plus support for use of parenthesis.

