### PR TITLE
PRESIDECMS-2723 more forgiving vips image processing

### DIFF
--- a/system/services/assetManager/VipsImageSizingService.cfc
+++ b/system/services/assetManager/VipsImageSizingService.cfc
@@ -374,7 +374,15 @@ component {
 		var smartcrop     = arguments.smartcrop ? "--smartcrop attention" : "";
 
 		try {
-			_exec( "vipsthumbnail", """#arguments.targetFile#"" -s #size# #smartcrop# --eprofile srgb -d -o ""#outputFormat#[#arguments.vipsQuality#,strip]""" );
+			try {
+				_exec( "vipsthumbnail", """#arguments.targetFile#"" -s #size# #smartcrop# --eprofile srgb -d -o ""#outputFormat#[#arguments.vipsQuality#,strip]""" );
+			} catch( any e ) {
+				if ( e.detail contains "no input profile" ) {
+					_exec( "vipsthumbnail", """#arguments.targetFile#"" -s #size# #smartcrop# -d -o ""#outputFormat#[#arguments.vipsQuality#,strip]""" );
+				} else {
+					rethrow;
+				}
+			}
 		} finally {
 			_deleteFile( arguments.targetFile );
 		}


### PR DESCRIPTION
If an image cannot be converted to `sRGB` while generating a thumbnail, then try again without conversion.

While there might be an argument for not bothering with sRGB conversion at all, I'm keen to keep things as compatible as possible in this ticket (i.e. not introducing a change that may have unexpected consequences).