### PR TITLE
PRESIDECMS-2886 display missing activity types in email logs

### DIFF
--- a/system/i18n/cms.properties
+++ b/system/i18n/cms.properties
@@ -2056,6 +2056,9 @@ mailcenter.logs.action.resend.original.message=The original email was re-sent to
 mailcenter.logs.action.resend.rebuild.message=The email was rebuilt and re-sent to the recipient address. {1}
 mailcenter.logs.action.resend.link.title=View activity of re-sent message
 
+mailcenter.logs.action.error.title=Sending error
+mailcenter.logs.action.error.message=A sending error occurred. Error message: {1}
+
 mailcenter.logs.action.markasspam.title=Complained
 mailcenter.logs.action.markasspam.message=The recipient flagged the email as spam.
 

--- a/system/i18n/cms.properties
+++ b/system/i18n/cms.properties
@@ -2056,6 +2056,15 @@ mailcenter.logs.action.resend.original.message=The original email was re-sent to
 mailcenter.logs.action.resend.rebuild.message=The email was rebuilt and re-sent to the recipient address. {1}
 mailcenter.logs.action.resend.link.title=View activity of re-sent message
 
+mailcenter.logs.action.markasspam.title=Complained
+mailcenter.logs.action.markasspam.message=The recipient flagged the email as spam.
+
+mailcenter.logs.action.unsubscribe.title=Unsubscribed
+mailcenter.logs.action.unsubscribe.message=The recipient unsubscribed from the email.
+
+mailcenter.logs.action.honeypotclick.title=Honeypot click
+mailcenter.logs.action.honeypotclick.message=We detected a click of the "Honeypot link". This is a strong indicatation that a link scanning bot has followed links in the email. We use this information when deciding whether or not to disregard certain activity in email statistics as bot traffic.
+
 mailcenter.logs.metadata.to.label=To
 mailcenter.logs.metadata.from.label=From
 mailcenter.logs.metadata.template.label=Email

--- a/system/i18n/enum/emailActivityType.properties
+++ b/system/i18n/enum/emailActivityType.properties
@@ -4,5 +4,5 @@ open.label=Opened
 click.label=Clicked
 markasspam.label=Marked as spam
 unsubscribe.label=Unsubscribed
-failed.label=Failed
+fail.label=Failed
 honeypotclick.label=Honeypot link clicked (bot)

--- a/system/views/admin/emailcenter/logs/viewLog.cfm
+++ b/system/views/admin/emailcenter/logs/viewLog.cfm
@@ -153,8 +153,8 @@
 											<cfcontinue />
 										</cfif>
 										<cfset logIcon    = "fa-exclamation-circle red" />
-										<cfset logTitle   = translateResource( uri="cms:mailcenter.logs.action.failed.title" ) />
-										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.failed.message", data=[ prc.activity.reason ] ) />
+										<cfset logTitle   = translateResource( uri="cms:mailcenter.logs.action.error.title" ) />
+										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.error.message", data=[ prc.activity.reason ] ) />
 									</cfcase>
 									<cfcase value="markasspam">
 										<cfset logIcon    = "fa-exclamation-triangle red" />

--- a/system/views/admin/emailcenter/logs/viewLog.cfm
+++ b/system/views/admin/emailcenter/logs/viewLog.cfm
@@ -134,19 +134,42 @@
 										<cfset logMessage = translateResource( "cms:mailcenter.logs.action.opened.message" ) />
 									</cfcase>
 									<cfcase value="click">
-										<cfset logIcon    = "fa-mouse-pointer" />
-										<cfset logTitle   = translateResource( "cms:mailcenter.logs.action.clicked.title" ) />
-										<cfset renderedLink       = Trim( renderEmailTrackingLink( prc.activity.link ?: "", prc.activity.link_title ?: "", prc.activity.link_body ?: "" ) ) />
-										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.clicked.message", data=[ renderedLink ] ) />
+										<cfset logIcon      = "fa-mouse-pointer" />
+										<cfset logTitle     = translateResource( "cms:mailcenter.logs.action.clicked.title" ) />
+										<cfset renderedLink = Trim( renderEmailTrackingLink( prc.activity.link ?: "", prc.activity.link_title ?: "", prc.activity.link_body ?: "" ) ) />
+										<cfset logMessage   = translateResource( uri="cms:mailcenter.logs.action.clicked.message", data=[ renderedLink ] ) />
 									</cfcase>
 									<cfcase value="resend">
