### PR TITLE
PRESIDECMS-2823 ensure cookies have secure=true when sites not used. 

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -636,7 +636,7 @@ component {
 		var cleanedCookies    = [];
 		var anyCookiesChanged = false;
 		var site              = cbController.getRequestContext().getSite();
-		var isSecure          = ( site.protocol ?: "http" ) == "https";
+		var isSecure          = cbController.getSetting( "forcessl" ) || ( site.protocol ?: "http" ) == "https";
 
 		for( var cooky in allCookies ) {
 			if ( !Len( Trim( cooky ) ) ) {


### PR DESCRIPTION
When site feature is not used and applications configure the forceSsl
flag, all cookies should be set with a secure flag. i.e. for admin
only applications.