### PR TITLE
PRESIDECMS-2788 add an interception point that fires after delayed viewlets are rendered.

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -289,6 +289,7 @@ component {
 		interceptorSettings.customInterceptionPoints.append( "preRenderDataManagerObjectInfoCard"    );
 		interceptorSettings.customInterceptionPoints.append( "preRenderDataManagerObjectTabs"        );
 		interceptorSettings.customInterceptionPoints.append( "postPrepareDevToolsVersions"           );
+		interceptorSettings.customInterceptionPoints.append( "postRenderDelayedViewlets"             );
 	}
 
 	private void function __setupCachebox() {

--- a/system/services/rendering/DelayedViewletRendererService.cfc
+++ b/system/services/rendering/DelayedViewletRendererService.cfc
@@ -36,8 +36,9 @@ component {
 		var dvPattern        = "<!--dv:(.*?)\((#encodedArgsRegex#)\)\(private=(true|false),prePostExempt=(true|false)\)-->";
 		var cb               = $getColdbox();
 		var rendererSvc      = _getContentRendererService();
+		var interceptData    = {};
 
-		return _getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.content, regexPattern=dvPattern, recurse=true, processor=function( captureGroups ){
+		interceptData.renderedContent =_getDynamicFindAndReplaceService().dynamicFindAndReplace( source=arguments.content, regexPattern=dvPattern, recurse=true, processor=function( captureGroups ){
 			var renderedViewlet = cb.renderViewlet(
 				  event         = ( arguments.captureGroups[ 2 ] ?: "" )
 				, args          = _parseArgs( Trim( arguments.captureGroups[ 3 ] ?: "" ) )
@@ -55,6 +56,10 @@ component {
 
 			return "";
 		} );
+
+		$announceInterception( "postRenderDelayedViewlets", interceptData );
+
+		return interceptData.renderedContent ?: "";
 	}
 
 	/**

--- a/tests/integration/api/rendering/DelayedViewletRendererServiceTest.cfc
+++ b/tests/integration/api/rendering/DelayedViewletRendererServiceTest.cfc
@@ -152,6 +152,7 @@ proident, sunt in Test #replacements[ dvs[3] ]#==RICHRENDERED==RICHRENDERED culp
 
 		service.$( "$getColdbox", mockColdbox );
 		service.$( "$isFeatureEnabled", true );
+		service.$( "$announceInterception" );
 
 		return service;
 	}


### PR DESCRIPTION
This allows custom code to alter the rendered content AFTER all handler logic has run
that crafts the full page content.

This is important for things like google tag manager where content handlers might publish
event data that is needed to output in the final content.