### PR TITLE
Make confirmation box title dynamic with 18n

### DIFF
--- a/system/assets/js/admin/presidecore/preside.confirmation.prompts.js
+++ b/system/assets/js/admin/presidecore/preside.confirmation.prompts.js
@@ -33,7 +33,7 @@
 		}
 
 		var confirmationDialog = presideBootbox.dialog( {
-			  title   : "Confirmation"
+			  title   : i18n.translateResource( "cms:confirmation.prompt.title" )
 			, message : $message
 			, buttons : {
 				  cancel  : {

--- a/system/i18n/cms.properties
+++ b/system/i18n/cms.properties
@@ -32,6 +32,7 @@ two.factor.auth.verify.button=Verify
 
 helpandsupport.link=Help and support
 
+confirmation.prompt.title=Confirmation
 confirmation.prompt=Are you sure you want to {1}?
 confirmation.prompt.please.type.message=Please type {1} in the input below to proceed.
 confirmation.prompt.confirm.button=Confirm

--- a/system/i18n/cms_de.properties
+++ b/system/i18n/cms_de.properties
@@ -27,6 +27,7 @@ login.two.factor.auth.help.gethelp.para=Wenn Sie Probleme mit dem Erhalt eines A
 login.two.factor.auth.setup.read.more=Mehr lesen...
 two.factor.auth.verify.button=Best\u00E4tigen
 helpandsupport.link=Hilfe und Unterst\u00FCtzung
+confirmation.prompt.title=Bitte best\u00e4tigen Sie
 confirmation.prompt=Wollen Sie wirklich {1}?
 confirmation.prompt.please.type.message=Bitte geben Sie {1} in das Eingabefeld unten ein, um fortzufahren.
 confirmation.prompt.confirm.button=Best\u00E4tigen

--- a/system/i18n/cms_fr.properties
+++ b/system/i18n/cms_fr.properties
@@ -22,6 +22,7 @@ login.two.factor.auth.help.gethelp.para=Veuillez prendre contact avec l'administ
 login.two.factor.auth.setup.read.more=En savoir plus...
 two.factor.auth.verify.button=V\u00E9rifier
 helpandsupport.link=Aide et support
+confirmation.prompt.title=Veuillez confirmer
 confirmation.prompt=Etes-vous s\u00FBr de vouloir {1}?
 info.notification.title=L'op\u00E9ration a r\u00E9ussi
 error.notification.title=Erreur

--- a/system/i18n/cms_nl.properties
+++ b/system/i18n/cms_nl.properties
@@ -23,6 +23,7 @@ login.two.factor.auth.help.gethelp.para=Neem contact op met een systeembeheerder
 login.two.factor.auth.setup.read.more=Lees meer...
 two.factor.auth.verify.button=Verifi\u00EBren
 helpandsupport.link=Hulp en ondersteuning
+confirmation.prompt.title=Bevestig alstublieft
 confirmation.prompt=Weet je zeker dat je {1}?
 child.confirmation.prompt=Deze pagina heeft {1} onderliggende pagina('s). Weet je zeker dat je {2}?
 info.notification.title=Succes


### PR DESCRIPTION
The confirmation box dialog has a hard coded title of "Confirmation". I think it would be better to use the i18n resource bundles for the title, too.

I have
- added an entry "confirmation.prompt.title" to 
  - `cms.properties`
  - `cms_de.properties`
  - `cms_fr.properties`
  - `cms_nl.properties`
- modified `system/assets/js/admin/presidecore/preside.confirmation.prompts.js `
==> use `i18n.translateResource( "cms:confirmation.prompt.title" )` instead of the hard coded title