-										<cfset logIcon    = "fa-refresh" />
-										<cfset linkTitle  = translateResource( "cms:mailcenter.logs.action.resend.link.title" ) />
-										<cfset data       = DeserializeJson( prc.activity.extra_data ) />
-										<cfset resendType = data.resendType ?: "rebuild" />
-										<cfset renderedLink       = '<a class="load-in-place" href="#event.buildAdminLink( linkTo="emailCenter.logs.viewLog", queryString="id=#data.resentMessageId#" )#">#linkTitle#</a>' />
-										<cfset logTitle   = translateResource( "cms:mailcenter.logs.action.resend.title" ) />
-										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.resend.#resendType#.message", data=[ renderedLink ] ) />
+										<cfset logIcon      = "fa-refresh" />
+										<cfset linkTitle    = translateResource( "cms:mailcenter.logs.action.resend.link.title" ) />
+										<cfset data         = DeserializeJson( prc.activity.extra_data ) />
+										<cfset resendType   = data.resendType ?: "rebuild" />
+										<cfset renderedLink = '<a class="load-in-place" href="#event.buildAdminLink( linkTo="emailCenter.logs.viewLog", queryString="id=#data.resentMessageId#" )#">#linkTitle#</a>' />
+										<cfset logTitle     = translateResource( "cms:mailcenter.logs.action.resend.title" ) />
+										<cfset logMessage   = translateResource( uri="cms:mailcenter.logs.action.resend.#resendType#.message", data=[ renderedLink ] ) />
+									</cfcase>
+									<cfcase value="fail">
+										<cfif isTrue( prc.log.failed ) and !DateDiff( "s", prc.activity.datecreated, prc.log.failed_date )>
+											<cfcontinue />
+										</cfif>
+										<cfset logIcon    = "fa-exclamation-circle red" />
+										<cfset logTitle   = translateResource( uri="cms:mailcenter.logs.action.failed.title" ) />
+										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.failed.message", data=[ prc.activity.reason ] ) />
+									</cfcase>
+									<cfcase value="markasspam">
+										<cfset logIcon    = "fa-exclamation-triangle red" />
+										<cfset logTitle   = translateResource( uri="cms:mailcenter.logs.action.markasspam.title" ) />
+										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.markasspam.message" ) />
+									</cfcase>
+									<cfcase value="unsubscribe">
+										<cfset logIcon    = "fa-sign-out red" />
+										<cfset logTitle   = translateResource( uri="cms:mailcenter.logs.action.unsubscribe.title" ) />
+										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.unsubscribe.message" ) />
+									</cfcase>
+									<cfcase value="honeypotclick">
+										<cfset logIcon    = "fa-android orange" />
+										<cfset logTitle   = translateResource( uri="cms:mailcenter.logs.action.honeypotclick.title" ) />
+										<cfset logMessage = translateResource( uri="cms:mailcenter.logs.action.honeypotclick.message" ) />
 									</cfcase>
 									<cfdefaultcase>
 										<cfcontinue/>
@@ -162,7 +185,7 @@
 									, message         = logMessage
 									, ipAddress       = prc.activity.user_ip
 									, userAgent       = prc.activity.user_agent
-									, showAuditTrail  = prc.activity.activity_type != "resend"
+									, showAuditTrail  = ArrayFindNoCase( [ "open", "click" ], prc.activity.activity_type )
 								} )#
 							</cfloop>
 						</div>


### PR DESCRIPTION
We added new activity types for email activity tracking some time ago.
However, we had failed to add them into the log view of email sends.

This change makes minimal changes to display log entiries for:

* Email failures
* Spam complaints
* Unsubscribes
* Honey-pot clicks

Also fixes a missing i18n entry for the 'fail' activity type.
