### PR TITLE
PRESIDECMS-2997 definition list style info card

### DIFF
--- a/system/assets/css/admin/specific/datamanager/infoCard/infoCard.less
+++ b/system/assets/css/admin/specific/datamanager/infoCard/infoCard.less
@@ -1,4 +1,14 @@
 .view-record-detail-card {
 	margin-top    : 0;
 	margin-bottom : 20px;
+
+	.info-card-dl {
+		dt {
+			margin-top: 0.5em;
+
+			&:first-child {
+				margin-top: 0;
+			}
+		}
+	}
 }

--- a/system/base/EnhancedDataManagerBase.cfc
+++ b/system/base/EnhancedDataManagerBase.cfc
@@ -12,6 +12,7 @@ component extends="preside.system.base.AdminHandler" {
 	variables.permissionKeyCache = {};
 	variables.maxTabCount        = 6;
 	variables.sidebarNavigation  = false;
+	variables.infoCardStyle      = "default";
 
 // PUBLIC ACTIONS
 	public void function viewRecord( event, rc, prc ){
@@ -151,6 +152,7 @@ component extends="preside.system.base.AdminHandler" {
 		args.col1 = Duplicate( variables.infoCol1 ?: [] );
 		args.col2 = Duplicate( variables.infoCol2 ?: [] );
 		args.col3 = Duplicate( variables.infoCol3 ?: [ "created", "modified" ] );
+		args.infoCardStyle = variables.infoCardStyle;
 
 		announceInterception( "preRenderDataManagerObjectInfoCard", args );
 
@@ -159,15 +161,23 @@ component extends="preside.system.base.AdminHandler" {
 				var field = args[ "col#i#" ][ n ];
 				var rendered = _render( field );
 
-				if ( rendered.trim().len() ) {
-					args[ "col#i#" ][ n ] = rendered;
+				if ( Len( Trim( rendered ) ) ) {
+					if ( infoCardStyle == "definitionList" ) {
+						args[ "col#i#" ][ n ] = {
+							  title = translateResource( uri="preside-objects.#objectName#:infocard.#field#", defaultValue=translateObjectProperty( objectName, field ) )
+							, value = rendered
+						};
+
+					} else {
+						args[ "col#i#" ][ n ] = rendered;
+					}
 				} else {
-					args[ "col#i#" ].deleteAt( n );
+					ArrayDeleteAt( args[ "col#i#" ], n );
 				}
 			}
 		}
 
-		if ( args.col1.len() || args.col2.len() || args.col3.len() ) {
+		if ( ArrayLen( args.col1 ) || ArrayLen( args.col2 ) || ArrayLen( args.col3 ) ) {
 			if ( !IsArray( args.infoColSizes ?: "" ) ) {
 				if ( IsArray( variables.infoColSizes ?: "" ) && ArrayLen( variables.infoColSizes ) == 3 ) {
 					args.infoColSizes = variables.infoColSizes;

--- a/system/views/admin/datamanager/_infoCard.cfm
+++ b/system/views/admin/datamanager/_infoCard.cfm
@@ -5,11 +5,12 @@
 	args.col3            = args.col3 ?: [];
 	args.infoDescription = args.infoDescription ?: "";
 	args.infoColSizes    = args.infoColSizes ?: [ 4, 4, 4 ];
+	args.infoCardStyle   = args.infoCardStyle  ?: "default"; // default, or definitionList
 </cfscript>
 
 <cfoutput>
 	<div class="view-record-detail-card">
-		<cfif args.infoDescription.len()>
+		<cfif Len( args.infoDescription )>
 			#args.infoDescription#
 			<hr>
 		</cfif>
@@ -18,11 +19,27 @@
 			<cfloop from="1" to="3" index="i">
 				<cfif args.infoColSizes[ i ]>
 					<div class="col-md-#args.infoColSizes[ i ]#">
-						<ul class="list-unstyled">
-							<cfloop array="#args[ 'col#i#' ]#" index="n" item="item">
+						<cfif args.infoCardStyle == "definitionList">
+							<dl class="info-card-dl">
+						<cfelse>
+							<ul class="list-unstyled">
+						</cfif>
+
+						<cfloop array="#args[ 'col#i#' ]#" index="n" item="item">
+							<cfif args.infoCardStyle == "definitionList">
+								<dt>#item.title#</dt>
+								<dd>#item.value#</dd>
+							<cfelse>
 								<li>#item#</li>
-							</cfloop>
-						</ul>
+							</cfif>
+						</cfloop>
+
+						<cfif args.infoCardStyle == "definitionList">
+							</dl>
+						<cfelse>
+							</ul>
+						</cfif>
+
 					</div>
 				</cfif>
 			</cfloop>


### PR DESCRIPTION
In the "enhanced datamanager view", allow a simple way for developers to display the info card in a definition list, with items then consisting of a title + body in the format:

```html
<dl class="info-card-dl">
  <dt>Field title</dt>
  <dd>Rendered field value</dd>
  <dt>Another field title</dt>
  <dd>Another rendered field value</dd>
</dl>
```

This can lead to much more readable info cards and minimal dev to make them appear nicely. The current default style is just an unordered list where developers are responsible for formatting the items in a way that communicates both their value and meaning:

```html
<ul class="list-unstyled">
  <li>Rendered field value</li>
  <li>Another rendered field value</li>
</ul>
```

## Developer implementation

To enable the new style, developers can add the following line to the pseudo-constructor of their datamanager component:

```cfc
variables.infoCardStyle  = "definitionList";
```

### Field titles

The system will try two i18n URIs in the following order to translate a field title. Developers should ensure at least one exists:

1. `preside-objects.name_of_object:infocard.name_of_info_card_field`
2. `preside-objects.name_of_object:field.name_of_info_card_field.title`

This means you can very easily render fields on an object in the info card without the need of any handlers for renders. Just use the field name in your `infoCol` arrays.

