### PR TITLE
PRESIDECMS-3041 Fix jquery change breaking 1-to-many configurator control

### DIFF
--- a/system/assets/js/admin/presidecore/preside.object.configurator.js
+++ b/system/assets/js/admin/presidecore/preside.object.configurator.js
@@ -266,6 +266,9 @@
 					}
 				}
 				for( var i=0; i<fields.length; i++ ) {
+					if ( !$.trim( fields[ i ] ).length ) {
+						continue;
+					}
 					var targetField = targetFields[ i ]
 					  , $field      = $( '[name=' + fields[ i ] + ']', presideObjectConfigurator.$originalInput.closest( 'form' ) );
 

--- a/system/assets/js/admin/presidecore/preside.object.configurator.js
+++ b/system/assets/js/admin/presidecore/preside.object.configurator.js
@@ -188,6 +188,10 @@
 			this.$configuratorAddButton.on( "click", function( e ) {
 				var dynamicIframeSrc = iframeSrc;
 				for( var i=0; i<fields.length; i++ ) {
+					if ( !$.trim( fields[ i ] ).length ) {
+						continue;
+					}
+
 					var targetField = targetFields[ i ]
 					  , $field      = $( '[name=' + fields[ i ] + ']', presideObjectConfigurator.$originalInput.closest( 'form' ) );
 


### PR DESCRIPTION
The issue here is that `("").split()` in javascript produces `[ "" ]` (i.e. an array with one entry that is an empty string). The logic here was expecting this to be an empty array.

In prior version of jquery this was fine as `[name=]` was a valid selector. In the patched version of jquery this is not a valid selector and so breaks, revealing the bug that was always really there.