### PR TITLE
PRESIDECMS-2998 Datamanager view record in ajax modal

### DIFF
--- a/system/base/EnhancedDataManagerBase.cfc
+++ b/system/base/EnhancedDataManagerBase.cfc
@@ -61,6 +61,10 @@ component extends="preside.system.base.AdminHandler" {
 
 		_overrideAdminLayout( argumentCollection=arguments );
 		event.setView( "/admin/datamanager/_viewRecord" );
+
+		if ( IsTrue( rc.modalView ?: "" ) ) {
+			event.setLayout( "adminAjaxModal" );
+		}
 	}
 
 // CUSTOMIZATIONS
@@ -123,6 +127,10 @@ component extends="preside.system.base.AdminHandler" {
 
 		if ( Len( Trim( queryString ) ) ) {
 			qs &= "&#queryString#";
+		}
+
+		if ( IsTrue( args.modalView ?: "" ) ) {
+			qs &= "&modalView=true";
 		}
 
 		return event.buildAdminLink( linkto="datamanager.#objectName#.viewRecord", queryString=qs );

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -291,6 +291,10 @@ component extends="preside.system.base.AdminHandler" {
 			, defaultHandler = "admin.dataHelpers.viewRecord"
 			, args           = { objectName= objectName, recordId=recordId, version=version }
 		);
+
+		if ( IsTrue( rc.modalView ?: "" ) ) {
+			event.setLayout( "adminAjaxModal" );
+		}
 	}
 
 	public void function addRecord( event, rc, prc ) {
@@ -2258,9 +2262,10 @@ component extends="preside.system.base.AdminHandler" {
 			}
 
 			var canFlagRecord          = canEdit && isFlaggingEnabled( objectName=objectName );
+			var modalView              = canView && dataManagerService.usesModalViewRecord( objectName );
 			var addChildRecordLink     = canAdd && isTreeView  ? event.buildAdminLink( objectName=objectName, operation="addRecord", queryString="#parentProperty#={id}" ) : "";
 			var sortChildrenRecordLink = canEdit && isTreeView ? event.buildAdminLink( objectName=objectName, operation="sortRecords", queryString="#parentProperty#={id}" ) : "";
-			var viewRecordLink         = canView               ? event.buildAdminLink( objectName=objectName, recordId="{id}" )                                                       : "";
+			var viewRecordLink         = canView               ? event.buildAdminLink( objectName=objectName, recordId="{id}", args={ modalView=modalView } ) : "";
 			var cloneRecordLink        = canClone              ? event.buildAdminLink( objectName=objectName, recordId="{id}", operation="cloneRecord" )                              : "";
 			var editRecordLink         = canEdit               ? event.buildAdminLink( objectName=objectName, recordId="{id}", operation="editRecord", args={ resultAction="grid" } ) : "";
 			var deleteRecordLink       = canDelete             ? event.buildAdminLink( objectName=objectName, recordId="{id}", operation="deleteRecordAction" )                       : "";
@@ -2268,6 +2273,7 @@ component extends="preside.system.base.AdminHandler" {
 			var deleteRecordTitle      = canDelete             ? translateResource( uri="cms:datamanager.deleteRecord.prompt", data=[ objectTitleSingular, "{recordlabel}" ] )        : "";
 			var deleteRecordTitleThis  = canDelete             ? translateResource( uri="cms:datamanager.deleteRecord.this",   data=[ objectTitleSingular ] )                         : "";
 			var flagRecordLink         = canFlagRecord         ? event.buildAdminLink( objectName=objectName, recordId="{id}", operation="flagRecordAction" )                         : "";
+
 		}
 
 		for( var record in records ){
@@ -2293,10 +2299,12 @@ component extends="preside.system.base.AdminHandler" {
 					);
 				} else {
 					if ( canView ) {
-						actions.append( {
-							  link       = viewRecordLink.replace( "{id}", record.id )
+						ArrayAppend( actions, {
+							  link       = Replace( viewRecordLink, "{id}", record.id )
 							, icon       = "fa-eye"
 							, contextKey = "v"
+							, modal      = modalView
+							, modalTitle = objectTitleSingular
 						} );
 					}
 					if ( canAdd && isTreeView ) {

--- a/system/handlers/admin/ObjectLinks.cfc
+++ b/system/handlers/admin/ObjectLinks.cfc
@@ -34,6 +34,10 @@ component {
 				queryString &= "&version=#version#";
 			}
 
+			if ( isTrue( args.modalView ?: "" ) ) {
+				queryString &= "&modalView=true";
+			}
+
 			return event.buildAdminLink(
 				  linkto      = "datamanager.viewRecord"
 				, queryString = _queryString( queryString, args )

--- a/system/layouts/adminAjaxModal.cfm
+++ b/system/layouts/adminAjaxModal.cfm
@@ -1,0 +1,1 @@
+<cfoutput><div class="modal-padding">#renderView()#</div></cfoutput>

--- a/system/services/admin/DataManagerService.cfc
+++ b/system/services/admin/DataManagerService.cfc
@@ -297,6 +297,15 @@ component {
 		);
 	}
 
+	public boolean function usesModalViewRecord( required string objectName ) {
+		var modalView = _getPresideObjectService().getObjectAttribute(
+			  objectName    = arguments.objectName
+			, attributeName = "datamanagerModalView"
+		);
+
+		return IsBoolean( modalView ) && modalView;
+	}
+
 	public boolean function usesTreeView( required string objectName ) {
 		var treeView = _getPresideObjectService().getObjectAttribute(
 			  objectName    = arguments.objectName

--- a/system/views/admin/datamanager/_listingActions.cfm
+++ b/system/views/admin/datamanager/_listingActions.cfm
@@ -8,7 +8,14 @@
 				<cfif IsSimpleValue( action )>
 					#action#
 				<cfelse>
-					<a class="<cfif i == 1>row-link</cfif><cfif Len( Trim( action.class ?: "" ))> #action.class#</cfif>"<cfif Len( Trim( action.contextKey ?: "" ))> data-context-key="#action.contextKey#"</cfif> href="#( action.link ?: "" )#"<cfif Len( Trim( action.title ?: "" ))> title="#HtmlEditFormat( action.title )#"</cfif><cfif Len( Trim( action.target ?: "" ))> target="#action.target#"</cfif> <cfif Len( action.match ?: "")> data-confirmation-match="#action.match#"</cfif>>
+					<a href="#( action.link ?: "" )#"
+					   class="<cfif i == 1>row-link</cfif><cfif Len( Trim( action.class ?: "" ))> #action.class#</cfif>"
+					   <cfif Len( Trim( action.contextKey ?: "" ))> data-context-key="#action.contextKey#"</cfif>
+					   <cfif Len( Trim( action.title ?: "" ))>title="#HtmlEditFormat( action.title )#"</cfif>
+					   <cfif Len( Trim( action.target ?: "" ))>target="#action.target#"</cfif>
+					   <cfif Len( action.match ?: "")>data-confirmation-match="#action.match#"</cfif>
+					   <cfif isTrue( action.modal ?: "" )>data-toggle="bootbox-modal" data-buttons="ok" data-modal-class="full-screen-dialog" data-title="#HtmlEditFormat( action.modalTitle ?: '' )#"</cfif>
+					>
 						<i class="fa fa-fw #( action.icon ?: "" )#"></i>
 					</a>
 				</cfif>


### PR DESCRIPTION
Adds the ability for developers to have datamanager grid listings have their view record link open in a modal dialog by simply adding an annotation to the preside object.

## Developer implementation

By adding the `@datamanagerModalView true` annotation to your preside object, view links _from within a datamanager grid listing_ will open in a modal dialog.