### PR TITLE
PRESIDECMS-2745 add various request level caching to rules engine

### DIFF
--- a/system/services/rulesEngine/RulesEngineConditionService.cfc
+++ b/system/services/rulesEngine/RulesEngineConditionService.cfc
@@ -41,14 +41,17 @@ component displayName="RulesEngine Condition Service" {
 		var conditionRecord = $getPresideObject( "rules_engine_condition" ).selectData( id=arguments.conditionId );
 
 		if ( conditionRecord.recordCount ) {
-			if ( IsSimpleValue( conditionRecord.expressions ) ) {
-				conditionRecord.expressions[ 1 ] = DeSerializeJson( conditionRecord.expressions ); // deliberately against a cached query to avoid doing this multiple times
+			// deliberately against a cached query to avoid doing this multiple times
+			// where possible
+			if ( !QueryColumnExists( conditionRecord, "serializedExpressions" ) ) {
+				QueryAddColumn( conditionRecord, "serializedExpressions", [ DeSerializeJson( conditionRecord.expressions ) ] )
 			}
+
 			return {
 				  id          = arguments.conditionId
 				, name        = conditionRecord.condition_name
 				, context     = conditionRecord.context
-				, expressions = conditionRecord.expressions
+				, expressions = conditionRecord.serializedExpressions
 			};
 		}
 

--- a/system/services/rulesEngine/RulesEngineConditionService.cfc
+++ b/system/services/rulesEngine/RulesEngineConditionService.cfc
@@ -43,15 +43,15 @@ component displayName="RulesEngine Condition Service" {
 		if ( conditionRecord.recordCount ) {
 			// deliberately against a cached query to avoid doing this multiple times
 			// where possible
-			if ( !QueryColumnExists( conditionRecord, "serializedExpressions" ) ) {
-				QueryAddColumn( conditionRecord, "serializedExpressions", [ DeSerializeJson( conditionRecord.expressions ) ] )
+			if ( !QueryColumnExists( conditionRecord, "deserializedExpressions" ) ) {
+				QueryAddColumn( conditionRecord, "deserializedExpressions", [ DeSerializeJson( conditionRecord.expressions ) ] )
 			}
 
 			return {
 				  id          = arguments.conditionId
 				, name        = conditionRecord.condition_name
 				, context     = conditionRecord.context
-				, expressions = conditionRecord.serializedExpressions
+				, expressions = conditionRecord.deserializedExpressions
 			};
 		}
 

--- a/system/services/rulesEngine/RulesEngineExpressionService.cfc
+++ b/system/services/rulesEngine/RulesEngineExpressionService.cfc
@@ -315,10 +315,9 @@ component displayName="RulesEngine Expression Service" {
 			);
 		}
 
-		var noCache         = $getRequestContext().isEmailRenderingContext() || $getRequestContext().isBackgroundThread();
-		var requestCacheKey = noCache ? "" : ( arguments.expressionId & arguments.context & SerializeJson( arguments.payload ) & SerializeJson( arguments.configuredFields ) );
+		var requestCacheKey = arguments.expressionId & arguments.context & SerializeJson( arguments.payload ) & SerializeJson( arguments.configuredFields );
 
-		if ( noCache || !StructKeyExists( request, "_rulesEngineEvaluateExpressionCache" ) || !StructKeyExists( request._rulesEngineEvaluateExpressionCache, requestCacheKey ) ) {
+		if ( !StructKeyExists( request, "_rulesEngineEvaluateExpressionCache" ) || !StructKeyExists( request._rulesEngineEvaluateExpressionCache, requestCacheKey ) ) {
 			var handlerAction = expression.expressionhandler ?: "rules.expressions." & arguments.expressionId & ".evaluateExpression";
 			var eventArgs     = {
 				  context = arguments.context
@@ -334,10 +333,6 @@ component displayName="RulesEngine Expression Service" {
 				, prePostExempt  = true
 				, eventArguments = eventArgs
 			);
-
-			if ( noCache ) {
-				return result;
-			}
 
 			request._rulesEngineEvaluateExpressionCache[ requestCacheKey ] = result;
 		}

--- a/tests/integration/api/rulesEngine/RulesEngineContextServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineContextServiceTest.cfc
@@ -216,9 +216,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		) );
 
 		mockColdbox = createEmptyMock( "preside.system.coldboxModifications.Controller" );
+		mockRequestContext = createStub();
 		service.$( "$getColdbox", mockColdbox );
+		service.$( "$getRequestContext", mockRequestContext );
 
-		request._rulesEngineContextPayloadCache = {};
+		mockRequestContext.$( "isEmailRenderingContext", false );
+		mockRequestContext.$( "isBackgroundThread"     , true  );
 
 		return service;
 	}

--- a/tests/integration/api/rulesEngine/RulesEngineContextServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineContextServiceTest.cfc
@@ -218,6 +218,8 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		mockColdbox = createEmptyMock( "preside.system.coldboxModifications.Controller" );
 		service.$( "$getColdbox", mockColdbox );
 
+		request._rulesEngineContextPayloadCache = {};
+
 		return service;
 	}
 

--- a/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
@@ -711,6 +711,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		variables.mockI18n                   = createStub();
 		variables.mockExpressions            = arguments.expressions;
 		variables.mockColdboxController      = CreateStub();
+		variables.mockRequestContext         = createStub();
 		mockReaderService.$( "getExpressionsFromDirectories" ).$args( mockDirectories ).$results( mockExpressions );
 		mockI18n.$( "getFWLanguageCode" ).$results( "en" );
 		mockI18n.$( "getFWCountryCode" ).$results( "" );
@@ -729,12 +730,16 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		service = createMock( object=service );
 
 		service.$( "$getColdbox", mockColdboxController );
+		service.$( "$getRequestContext", mockRequestContext );
 		service.$( "_lazyLoadDynamicExpressions" );
 		mockContextService.$( "getContextObject" ).$args( "request" ).$results( "request_object" );
 		mockContextService.$( "getContextObject" ).$args( "" ).$results( "" );
 		service.$( "translateExpressionCategory", "default" );
 		service.$( "$getAdminLoginService", mockAdminLoginService );
 		service.$( "$getAdminPermissionService", mockAdminPermissionService );
+
+		mockRequestContext.$( "isEmailRenderingContext", false );
+		mockRequestContext.$( "isBackgroundThread"     , true  );
 
 		return service;
 	}

