### PR TITLE
Feature presidecms 2915 the expression userisloggedin could not be found

### DIFF
--- a/system/handlers/rules/expressions/UserIsLoggedIn.cfc
+++ b/system/handlers/rules/expressions/UserIsLoggedIn.cfc
@@ -3,7 +3,7 @@
  *
  * @expressionContexts webrequest
  * @expressionCategory website_user
- * @feature            rulesEnging and websiteUsers
+ * @feature            rulesEngine and websiteUsers
  */
 component {
 


### PR DESCRIPTION
fix typo on feature annotation for UserIsLoggedIn