### PR TITLE
PRESIDECMS-2938 stackoverflow error when generating asset derivative

### DIFF
--- a/system/services/assetManager/AssetQueueService.cfc
+++ b/system/services/assetManager/AssetQueueService.cfc
@@ -7,8 +7,8 @@ component implements="preside.system.services.assetManager.IAssetQueue" {
 
 // CONSTRUCTOR
 	/**
-	 * @assetManagerService.inject delayedInjector:assetManager:assetManagerService
-	 * @siteService.inject         delayedInjector:sites:siteService
+	 * @assetManagerService.inject delayedInjector:assetManagerService
+	 * @siteService.inject         delayedInjector:siteService
 	 * @queueBatchSize.inject      coldbox:setting:assetManager.queue.batchSize
 	 */
 	public any function init(


### PR DESCRIPTION
Inject the correct services to avoid infinite `onMissingMethod` calls