### PR TITLE
PRESIDECMS-2801 remove needless rules engine expression cache

### DIFF
--- a/system/services/routeHandlers/RulesEngineConditionsExpressionsJsHandler.cfc
+++ b/system/services/routeHandlers/RulesEngineConditionsExpressionsJsHandler.cfc
@@ -39,7 +39,7 @@ component {
 
 	public string function build( required struct buildArgs, required any event ) {
 		var ruleContext = buildArgs.conditionExpressionsContext ?: "";
-		var path   = "/#i18n.getFwLocale()#/#ruleContext#/#variables._applicationCacheBuster#/";
+		var path   = "/#i18n.getFwLocale()#/#ruleContext#/#LCase( Hash( variables._applicationCacheBuster & event.getAdminUserId() ) )#/";
 
 		if ( Len( Trim( buildArgs.excludeTags ?: "" ) ) ) {
 			path &= "?excludeTags=#Trim( buildArgs.excludeTags )#";

--- a/system/services/routeHandlers/RulesEngineFilterExpressionsJsHandler.cfc
+++ b/system/services/routeHandlers/RulesEngineFilterExpressionsJsHandler.cfc
@@ -39,7 +39,7 @@ component {
 
 	public string function build( required struct buildArgs, required any event ) {
 		var object = buildArgs.filterExpressionsObject ?: "";
-		var path   = "/#i18n.getFwLocale()#/#object#/#variables._applicationCacheBuster#/";
+		var path   = "/#i18n.getFwLocale()#/#object#/#LCase( Hash( variables._applicationCacheBuster & event.getAdminUserId() ) )#/";
 
 		if ( Len( Trim( buildArgs.excludeTags ?: "" ) ) ) {
 			path &= "?excludeTags=#Trim( buildArgs.excludeTags )#";

--- a/system/services/rulesEngine/RulesEngineExpressionService.cfc
+++ b/system/services/rulesEngine/RulesEngineExpressionService.cfc
@@ -32,7 +32,6 @@ component displayName="RulesEngine Expression Service" {
 		_setAutoExpressionGenerator( arguments.autoExpressionGenerator );
 		_setExpressions( expressionReaderService.getExpressionsFromDirectories( expressionDirectories ) );
 		_setI18n( i18n );
-		_setRulesEngineExpressionCache( {} );
 
 		return this;
 	}
@@ -53,13 +52,6 @@ component displayName="RulesEngine Expression Service" {
 		, string excludeTags  = ""
 		, array  userRoles    = _getAdminUserRoles()
 	) {
-		var cache    = _getRulesEngineExpressionCache();
-		var cachekey = arguments.filterObject & "_" & _getI18n().getFWLanguageCode() & "_" & _getI18n().getFWCountryCode() & "_" & arguments.context & "_" & arguments.excludeTags & "_" & hash( serializeJSON( arguments.userRoles ) );
-
-		if ( StructKeyExists( cache, cacheKey ) ) {
-			return cache[ cacheKey ];
-		}
-
 		_lazyLoadDynamicExpressions( argumentCollection=arguments );
 
 		var allExpressions       = _getExpressions();
@@ -130,8 +122,6 @@ component displayName="RulesEngine Expression Service" {
 			}
 			return aCategory > bCategory ? 1 : -1;
 		} );
-
-		cache[ cacheKey ] = list;
 
 		return list;
 	}
@@ -558,13 +548,6 @@ component displayName="RulesEngine Expression Service" {
 		  required string objectName
 		,          string structKeyPreffix = ""
 	) {
-		var cache    = _getRulesEngineExpressionCache();
-		var cachekey = "autoExpressionRoleLimits" & "_" & arguments.structKeyPreffix & "_" & arguments.objectName;
-
-		if ( StructKeyExists( cache, cacheKey ) ) {
-			return cache[ cacheKey ];
-		}
-
 		var roleLimit  = {};
 		var properties = $getPresideObjectService().getObjectProperties( arguments.objectName );
 
@@ -589,7 +572,6 @@ component displayName="RulesEngine Expression Service" {
 			}
 		}
 
-		cache[ cacheKey ] = roleLimit;
 		return roleLimit;
 	}
 
@@ -675,13 +657,6 @@ component displayName="RulesEngine Expression Service" {
 	}
 	private void function _setContextService( required any contextService ) {
 		_contextService = arguments.contextService;
-	}
-
-	private struct function _getRulesEngineExpressionCache() {
-		return _rulesEngineExpressionCache;
-	}
-	private void function _setRulesEngineExpressionCache( required struct rulesEngineExpressionCache ) {
-		_rulesEngineExpressionCache = arguments.rulesEngineExpressionCache;
 	}
 
 	private any function _getI18n() {

--- a/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
+++ b/tests/integration/api/rulesEngine/RulesEngineExpressionServiceTest.cfc
@@ -278,6 +278,8 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				var object  = "usergroup";
 				var expressionIds = mockExpressions.keyArray();
 
+				service.$( "getObjectFieldsExpressionRoleLimits", {} );
+
 				for( var id in expressionIds ){
 					service.$( "getExpression" ).$args( expressionId=id, objectName=object ).$results(
 						{ id=id, label=id, text=id, fields={}, contexts=mockExpressions[id].contexts }


### PR DESCRIPTION
The cache here is never really used. The method result that is cached is only ever called internally and the result of this is then cached again to file.

Furthermore, we're creating cache files (and recalculating from scratch) for every combination of user role that might ask for the data - regardless of whether or not this will make a difference. There are no core objects that use this system of roles and so we're wasting a huge amount of processor and memory due to this additional role layer.