### PR TITLE
PRESIDECMS-2729 Prevent unnecessary column fetches in dbsync

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -240,8 +240,8 @@ component {
 
 	private void function _clearExistingApplication() {
 		onApplicationEnd( application );
-		application.clear();
-		request.delete( "cb_requestcontext" );
+		StructClear( application );
+		StructDelete( request, "cb_requestcontext" );
 		SystemCacheClear( "template" );
 
 		if ( ( server.coldfusion.productName ?: "" ) == "Lucee" ) {

--- a/system/services/presideObjects/SqlSchemaSynchronizer.cfc
+++ b/system/services/presideObjects/SqlSchemaSynchronizer.cfc
@@ -167,8 +167,8 @@ component {
 
 	) {
 		var adapter        = _getAdapter( dsn = arguments.dsn );
-		var tableExists    =  _tableExists( tableName=arguments.tableName, dsn=arguments.dsn );
-		var tableColumns   = tableExists ? _getTableColumns( tableName=arguments.tableName, dsn=arguments.dsn ) : [];
+		var tableExists    = NullValue();
+		var tableColumns   = NullValue();
 		var columnSql      = "";
 		var colName        = "";
 		var column         = "";
@@ -189,8 +189,12 @@ component {
 
 		for( colName in ListToArray( arguments.dbFieldList ) ) {
 			colMeta = arguments.properties[ colName ];
-			if( _skipSync( colMeta ) && ArrayContainsNoCase( tableColumns, colName ) ) {
-				continue;
+			if( _skipSync( colMeta ) ) {
+				tableExists  = tableExists  ?: _tableExists( tableName=arguments.tableName, dsn=arguments.dsn );
+				tableColumns = tableColumns ?: tableExists ? _getTableColumns( tableName=arguments.tableName, dsn=arguments.dsn ) : [];
+				if ( ArrayContainsNoCase( tableColumns, colName ) ) {
+					continue;
+				}
 			}
 			column = sql.columns[ colName ] = StructNew();
 			args = {


### PR DESCRIPTION
This fetch was introduced as part of PRESIDECMS-2004 and currently means that we fetch all columns for all tables on every reload, regardless if there are any changes.
    
The fetch is ONLY required for a check when using the `skipDbSync` feature which afaik is used in a handful of external projects.
    
Delay the fetch until absolutely necessary for this feature and this negates a heap of wholly unnecessary schema querying.