### PR TITLE
PRESIDECMS-3026 simple, non-intrusive logic to assume a logged in user in background thread

### DIFF
--- a/system/services/taskmanager/AdHocTaskManagerService.cfc
+++ b/system/services/taskmanager/AdHocTaskManagerService.cfc
@@ -136,6 +136,10 @@ component displayName="Ad-hoc Task Manager Service" {
 				return true;
 			}
 
+			if ( Len( task.web_owner ?: "" ) ) {
+				$getWebsiteLoginService().spoofUserLoginInBgThread( task.web_owner );
+			}
+
 			if ( task.status == "running" || !markTaskAsRunning( taskId=arguments.taskId ) ) {
 				$raiseError( error={
 					  type    = "AdHoTaskManagerService.task.already.running"

--- a/system/services/websiteUsers/WebsiteLoginService.cfc
+++ b/system/services/websiteUsers/WebsiteLoginService.cfc
@@ -90,6 +90,21 @@ component displayName="Website login service" {
 	}
 
 	/**
+	 * For background threads, allows the thread to assume that a specific user is logged in
+	 *
+	 */
+	public function spoofUserLoginInBgThread( required string userId ) {
+		var user = _getUserDao().selectData(
+			  filter   = { id=arguments.userId, active=true }
+			, useCache = false
+		);
+
+		if ( user.recordCount ) {
+			request._bgThreadUser = $helpers.queryRowToStruct( user );
+		}
+	}
+
+	/**
 	 * Impersonates a login
 	 *
 	 * @userId.hint      ID of the user whom to impersonate
@@ -205,6 +220,9 @@ component displayName="Website login service" {
 	 * If no user is logged in, an empty structure will be returned.
 	 */
 	public struct function getLoggedInUserDetails() autodoc=true {
+		if ( $getRequestContext().isBackgroundThread() ) {
+			return request._bgThreadUser ?: {};
+		}
 		var userDetails = _getSessionStorage().getVar( name=_getSessionKey(), default={} );
 
 		return !IsNull( local.userDetails ) && IsStruct( userDetails ) ? userDetails : {};

--- a/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
+++ b/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
@@ -471,6 +471,7 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		mockUserDao           = getMockbox().createStub();
 		mockResetDao          = getMockbox().createStub();
 		mockUserLoginTokenDao = getMockbox().createStub();
+		mockRequestContext    = getMockbox().createStub();
 		mockBCryptService     = getMockBox().createEmptyMock( "preside.system.services.encryption.bcrypt.BCryptService" );
 		mockSysConfigService  = getMockBox().createEmptyMock( "preside.system.services.configuration.SystemConfigurationService" );
 		mockEmailService      = getMockBox().createEmptyMock( "preside.system.services.email.EmailService" );
@@ -490,10 +491,12 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		mockActionsService.$( "promoteVisitorActionsToUserActions", 1 );
 		service.$( "$recordWebsiteUserAction" );
 		service.$( "$announceInterception" );
+		service.$( "$getRequestContext", mockRequestContext );
 		mockSessionStorage.$( "rotate" );
 		service.$( "$getPresideObject" ).$args( "website_user_reset_token" ).$results( mockResetDao );
 		mockResetDao.$( "insertData", 1 );
 		mockResetDao.$( "deleteData", 1 );
+		mockRequestService.$( "isBackgroundThread", false );
 
 		return service;
 	}

--- a/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
+++ b/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
@@ -496,7 +496,7 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		service.$( "$getPresideObject" ).$args( "website_user_reset_token" ).$results( mockResetDao );
 		mockResetDao.$( "insertData", 1 );
 		mockResetDao.$( "deleteData", 1 );
-		mockRequestService.$( "isBackgroundThread", false );
+		mockRequestContext.$( "isBackgroundThread", false );
 
 		return service;
 	}


### PR DESCRIPTION
This allows threaded code to set a spoofed logged in user ID that might be
used by various logic run in the thread to give context.

In particular, if a developer creates an adhoc task with a web user owner,
that owner ID should and will now be used as the spoofed logged in user
for the task thread.