### PR TITLE
PRESIDECMS-2897 bare minimum implementation of record audittrail tab

### DIFF
--- a/system/base/EnhancedDataManagerBase.cfc
+++ b/system/base/EnhancedDataManagerBase.cfc
@@ -374,6 +374,10 @@ component extends="preside.system.base.AdminHandler" {
 		return "<p><em class=""light-grey""><i class=""fa fa-fw fa-exclamation-triangle""></i> TODO: implement your own <code>admin.datamanager.#objectName#._defaultTab</code> viewlet for your entity.</em></p>";
 	}
 
+	private string function _auditTrailTab( event, rc, prc, args={} ) {
+		return renderViewlet( event="admin.audittrail.recordTrailViewlet", args={ recordId=args.recordId ?: "" } );
+	}
+
 	private string function _getNonVersionDateCreated( required string objectName, required string recordId ) {
 		var record = presideObjectService.selectData(
 			  id               = arguments.recordId

--- a/system/handlers/admin/AuditTrail.cfc
+++ b/system/handlers/admin/AuditTrail.cfc
@@ -63,6 +63,20 @@ component extends="preside.system.base.AdminHandler" {
 		}
 	}
 
+	// VIEWLETS
+	private string function recordTrailViewlet( event, rc, prc, args={} ) {
+		args.logs = auditService.getTrail(
+			  page     = 1
+			, pageSize = 10
+			, recordId = args.recordId ?: ""
+		);
+		args.hasMore = args.logs.recordCount == 10;
+
+		event.include( "/js/admin/specific/auditTrail/" )
+
+		return renderView( view="/admin/auditTrail/_recordTrailViewlet", args=args );
+	}
+
 	// PRIVATE UTILITY
 	private void function _permissionsCheck( required string key, required any event ) {
 		var permKey   = "auditTrail." & arguments.key;

--- a/system/i18n/adminui.properties
+++ b/system/i18n/adminui.properties
@@ -6,3 +6,6 @@ info.card.modified.no.user=Updated {1}
 
 viewtab.dashboard.iconClass=fa-dashboard orange
 viewtab.dashboard.title=Dashboard
+
+viewtab.audittrail.iconClass=fa-history grey
+viewtab.audittrail.title=Audit history

--- a/system/views/admin/auditTrail/_recordTrailViewlet.cfm
+++ b/system/views/admin/auditTrail/_recordTrailViewlet.cfm
@@ -1,0 +1,21 @@
+<!---@feature admin--->
+<cfscript>
+	logs        = args.logs     ?: [];
+	recordId    = args.recordId ?: "";
+	hasMore     = isTrue( args.hasMore ?: "" );
+	loadMoreUrl = event.buildAdminLink( linkTo='auditTrail.loadMore', queryString='recordId=#recordId#&page=' );
+</cfscript>
+<cfoutput>
+	<cfif logs.recordcount>
+		<div class="timeline-container" id="audit-trail">
+			#renderView( view="/admin/auditTrail/_logs", args={ logs=logs } )#
+		</div>
+		<cfif hasMore>
+			<div class="load-more text-center">
+				<a class="load-more-logs btn btn-primary" data-load-more-target="audit-trail" data-href="#loadMoreUrl#"><i class="fa fa-plus-circle"></i> #translateResource( uri='cms:auditTrail.loadMore' )#</a>
+			</div>
+		</cfif>
+	<cfelse>
+		<p><em>#translateResource( uri='cms:auditTrail.noData' )#</em></p>
+	</cfif>
+</cfoutput>


### PR DESCRIPTION
Here, we implement the default body, title + icon for an audit trail tab
for a view record screen using "enhanced datamanager views". It would
be up to a developer to include "audittrail" as one of the tabs defined
in their variables._tabs setting in their datamanager handler.

![image](https://github.com/pixl8/Preside-CMS/assets/471162/5eccb68c-2ab6-403c-a815-3f76ecf88e05)
