### PR TITLE
PRESIDECMS-2762 requeue stale locked tasks within configurable window

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1082,6 +1082,11 @@ component {
 
 		settings.heartbeats.taskmanager.poolSize  = Val( settings.env.TASKMANAGER_POOL_SIZE  ?: 0 );
 		settings.heartbeats.adhocTask.poolSize    = Val( settings.env.ADHOCTASK_POOL_SIZE    ?: 0 );
+
+		settings.heartbeats.adhocTask.staleLockSettings = {
+			  minAgeInMinutes = 5
+			, maxAgeInMinutes = ( 7 * 24 * 60 ) // one week (i.e. ignore stale tasks over one week old to avoid restarting very old tasks with unexpected results)
+		};
 	}
 
 	private void function __setupNotifications() {

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1083,9 +1083,11 @@ component {
 		settings.heartbeats.taskmanager.poolSize  = Val( settings.env.TASKMANAGER_POOL_SIZE  ?: 0 );
 		settings.heartbeats.adhocTask.poolSize    = Val( settings.env.ADHOCTASK_POOL_SIZE    ?: 0 );
 
-		settings.heartbeats.adhocTask.staleLockSettings = {
-			  minAgeInMinutes = 5
-			, maxAgeInMinutes = ( 7 * 24 * 60 ) // one week (i.e. ignore stale tasks over one week old to avoid restarting very old tasks with unexpected results)
+		settings.heartbeats.adhocTask.staleTaskSettings = {
+			  lockedMinAgeInMinutes          = 5
+			, lockedMaxAgeInMinutes          = ( 7 * 24 * 60 ) // one week (i.e. ignore stale tasks over one week old to avoid restarting very old tasks with unexpected results)
+			, inactiveRunningMinAgeInMinutes = 360
+			, inactiveRunningMaxAgeInMinutes = ( 7 * 24 * 60 ) // one week (i.e. ignore stale tasks over one week old to avoid restarting very old tasks with unexpected results)
 		};
 	}
 

--- a/system/services/concurrency/PresideAdhocTaskHeartBeat.cfc
+++ b/system/services/concurrency/PresideAdhocTaskHeartBeat.cfc
@@ -36,7 +36,12 @@ component extends="AbstractHeartBeat" {
 			$raiseError( e );
 		}
 		try {
-			_getAdhocTaskmanagerService().unlockStaleLockedTasks();
+			_getAdhocTaskmanagerService().processStaleLockedTasks();
+		} catch( any e ) {
+			$raiseError( e );
+		}
+		try {
+			_getAdhocTaskmanagerService().failInactiveRunningTasks();
 		} catch( any e ) {
 			$raiseError( e );
 		}

--- a/system/services/concurrency/PresideAdhocTaskHeartBeat.cfc
+++ b/system/services/concurrency/PresideAdhocTaskHeartBeat.cfc
@@ -35,6 +35,11 @@ component extends="AbstractHeartBeat" {
 		} catch( any e ) {
 			$raiseError( e );
 		}
+		try {
+			_getAdhocTaskmanagerService().unlockStaleLockedTasks();
+		} catch( any e ) {
+			$raiseError( e );
+		}
 	}
 
 

--- a/system/services/taskmanager/AdHocTaskManagerService.cfc
+++ b/system/services/taskmanager/AdHocTaskManagerService.cfc
@@ -667,9 +667,9 @@ component displayName="Ad-hoc Task Manager Service" {
 
 		$getPresideObject( "taskmanager_adhoc_task" ).updateData(
 			  filter       = "status = :status and datemodified <= :datemodified"
-			, filterParams = { status="locked", dateModified=maxAge }
+			, filterParams = { status="running", dateModified=maxAge }
 			, data         = {
-				  status        = "running"
+				  status        = "failed"
 				, last_error    = '{"message":"Task marked as permanently failed as it has been in a running status for longer than the configured max age (#NumberFormat( maxAge )# minutes)" }'
 				, finished_on   = _now()
 			  }

--- a/system/services/taskmanager/AdHocTaskManagerService.cfc
+++ b/system/services/taskmanager/AdHocTaskManagerService.cfc
@@ -14,23 +14,24 @@ component displayName="Ad-hoc Task Manager Service" {
 	 * @threadUtil.inject                threadUtil
 	 * @logger.inject                    logbox:logger:adhocTaskManager
  	 * @executor.inject                  presideAdhocTaskManagerExecutor
- 	 * @minStaleLockTimeInMinutes.inject coldbox:setting:heartbeats.adhocTask.staleLockSettings.minAgeInMinutes
- 	 * @maxStaleLockTimeInMinutes.inject coldbox:setting:heartbeats.adhocTask.staleLockSettings.maxAgeInMinutes
+ 	 * @staleTaskSettings.inject         coldbox:setting:heartbeats.adhocTask.staleTaskSettings
 	 */
 	public any function init(
 		  required any siteService
 		, required any logger
 		, required any threadUtil
 		, required any executor
-		, required any minStaleLockTimeInMinutes
-		, required any maxStaleLockTimeInMinutes
+		, required any staleTaskSettings
 	) {
 		_setSiteService( arguments.siteService );
 		_setLogger( arguments.logger );
 		_setThreadUtil( arguments.threadUtil );
 		_setExecutor( arguments.executor );
-		_setMinStaleLockTimeInMinutes( arguments.minStaleLockTimeInMinutes );
-		_setMaxStaleLockTimeInMinutes( arguments.maxStaleLockTimeInMinutes );
+
+		_setMinStaleLockTimeInMinutes(       arguments.staleTaskSettings.lockedMinAgeInMinutes          ?: 5               );
+		_setMaxStaleLockTimeInMinutes(       arguments.staleTaskSettings.lockedMaxAgeInMinutes          ?: ( 7 * 24 * 60 ) );
+		_setMinInactiveRunningTimeInMinutes( arguments.staleTaskSettings.inactiveRunningMinAgeInMinutes ?: 240             );
+		_setMaxInactiveRunningTimeInMinutes( arguments.staleTaskSettings.inactiveRunningMaxAgeInMinutes ?: ( 7 * 24 * 60 ) );
 
 		return this;
 	}
@@ -619,17 +620,58 @@ component displayName="Ad-hoc Task Manager Service" {
 		return true;
 	}
 
-	public void function unlockStaleLockedTasks() {
+	public void function processStaleLockedTasks() {
 		var minAge = DateAdd( "n", 0-_getMinStaleLockTimeInMinutes(), Now() );
 		var maxAge = DateAdd( "n", 0-_getMaxStaleLockTimeInMinutes(), Now() );
 
 		$getPresideObject( "taskmanager_adhoc_task" ).updateData(
 			  filter       = "status = :status and datemodified < :minAge and datemodified > :maxAge"
-			, data         = { status="pending", last_error="Task was stuck in 'locked' status. Requeued." }
 			, filterParams = {
 				  status = "locked"
 				, minAge = { type="cf_sql_datetime", value=minAge }
 				, maxAge = { type="cf_sql_datetime", value=maxAge }
+			  }
+			, data         = {
+				  status     = "pending"
+				, last_error = '{"message":"Task was stuck in \"locked\" status and has been requeued."}'
+			  }
+		);
+
+		$getPresideObject( "taskmanager_adhoc_task" ).updateData(
+			  filter       = "status = :status and datemodified <= :datemodified"
+			, filterParams = { status="locked", dateModified=maxAge }
+			, data         = {
+				  status        = "failed"
+				, last_error    = '{"message":"Task marked as failed as it has been in a locked status for longer than the configured age (#NumberFormat( maxAge )# minutes)" }'
+				, finished_on   = _now()
+			  }
+		);
+	}
+
+	public void function failInactiveRunningTasks() {
+		var minAge = DateAdd( "n", 0-_getMinInactiveRunningTimeInMinutes(), Now() );
+		var maxAge = DateAdd( "n", 0-_getMaxInactiveRunningTimeInMinutes(), Now() );
+		var tasks = $getPresideObject( "taskmanager_adhoc_task" ).selectData(
+			  selectFields = [ "id" ]
+			, filter       = "status = :status and datemodified < :minAge and datemodified > :maxAge"
+			, filterParams = {
+				  status = "running"
+				, minAge = { type="cf_sql_datetime", value=minAge }
+				, maxAge = { type="cf_sql_datetime", value=maxAge }
+			  }
+		);
+
+		for( var task in tasks ) {
+			failTask( taskId=task.id, error={ message="Task marked as running but no activity for at least #_getMinInactiveRunningTimeInMinutes# minutes. Failing task as timed out." } );
+		}
+
+		$getPresideObject( "taskmanager_adhoc_task" ).updateData(
+			  filter       = "status = :status and datemodified <= :datemodified"
+			, filterParams = { status="locked", dateModified=maxAge }
+			, data         = {
+				  status        = "running"
+				, last_error    = '{"message":"Task marked as permanently failed as it has been in a running status for longer than the configured max age (#NumberFormat( maxAge )# minutes)" }'
+				, finished_on   = _now()
 			  }
 		);
 	}
@@ -763,5 +805,21 @@ component displayName="Ad-hoc Task Manager Service" {
 	private void function _setMaxStaleLockTimeInMinutes( required numeric maxStaleLockTimeInMinutes ) {
 	    _maxStaleLockTimeInMinutes = arguments.maxStaleLockTimeInMinutes;
 	}
+
+	private any function _getMinInactiveRunningTimeInMinutes() {
+	    return _minInactiveRunningTimeInMinutes;
+	}
+	private void function _setMinInactiveRunningTimeInMinutes( required numeric minInactiveRunningTimeInMinutes ) {
+	    _minInactiveRunningTimeInMinutes = arguments.minInactiveRunningTimeInMinutes;
+	}
+
+	private any function _getMaxInactiveRunningTimeInMinutes() {
+	    return _maxInactiveRunningTimeInMinutes;
+	}
+	private void function _setMaxInactiveRunningTimeInMinutes( required numeric maxInactiveRunningTimeInMinutes ) {
+	    _maxInactiveRunningTimeInMinutes = arguments.maxInactiveRunningTimeInMinutes;
+	}
+
+
 
 }

--- a/tests/integration/api/taskmanager/AdHocTaskManagerServiceTest.cfc
+++ b/tests/integration/api/taskmanager/AdHocTaskManagerServiceTest.cfc
@@ -815,13 +815,12 @@ component extends="testbox.system.BaseSpec" {
 		nowish              = DateAdd( 'd', 1, Now() );
 
 		var service = CreateMock( object=new preside.system.services.taskmanager.AdHocTaskManagerService(
-			  taskScheduler             = mockTaskScheduler
-			, siteService               = mockSiteService
-			, logger                    = mockLogBoxLogger
-			, threadUtil                = mockThreadUtil
-			, executor                  = mockExecutor
-			, minStaleLockTimeInMinutes = 5
-			, maxStaleLockTimeInMinutes = ( 60 * 24 )
+			  taskScheduler     = mockTaskScheduler
+			, siteService       = mockSiteService
+			, logger            = mockLogBoxLogger
+			, threadUtil        = mockThreadUtil
+			, executor          = mockExecutor
+			, staleTaskSettings = {}
 		) );
 
 		mockRequestContext.$( "setUseQueryCache" );

--- a/tests/integration/api/taskmanager/AdHocTaskManagerServiceTest.cfc
+++ b/tests/integration/api/taskmanager/AdHocTaskManagerServiceTest.cfc
@@ -815,11 +815,13 @@ component extends="testbox.system.BaseSpec" {
 		nowish              = DateAdd( 'd', 1, Now() );
 
 		var service = CreateMock( object=new preside.system.services.taskmanager.AdHocTaskManagerService(
-			  taskScheduler        = mockTaskScheduler
-			, siteService          = mockSiteService
-			, logger               = mockLogBoxLogger
-			, threadUtil           = mockThreadUtil
-			, executor             = mockExecutor
+			  taskScheduler             = mockTaskScheduler
+			, siteService               = mockSiteService
+			, logger                    = mockLogBoxLogger
+			, threadUtil                = mockThreadUtil
+			, executor                  = mockExecutor
+			, minStaleLockTimeInMinutes = 5
+			, maxStaleLockTimeInMinutes = ( 60 * 24 )
 		) );
 
 		mockRequestContext.$( "setUseQueryCache" );


### PR DESCRIPTION
Tasks can get stuck in a 'locked' state when an application crashes/restarts
at the point of thread creation to run the task. 

This change makes it so that locked tasks are checked at the same time
that queued tasks are checked. Any "stale" locked tasks are then requeued.

The definition of stale is configurable with defaults of between 1 week and   
5 minutes old. The 1 week limit made to prevent sudden very old stale tasks
from being run without warning and causing disruption.