### PR TITLE
PRESIDECMS-3108: scheduledtask runner fix

### DIFF
--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -515,14 +515,14 @@ component displayName="Task Manager Service" {
 				$getRequestContext().setSite( siteSvc.getSite( site_context ) );
 				activeSite = siteSvc.getActiveSiteId();
 			}
+
+			if ( Len( Trim( site_context ) ) && site_context != siteSvc.getActiveSiteId() ) {
+				return { tasksStarted=[], warning="Scheduled tasks are not configured to run for this site context. Please review your general task manager configuration settings" };
+			}
 		}
 
 		if ( !IsBoolean( scheduledTasksEnabled ) || !scheduledTasksEnabled ) {
 			return { tasksStarted=[], warning="Scheduled tasks are disabled" };
-		}
-
-		if ( Len( Trim( site_context ) ) && site_context != siteSvc.getActiveSiteId() ) {
-			return { tasksStarted=[], warning="Scheduled tasks are not configured to run for this site context. Please review your general task manager configuration settings" };
 		}
 
 		var tasks = getRunnableTasks();


### PR DESCRIPTION
if sites feature is not enabled then this currently errors because 2 local variables are used which do not exist in that case.