### PR TITLE
PRESIDECMS-2730 prevent multiple file reads of extensions

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -240,8 +240,8 @@ component {
 
 	private void function _clearExistingApplication() {
 		onApplicationEnd( application );
-		application.clear();
-		request.delete( "cb_requestcontext" );
+		StructClear( application );
+		StructDelete( request, "cb_requestcontext" );
 		SystemCacheClear( "template" );
 
 		if ( ( server.coldfusion.productName ?: "" ) == "Lucee" ) {

--- a/tests/integration/api/devtools/ExtensionManagerServiceTest.cfc
+++ b/tests/integration/api/devtools/ExtensionManagerServiceTest.cfc
@@ -103,6 +103,7 @@ component extends="testbox.system.BaseSpec"{
 
 // private helpers
 	private void function _setup( array ignore=[] ) {
+		StructDelete( application, "__presideappExtensions" );
 		manager = new preside.system.services.devtools.ExtensionManagerService(
 			  appMapping       = "/tests/resources/extensionManager/application"
 			, ignoreExtensions = arguments.ignore


### PR DESCRIPTION
Due to the nature of load order and when we need to read in extensions, the extension manager service is not a singleton.

Make it use an application cache to ensure that we only read the extension once per application reload.