--- a/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
@@ -711,7 +711,6 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		variables.mockI18n                   = createStub();
 		variables.mockExpressions            = arguments.expressions;
 		variables.mockColdboxController      = CreateStub();
-		variables.mockRequestContext         = createStub();
 		mockReaderService.$( "getExpressionsFromDirectories" ).$args( mockDirectories ).$results( mockExpressions );
 		mockI18n.$( "getFWLanguageCode" ).$results( "en" );
 		mockI18n.$( "getFWCountryCode" ).$results( "" );
@@ -730,16 +729,12 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 		service = createMock( object=service );
 
 		service.$( "$getColdbox", mockColdboxController );
-		service.$( "$getRequestContext", mockRequestContext );
 		service.$( "_lazyLoadDynamicExpressions" );
 		mockContextService.$( "getContextObject" ).$args( "request" ).$results( "request_object" );
 		mockContextService.$( "getContextObject" ).$args( "" ).$results( "" );
 		service.$( "translateExpressionCategory", "default" );
 		service.$( "$getAdminLoginService", mockAdminLoginService );
 		service.$( "$getAdminPermissionService", mockAdminPermissionService );
-
-		mockRequestContext.$( "isEmailRenderingContext", false );
-		mockRequestContext.$( "isBackgroundThread"     , true  );
 
 		return service;
 	}


### PR DESCRIPTION
PRESIDECMS-2745 add various request level caching to rules engine.

* Calculation of any given context's payload
* Evaluation of an individual expression
* Evaluation of an entire condition
* Various other calculations

The idea here is that the result of condition and expression evaluation
will not change within the scope of a request and neither will a payload
for a given context. In complicated pages with a lot of conditions to run,
we can save a lot of resource by caching results.

n.b. While here, also reduce use of member functions.