### PR TITLE
PRESIDECMS-2722 only deserialize json strings when they represent an array or object

### DIFF
--- a/system/services/rendering/DelayedViewletRendererService.cfc
+++ b/system/services/rendering/DelayedViewletRendererService.cfc
@@ -147,16 +147,17 @@ component {
 
 // PRIVATE HELPERS
 	private struct function _parseArgs( required string args ) {
-		var parsed = {};
-		var keyValues = args.listToArray( "," );
+		var parsed       = {};
+		var keyValues    = ListToArray( args, "," );
+		var jsonDetector = "^[\{\[]"; // string starts with "[" or "{"
 
 		for( var keyValue in keyValues ) {
-			var key   = keyValue.trim().listFirst( "=" ).trim();
-			var value = keyValue.trim().listRest( "=" ).trim();
+			var key   = Trim( ListFirst( keyValue, "=" ) );
+			var value = Trim( ListRest(  keyValue, "=" ) );
 
 			parsed[ key ] = ToString( ToBinary( value ) );
 
-			if ( IsJson( parsed[ key ] ) ) {
+			if ( ReFind( jsonDetector, parsed[ key ] ) && IsJson( parsed[ key ] ) ) {
 				parsed[ key ] = DeserializeJSON( parsed[ key ], false );
 			}
 		}

--- a/tests/integration/api/rendering/DelayedViewletRendererServiceTest.cfc
+++ b/tests/integration/api/rendering/DelayedViewletRendererServiceTest.cfc
@@ -6,7 +6,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 				var service    = _getService();
 				var complexArg = { test="this" };
 				var dvs        = [
-					  "<!--dv:test.viewlet( arg1=#ToBase64( 'true' )#, arg2=#ToBase64( 'test' )#, arg3=#ToBase64( SerializeJson( complexArg ) )# )(private=true,prePostExempt=false)-->"
+					  "<!--dv:test.viewlet( arg1=#ToBase64( 'true' )#, arg2=#ToBase64( '33e10' )#, arg3=#ToBase64( SerializeJson( complexArg ) )# )(private=true,prePostExempt=false)-->"
 					, "<!--dv:another.test.viewlet(arg3=#ToBase64( 'false' )#)(private=true,prePostExempt=true)-->"
 					, "<!--dv:nested.viewlet()(private=false,prePostExempt=false)-->"
 				];
@@ -30,7 +30,7 @@ proident, sunt in Test #replacements[ dvs[3] ]#==RICHRENDERED==RICHRENDERED culp
 
 				mockColdbox.$( "renderViewlet" ).$args(
 					  event         = "test.viewlet"
-					, args          = { arg1=true, arg2='test', arg3=complexArg }
+					, args          = { arg1=true, arg2='33e10', arg3=complexArg }
 					, private       = true
 					, prepostExempt = false
 					, delayed       = false


### PR DESCRIPTION
Prevents unnecessary deserialization of plain strings that can can have unexpected defaults (e.g. `354e10` being treated as a number and being expanded)