### PR TITLE
PRESIDECMS-2728 singleton postinit convention: prevent load order issues

### DIFF
--- a/system/interceptors/ApplicationReloadInterceptor.cfc
+++ b/system/interceptors/ApplicationReloadInterceptor.cfc
@@ -15,4 +15,10 @@ component extends="coldbox.system.Interceptor" {
 			logger.warn( "Application reload complete" );
 		}
 	}
+
+	public void function afterInstanceAutowire( event, interceptData ) {
+		if ( StructKeyExists( arguments.interceptData.target, "postInit" ) ) {
+			arguments.interceptData.target.postInit();
+		}
+	}
 }

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -34,8 +34,6 @@ component displayName="AssetManager Service" {
 		,          struct derivativeLimits       = {}
 		,          struct configuredFolders      = {}
 	) {
-		_migrateFromLegacyRecycleBinApproach();
-		_setupSystemFolders( arguments.configuredFolders );
 
 		_setDefaultStorageProvider( arguments.defaultStorageProvider );
 		_setDocumentMetadataService( arguments.documentMetadataService );
@@ -47,9 +45,16 @@ component displayName="AssetManager Service" {
 		_setDerivativeLimits( arguments.derivativeLimits );
 
 		_setConfiguredDerivatives( arguments.configuredDerivatives );
-		_setupConfiguredFileTypesAndGroups( arguments.configuredTypesByGroup );
+		_setConfiguredFolders( arguments.configuredFolders );
+		_setConfiguredTypesByGroup( arguments.configuredTypesByGroup );
 
 		return this;
+	}
+
+	public void function postInit() {
+		_migrateFromLegacyRecycleBinApproach();
+		_setupSystemFolders( _getConfiguredFolders() );
+		_setupConfiguredFileTypesAndGroups( _getConfiguredTypesByGroup() );
 	}
 
 // PUBLIC API METHODS
@@ -2840,4 +2845,19 @@ component displayName="AssetManager Service" {
 			, tooBigPlaceholder = arguments.derivativeLimits.tooBigPlaceholder ?: "/preside/system/assets/images/placeholders/largeimage.jpg"
 		};
 	}
+
+	private struct function _getConfiguredFolders() {
+	    return _configuredFolders;
+	}
+	private void function _setConfiguredFolders( required struct configuredFolders ) {
+	    _configuredFolders = arguments.configuredFolders;
+	}
+
+	private struct function _getConfiguredTypesByGroup() {
+	    return _configuredTypesByGroup;
+	}
+	private void function _setConfiguredTypesByGroup( required struct configuredTypesByGroup ) {
+	    _configuredTypesByGroup = arguments.configuredTypesByGroup;
+	}
+
 }

--- a/system/services/forms/FormsService.cfc
+++ b/system/services/forms/FormsService.cfc
@@ -41,9 +41,11 @@ component displayName="Forms service" {
 		_setConfiguredControls( arguments.configuredControls );
 		_setSiteService( arguments.siteService );
 
-		_loadForms();
-
 		return this;
+	}
+
+	public void function postInit() {
+		_loadForms();
 	}
 
 // PUBLIC API METHODS

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -65,17 +65,20 @@ component displayName="Preside Object Service" {
 		_setInstanceId( CreateObject('java','java.lang.System').identityHashCode( this ) );
 		_setDefaultQueryTimeout( arguments.defaultQueryTimeout   );
 		_setDefaultBgQueryTimeout( arguments.defaultBgQueryTimeout );
+		_setReloadDb( arguments.reloadDb );
 
+		return this;
+	}
+
+	public void function postInit() {
 		_loadObjects();
 
-		if ( arguments.reloadDb ) {
+		if ( _getReloadDb() ) {
 			dbSync();
 		}
 
 		_setSimpleLocalCache({});
 		_setCacheMap({});
-
-		return this;
 	}
 
 // PUBLIC API METHODS
@@ -4450,5 +4453,12 @@ component displayName="Preside Object Service" {
 	}
 	private void function _setDefaultBgQueryTimeout( required numeric defaultBgQueryTimeout ) {
 		_defaultBgQueryTimeout = arguments.defaultBgQueryTimeout;
+	}
+
+	private boolean function _getReloadDb() {
+	    return _reloadDb;
+	}
+	private void function _setReloadDb( required boolean reloadDb ) {
+	    _reloadDb = arguments.reloadDb;
 	}
 }

--- a/tests/integration/api/forms/FormsServiceTest.cfc
+++ b/tests/integration/api/forms/FormsServiceTest.cfc
@@ -923,6 +923,8 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase" {
 			, featureService       = mockFeatureService
 		) );
 
+		service.postInit();
+
 		service.$( "$hasAdminPermission", true );
 		service.$( "$getSystemConfigurationService", mockConfigService );
 		service.$( "$getPresideSetting", "" );

--- a/tests/resources/HelperObjects/PresideBddTestCase.cfc
+++ b/tests/resources/HelperObjects/PresideBddTestCase.cfc
@@ -125,6 +125,7 @@
 					, selectDataViewService  = arguments.selectDataViewService
 					, reloadDb               = false
 				);
+				request[ key ].postInit();
 				request[ key ] = getMockbox().createMock( object=request[ key ] );
 
 				versioningService.$( "$getPresideObjectService", request[ key ] );

--- a/tests/resources/HelperObjects/PresideTestCase.cfc
+++ b/tests/resources/HelperObjects/PresideTestCase.cfc
@@ -128,6 +128,7 @@
 					, reloadDb               = false
 					, throwOnLongTableName   = arguments.throwOnLongTableName
 				);
+				request[ key ].postInit();
 
 				request[ key ] = getMockbox().createMock( object=request[ key ] );
 


### PR DESCRIPTION
Prevent load order issues where preside object service, asset manager service, etc. trigger interceptors during their constructor leading to potential load order issues with DI.