### PR TITLE
PRESIDECMS-3109 Avoid use of ArrayFind using objects as the values.

### DIFF
--- a/system/services/email/EmailStyleInliner.cfc
+++ b/system/services/email/EmailStyleInliner.cfc
@@ -163,8 +163,7 @@ component {
 	}
 
 	private array function _getElementsWithStylesToApply( required any doc, required array styles ) {
-		var elems         = {};
-		var elemStyles    = {};
+		var elems = {};
 
 		for( var style in arguments.styles ) {
 			try {
@@ -177,11 +176,13 @@ component {
 				var hashCode = selectedElem.hashCode();
 
 				if ( !StructKeyExists( elems, hashCode ) ) {
-					elems[ hashCode ]      = selectedElem;
-					elemStyles[ hashCode ] = StructNew( "linked" );
+					elems[ hashCode ] = {
+						  element = selectedElem
+						, styles  = StructNew( "linked" )
+					};
 				}
 
-				var elemStyle = elemStyles[ hashCode ];
+				var elemStyle = elems[ hashCode ].styles;
 
 				if ( !StructCount( elemStyle ) ) {
 					var existingInlineStyles = ListToArray( selectedElem.attr( "style" ), ";" );
@@ -210,18 +211,19 @@ component {
 				}
 			}
 		}
-		var result = [];
-		for( var hashCode in elemStyles ) {
-			var styleDefs = elemStyles[ hashCode ];
-			var styles    = [];
 
-			for( var prop in styleDefs ) {
-				ArrayAppend( styles, "#prop#:#styleDefs[ prop ].value#" );
+		var result = [];
+		for( var hashCode in elems ) {
+			var elemStyles  = elems[ hashcode ].styles;
+			var plainStyles = [];
+
+			for( var prop in elemStyles ) {
+				ArrayAppend( plainStyles, "#prop#:#elemStyles[ prop ].value#" );
 			}
 
 			ArrayAppend( result, {
-				  element = elems[ hashCode ]
-				, style   = ArrayToList( styles, ";" )
+				  element = elems[ hashCode ].element
+				, style   = ArrayToList( plainStyles, ";" )
 			} );
 		}
 

--- a/system/services/email/EmailStyleInliner.cfc
+++ b/system/services/email/EmailStyleInliner.cfc
@@ -212,15 +212,16 @@ component {
 		}
 		var result = [];
 		for( var hashCode in elemStyles ) {
-			var elem  = elemStyles[ hashCode ];
-			var style = "";
-			for( var prop in elem ) {
-				style = ListAppend( style, "#prop#:#elem[ prop ].value#", ";" );
+			var styleDefs = elemStyles[ hashCode ];
+			var styles    = [];
+
+			for( var prop in styleDefs ) {
+				ArrayAppend( styles, "#prop#:#styleDefs[ prop ].value#" );
 			}
 
 			ArrayAppend( result, {
 				  element = elems[ hashCode ]
-				, style   = style
+				, style   = ArrayToList( styles, ";" )
 			} );
 		}
 

--- a/system/services/email/EmailStyleInliner.cfc
+++ b/system/services/email/EmailStyleInliner.cfc
@@ -46,7 +46,7 @@ component {
 			return fromCache;
 		}
 
-		arguments.html = trim( arguments.html );
+		arguments.html = Trim( arguments.html );
 
 		var innerHtmlOnly = !FindNoCase( "</html>", arguments.html );
 
@@ -163,10 +163,10 @@ component {
 	}
 
 	private array function _getElementsWithStylesToApply( required any doc, required array styles ) {
-		var elems         = [];
-		var elemStyles    = [];
+		var elems         = {};
+		var elemStyles    = {};
 
-		for( var style in styles ) {
+		for( var style in arguments.styles ) {
 			try {
 				var selectedElements = doc.select( style.selector );
 			} catch( any e ) {
@@ -174,14 +174,14 @@ component {
 			}
 
 			for ( var selectedElem in selectedElements ) {
-				var index = ArrayFind( elems, selectedElem );
-				if ( !index ) {
-					ArrayAppend( elems, selectedElem );
-					ArrayAppend( elemStyles, StructNew( "linked" ) );
-					index = ArrayLen( elems );
-				}
-				var elemStyle = elemStyles[ index ];
+				var hashCode = selectedElem.hashCode();
 
+				if ( !StructKeyExists( elems, hashCode ) ) {
+					elems[ hashCode ]      = selectedElem;
+					elemStyles[ hashCode ] = StructNew( "linked" );
+				}
+
+				var elemStyle = elemStyles[ hashCode ];
 
 				if ( !StructCount( elemStyle ) ) {
 					var existingInlineStyles = ListToArray( selectedElem.attr( "style" ), ";" );
@@ -210,23 +210,21 @@ component {
 				}
 			}
 		}
-
-		var index = 1;
-		for( var elem in elemStyles ) {
+		var result = [];
+		for( var hashCode in elemStyles ) {
+			var elem  = elemStyles[ hashCode ];
 			var style = "";
 			for( var prop in elem ) {
 				style = ListAppend( style, "#prop#:#elem[ prop ].value#", ";" );
 			}
 
-			elems[ index ] = {
-				  element = elems[ index ]
+			ArrayAppend( result, {
+				  element = elems[ hashCode ]
 				, style   = style
-			};
-
-			index++;
+			} );
 		}
 
-		return elems;
+		return result;
 	}
 
 	private array function _orderStylesBySelectorPrecedence( required array styles ) {


### PR DESCRIPTION
In one running instance with issues, code was spending a lot of time doing this with garbage collection.

Test out this alternative approach using java hashCodes for each object and a struct to maintain better performing unique checks. 

Logic is otherwise the same.

