### PR TITLE
PRESIDECMS-2835 do not reprocess draft emails in template stats migration

### DIFF
--- a/system/services/email/EmailStatsService.cfc
+++ b/system/services/email/EmailStatsService.cfc
@@ -271,7 +271,7 @@ component {
 
 		if ( migration.recordCount ) {
 			$systemOutput( "[EmailLogPerformance] Resetting previous migration from temporary performance extension..." );
-			templateDao.updateData( forceUpdateAll=true, data={
+			templateDao.updateData( filter={ _version_is_draft=false }, data={
 				  stats_collection_enabled    = false
 				, stats_collection_enabled_on = ""
 			} );


### PR DESCRIPTION
These emails should have no emails sent and so stats update is irrelevant.
This prevents inadvertently publishing these templates in the update process
which could lead to old draft but scheduled emails getting sent out
after the upgrade.