### PR TITLE
PRESIDECMS-2904 database connection retries

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -749,8 +749,9 @@ component {
 		settings.useQueryCacheDefault        = true;
 		settings.mssql = { useVarcharMaxForText = false }
 		settings.datasourceConnection = {
-			  retries    = Val( settings.env.DATASOURCE_CONNECTION_RETRIES     ?: 0   )
-			, retryPause = Val( settings.env.DATASOURCE_CONNECTION_RETRY_PAUSE ?: 100 )
+			  retries      = Val( settings.env.DATASOURCE_CONNECTION_RETRIES     ?: 0   )
+			, retryPause   = Val( settings.env.DATASOURCE_CONNECTION_RETRY_PAUSE ?: 100 )
+			, failureRegex = settings.env.DATASOURCE_CONNECTION_FAILURE_REGEX ?: "Communications link failure"
 		};
 
 		settings.queryTimeout = {

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -748,6 +748,10 @@ component {
 		settings.autoRestoreDeprecatedFields = true;
 		settings.useQueryCacheDefault        = true;
 		settings.mssql = { useVarcharMaxForText = false }
+		settings.datasourceConnection = {
+			  retries    = Val( settings.env.DATASOURCE_CONNECTION_RETRIES     ?: 0   )
+			, retryPause = Val( settings.env.DATASOURCE_CONNECTION_RETRY_PAUSE ?: 100 )
+		};
 
 		settings.queryTimeout = {
 			  default                 = Val( settings.env.QUERY_TIMEOUT ?: 0 )

--- a/system/services/database/SqlRunner.cfc
+++ b/system/services/database/SqlRunner.cfc
@@ -105,10 +105,7 @@ component singleton=true {
 				);
 				break;
 			} catch( database e ) {
-				if ( e.message contains "Communications link failure" ) {
-					if ( connectionAttempts >= connectionRetries ) {
-						rethrow;
-					}
+				if ( e.message contains "Communications link failure" && connectionAttempts < connectionRetries ) {
 					sleep( connectionRetryPause );
 				} else {
 					rethrow;

--- a/system/services/database/SqlRunner.cfc
+++ b/system/services/database/SqlRunner.cfc
@@ -2,24 +2,27 @@ component singleton=true {
 
 // CONSTRUCTOR
 	/**
-	 * @logger.inject                defaultLogger
-	 * @defaultQueryTimeout.inject   coldbox:setting:queryTimeout.default
-	 * @defaultBgQueryTimeout.inject coldbox:setting:queryTimeout.backgroundThreadDefault
-	 * @connectionRetries.inject     coldbox:setting:datasourceConnection.retries
-	 * @connectionRetryPause.inject  coldbox:setting:datasourceConnection.retryPause
+	 * @logger.inject                 defaultLogger
+	 * @defaultQueryTimeout.inject    coldbox:setting:queryTimeout.default
+	 * @defaultBgQueryTimeout.inject  coldbox:setting:queryTimeout.backgroundThreadDefault
+	 * @connectionRetries.inject      coldbox:setting:datasourceConnection.retries
+	 * @connectionRetryPause.inject   coldbox:setting:datasourceConnection.retryPause
+	 * @connectionFailureRegex.inject coldbox:setting:datasourceConnection.failureRegex
 	 */
 	public any function init(
 		  required any     logger
-		,          numeric defaultQueryTimeout   = 0
-		,          numeric defaultBgQueryTimeout = 0
-		,          numeric connectionRetries     = 0
-		,          numeric connectionRetryPause  = 100
+		,          numeric defaultQueryTimeout    = 0
+		,          numeric defaultBgQueryTimeout  = 0
+		,          numeric connectionRetries      = 0
+		,          numeric connectionRetryPause   = 100
+		,          string  connectionFailureRegex = "Communications link failure"
 	) {
 		_setLogger( arguments.logger );
 		_setDefaultQueryTimeout( arguments.defaultQueryTimeout );
 		_setDefaultBgQueryTimeout( arguments.defaultBgQueryTimeout );
 		_setConnectionRetries( arguments.connectionRetries );
 		_setConnectionRetryPause( arguments.connectionRetryPause );
+		_setConnectionFailureRegex( arguments.connectionFailureRegex );
 
 		return this;
 	}
@@ -105,7 +108,7 @@ component singleton=true {
 				);
 				break;
 			} catch( database e ) {
-				if ( e.message contains "Communications link failure" && connectionAttempts < connectionRetries ) {
+				if ( ReFindNoCase( _getConnectionFailureRegex(), e.message ) && connectionAttempts < connectionRetries ) {
 					sleep( connectionRetryPause );
 				} else {
 					rethrow;
@@ -212,5 +215,12 @@ component singleton=true {
 	}
 	private void function _setConnectionRetryPause( required numeric connectionRetryPause ) {
 	    _connectionRetryPause = arguments.connectionRetryPause;
+	}
+
+	private string function _getConnectionFailureRegex() {
+	    return _connectionFailureRegex;
+	}
+	private void function _setConnectionFailureRegex( required string connectionFailureRegex ) {
+	    _connectionFailureRegex = arguments.connectionFailureRegex;
 	}
 }


### PR DESCRIPTION
Add configuration options to retry database queries when getting connection errors to the database. This is to help prevent temporary connection issues from halting requests/background tasks completely in cases where a quick retry may resolve.

Defaulting to no retries so that there is no change of behaviour.