### PR TITLE
PRESIDECMS-2729 lazy load fetching columns from DB

### DIFF
--- a/system/services/presideObjects/SqlSchemaSynchronizer.cfc
+++ b/system/services/presideObjects/SqlSchemaSynchronizer.cfc
@@ -167,8 +167,8 @@ component {
 
 	) {
 		var adapter        = _getAdapter( dsn = arguments.dsn );
-		var tableExists    =  _tableExists( tableName=arguments.tableName, dsn=arguments.dsn );
-		var tableColumns   = tableExists ? _getTableColumns( tableName=arguments.tableName, dsn=arguments.dsn ) : [];
+		var tableExists    = NullValue();
+		var tableColumns   = NullValue();
 		var columnSql      = "";
 		var colName        = "";
 		var column         = "";
@@ -189,8 +189,12 @@ component {
 
 		for( colName in ListToArray( arguments.dbFieldList ) ) {
 			colMeta = arguments.properties[ colName ];
-			if( _skipSync( colMeta ) && ArrayContainsNoCase( tableColumns, colName ) ) {
-				continue;
+			if( _skipSync( colMeta ) ) {
+				tableExists  = tableExists  ?: _tableExists( tableName=arguments.tableName, dsn=arguments.dsn );
+				tableColumns = tableColumns ?: tableExists ? _getTableColumns( tableName=arguments.tableName, dsn=arguments.dsn ) : [];
+				if ( ArrayContainsNoCase( tableColumns, colName ) ) {
+					continue;
+				}
 			}
 			column = sql.columns[ colName ] = StructNew();
 			args = {

--- a/system/services/presideObjects/SqlSchemaVersioning.cfc
+++ b/system/services/presideObjects/SqlSchemaVersioning.cfc
@@ -15,6 +15,21 @@ component singleton=true {
 	}
 
 // PUBLIC API METHODS
+	public string function getDbVersion( required array dsns ) {
+		for( var dsn in arguments.dsns ){
+			_checkVersionsTableExistance( dsn = dsn );
+			var versionRecord = _runSql(
+				  sql = "select version_hash from _preside_generated_entity_versions where entity_type = 'db' and entity_name = 'db'"
+				, dsn = dsn
+			);
+
+			if ( versionRecord.recordCount ) {
+				return versionRecord.version_hash;
+			}
+		}
+		return "";
+	}
+
 	public struct function getVersions( required array dsns ) {
 		var dsn            = "";
 		var versions       = {};


### PR DESCRIPTION
This fetch was introduced as part of PRESIDECMS-2004 and currently means that we fetch all columns for all tables on every reload, regardless if there are any changes.
    
The fetch is ONLY required for a check when using the `skipDbSync` feature which afaik is used in a handful of external projects.
    
Delay the fetch until absolutely necessary for this feature and this negates a heap of wholly unnecessary schema querying.
