### PR TITLE
PRESIDECMS-2822 determine redirect type by whether or not downloads want to be tracked.

### DIFF
--- a/system/handlers/core/AssetDownload.cfc
+++ b/system/handlers/core/AssetDownload.cfc
@@ -112,7 +112,7 @@ component {
 				} );
 
 				var filename = _getFilenameForAsset( Len( Trim( asset.file_name ) ) ? asset.file_name : asset.title, type.extension );
-				if ( type.serveAsAttachment ) {
+				if ( type.trackDownloads ) {
 					websiteUserActionService.recordAction(
 						  action     = "download"
 						, type       = "asset"

--- a/system/handlers/core/AssetDownload.cfc
+++ b/system/handlers/core/AssetDownload.cfc
@@ -127,7 +127,7 @@ component {
 				if ( !ReFindNoCase( "^/asset/", assetPublicUrl ) && event.getCurrentUrl() != UrlDecode( assetPublicUrl ) ) {
 					setNextEvent(
 						  url        = assetPublicUrl
-						, statusCode = type.serveAsAttachment ? 302 : 301
+						, statusCode = type.trackDownloads ? 302 : 301
 					);
 				}
 


### PR DESCRIPTION
Instead of whether the download is being served as an attachment or inline which is
a coincidental reason. The main driver is that we should not cache the redirect
when we want all traffic to pass through here for tracking purposes.
