### PR TITLE
PRESIDECMS-2920 text property match expression with space not returning expected result

### DIFF
--- a/system/handlers/rules/dynamic/presideObjectExpressions/TextFormulaPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/TextFormulaPropertyMatches.cfc
@@ -28,7 +28,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	){
-		arguments.value = ListChangeDelims( arguments.value, ",", " , " );
+		switch ( arguments._stringOperator ) {
+			case "oneof":
+			case "noneof":
+				arguments.value = ListItemTrim( arguments.value );
+		}
 
 		var paramName = "textFormulaPropertyMatches" & Replace( LCase( CreateUUID() ), "-", "", "all" );
 		var filterSql = "#arguments.propertyName# ${operator} :#paramName#";

--- a/system/handlers/rules/dynamic/presideObjectExpressions/TextPropertyMatches.cfc
+++ b/system/handlers/rules/dynamic/presideObjectExpressions/TextPropertyMatches.cfc
@@ -28,7 +28,11 @@ component extends="preside.system.base.AutoObjectExpressionHandler" {
 		,          string  _stringOperator = "contains"
 		,          string  value           = ""
 	){
-		arguments.value = ListChangeDelims( arguments.value, ",", " , " );
+		switch ( arguments._stringOperator ) {
+			case "oneof":
+			case "noneof":
+				arguments.value = ListItemTrim( arguments.value );
+		}
 
 		var paramName     = "textPropertyMatches" & Replace( LCase( CreateUUId() ), "-", "", "all" );
 		var filterSql     = "#arguments.objectName#.#propertyName# ${operator} :#paramName#";


### PR DESCRIPTION
Use `ListItemTrim` only if the operator is `oneof` or `noneof`