### PR TITLE
PRESIDECMS-3122 Implement a straightforward mechanism for setting up CSPs for websites

### DIFF
--- a/box.json
+++ b/box.json
@@ -30,7 +30,7 @@
         }
     ],
     "dependencies":{
-        "sticker":"1.3.3",
+        "sticker":"1.3.4",
         "lucee-spreadsheet":"3.0.0",
         "presidecmseditor":"github:pixl8/Preside-Editor#4.17.1",
         "cbi18n":"1.3.1+56",

--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -16,6 +16,7 @@ component {
 		, boolean showDbSyncScripts            = false
 		, boolean bufferOutput                 = true
 		, boolean allowPingRequests            = false
+		, boolean enableContentSecurityPolicy  = true
 	)  {
 
 		this.PRESIDE_APPLICATION_ID                  = arguments.id;
@@ -34,6 +35,7 @@ component {
 		this.showDbSyncScripts                       = arguments.showDbSyncScripts;
 		this.bufferOutput                            = arguments.bufferOutput;
 		this.allowPingRequests                       = arguments.allowPingRequests;
+		this.enableContentSecurityPolicy             = arguments.enableContentSecurityPolicy;
 
 		_setupMappings( argumentCollection=arguments );
 		_setupDefaultTagAttributes();
@@ -72,6 +74,7 @@ component {
 		} else {
 			_invalidateSessionIfNotUsed();
 		}
+		_setContentSecurityPolicy();
 		_cleanupCookies();
 	}
 
@@ -86,6 +89,7 @@ component {
 		} else {
 			_invalidateSessionIfNotUsed();
 		}
+		_setContentSecurityPolicy();
 		_cleanupCookies();
 	}
 
@@ -920,5 +924,19 @@ component {
 		}
 
 		return application._sessionType;
+	}
+
+	private void function _setContentSecurityPolicy() {
+		if ( this.enableContentSecurityPolicy ) {
+			var controller = _getColdboxController();
+
+			if ( !IsNull( local.controller ) ) {
+				var wb = controller.getWirebox();
+
+				if ( wb.containsInstance( "contentSecurityPolicyManager" ) ) {
+					wb.getInstance( "contentSecurityPolicyManager" ).outputPolicyHeader();
+				}
+			}
+		}
 	}
 }

--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -735,6 +735,14 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 		getRequestContext().setValue( name="xframeoptions", value=UCase( arguments.value ), private=true );
 	}
 
+	public void function setContentSecurityPolicy( required string policy ) {
+		getRequestContext().setValue( name="contentSecurityPolicy", value=arguments.policy, private=true );
+	}
+
+	public string function getContentSecurityPolicy() {
+		return getRequestContext().getValue( name="contentSecurityPolicy", defaultValue="", private=true );
+	}
+
 // FRONT END, dealing with current page
 	public void function initializePresideSiteteePage (
 		  string  slug

--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -618,7 +618,7 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 	}
 
 	public string function renderIncludes( string type, string group="default" ) {
-		var rendered      = getModel( "StickerForPreside" ).renderIncludes( argumentCollection = arguments );
+		var rendered      = getModel( "StickerForPreside" ).renderIncludes( argumentCollection = arguments, nonce=getRequestNonce() );
 
 		if ( !StructKeyExists( arguments, "type" ) || arguments.type == "js" ) {
 			var inlineJs = getRequestContext().getValue( name="__presideInlineJs", defaultValue={}, private=true );
@@ -645,7 +645,7 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 		var inlineJs = getRequestContext().getValue( name="__presideInlineJs", defaultValue={}, private=true );
 
 		inlineJs[ arguments.group ] = inlineJs[ arguments.group ] ?: [];
-		inlineJs[ arguments.group ].append( "<script type=""text/javascript"">" & Chr(10) & arguments.js & Chr(10) & "</script>" );
+		inlineJs[ arguments.group ].append( "<script type=""text/javascript"" nonce=""#getRequestNonce()#"">" & Chr(10) & arguments.js & Chr(10) & "</script>" );
 
 		getRequestContext().setValue( name="__presideInlineJs", value=inlineJs, private=true );
 	}
@@ -741,6 +741,17 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 
 	public string function getContentSecurityPolicy() {
 		return getRequestContext().getValue( name="contentSecurityPolicy", defaultValue="", private=true );
+	}
+
+	public string function getRequestNonce() {
+		var nonce = getRequestContext().getValue( name="_requestNonce", defaultValue="", private=true );
+
+		if ( !Len( Trim( nonce ) ) ) {
+			nonce = LCase( Hash( CreateUUID() ) );
+			getRequestContext().setValue( name="_requestNonce", value=nonce, private=true );
+		}
+
+		return nonce;
 	}
 
 // FRONT END, dealing with current page

--- a/system/coldboxModifications/RequestContextDecorator.cfc
+++ b/system/coldboxModifications/RequestContextDecorator.cfc
@@ -198,10 +198,18 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 		return link;
 	}
 
-	public string function getProtocol() {
+	public string function getProtocol( boolean fromSite=false ) {
+		if ( arguments.fromSite ) {
+			var site = getSite();
+			if ( StructKeyExists( site, "protocol" ) && Len( site.protocol ) ) {
+				return site.protocol;
+			}
+		}
+
 		if ( getController().getSetting( "forcessl" ) ) {
 			return "https";
 		}
+
 		return ( cgi.https ?: "" ) == "on" ? "https" : "http";
 	}
 
@@ -618,7 +626,7 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 	}
 
 	public string function renderIncludes( string type, string group="default" ) {
-		var rendered      = getModel( "StickerForPreside" ).renderIncludes( argumentCollection = arguments, nonce=getRequestNonce() );
+		var rendered = getModel( "StickerForPreside" ).renderIncludes( argumentCollection = arguments, nonce=getRequestNonce() );
 
 		if ( !StructKeyExists( arguments, "type" ) || arguments.type == "js" ) {
 			var inlineJs = getRequestContext().getValue( name="__presideInlineJs", defaultValue={}, private=true );
@@ -741,6 +749,26 @@ component accessors=true extends="preside.system.coldboxModifications.RequestCon
 
 	public string function getContentSecurityPolicy() {
 		return getRequestContext().getValue( name="contentSecurityPolicy", defaultValue="", private=true );
+	}
+
+	public void function addToContentSecurityPolicy( required string directive, required string value ) {
+		var sources = getRequestContext().getValue( name="additionalCspSources", defaultValue={}, private=true );
+
+		if ( !StructKeyExists( sources, arguments.directive ) ) {
+			sources[ arguments.directive ] = [];
+		}
+
+		if ( ReFind( "^//", arguments.value ) ) {
+			arguments.value = "#getProtocol( fromSite=true )#:#arguments.value#";
+		}
+
+		ArrayAppend( sources[ arguments.directive ], arguments.value );
+
+		getRequestContext().setValue( name="additionalCspSources", value=sources, private=true );
+	}
+
+	public struct function getAdditionalCspSources() {
+		return getRequestContext().getValue( name="additionalCspSources", defaultValue={}, private=true );
 	}
 
 	public string function getRequestNonce() {

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1003,6 +1003,7 @@ component {
 		settings.enum.dataExportExcelDataTypes    = [ "mapped", "string" ];
 		settings.enum.systemAlertLevel            = [ "critical", "warning", "advisory" ];
 		settings.enum.adminToolbarModes           = [ "fixed", "reveal", "none" ];
+		settings.enum.cspConfigMode               = [ "disabled", "strict", "manual" ];
 	}
 
 	private void function __setupFormValidationProviders() {

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1003,7 +1003,7 @@ component {
 		settings.enum.dataExportExcelDataTypes    = [ "mapped", "string" ];
 		settings.enum.systemAlertLevel            = [ "critical", "warning", "advisory" ];
 		settings.enum.adminToolbarModes           = [ "fixed", "reveal", "none" ];
-		settings.enum.cspConfigMode               = [ "disabled", "strict", "manual" ];
+		settings.enum.cspConfigMode               = [ "disabled", "manual" ];
 	}
 
 	private void function __setupFormValidationProviders() {

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1016,6 +1016,7 @@ component {
 			, "enumService"
 			, "EmailCenterValidators"
 			, "FormbuilderValidators"
+			, "ContentSecurityPolicyManager"
 		];
 	}
 

--- a/system/forms/system-config/content-security-policy.xml
+++ b/system/forms/system-config/content-security-policy.xml
@@ -10,5 +10,9 @@ This form is used for configuring how Content Security Policy is applied to the 
 			<field sortorder="10" name="csp_mode"      control="enumRadioList" required="true" default="disabled" enum="cspConfigMode" toggleFields="manual:manual_policy" />
 			<field sortorder="20" name="manual_policy" control="textarea"      required="false" />
 		</fieldset>
+		<fieldset id="admin" sortorder="20">
+			<field sortorder="10" name="admin_csp_mode"      control="enumRadioList" required="true" default="disabled" enum="cspConfigMode" toggleFields="manual:admin_manual_policy" />
+			<field sortorder="20" name="admin_manual_policy" control="textarea"      required="false" />
+		</fieldset>
 	</tab>
 </form>

--- a/system/forms/system-config/content-security-policy.xml
+++ b/system/forms/system-config/content-security-policy.xml
@@ -8,11 +8,15 @@ This form is used for configuring how Content Security Policy is applied to the 
 	<tab id="general" sortorder="10">
 		<fieldset id="general" sortorder="10">
 			<field sortorder="10" name="csp_mode"      control="enumRadioList" required="true" default="disabled" enum="cspConfigMode" toggleFields="manual:manual_policy" />
-			<field sortorder="20" name="manual_policy" control="textarea"      required="false" />
+			<field sortorder="20" name="manual_policy" control="textarea"      required="false">
+				<rule validator="contentSecurityPolicy" message="system-config.content-security-policy:csp.validation.message" />
+			</field>
 		</fieldset>
 		<fieldset id="admin" sortorder="20">
 			<field sortorder="10" name="admin_csp_mode"      control="enumRadioList" required="true" default="disabled" enum="cspConfigMode" toggleFields="manual:admin_manual_policy" />
-			<field sortorder="20" name="admin_manual_policy" control="textarea"      required="false" />
+			<field sortorder="20" name="admin_manual_policy" control="textarea"      required="false">
+				<rule validator="contentSecurityPolicy" message="system-config.content-security-policy:csp.validation.message" />
+			</field>
 		</fieldset>
 	</tab>
 </form>

--- a/system/forms/system-config/content-security-policy.xml
+++ b/system/forms/system-config/content-security-policy.xml
@@ -18,5 +18,11 @@ This form is used for configuring how Content Security Policy is applied to the 
 				<rule validator="contentSecurityPolicy" message="system-config.content-security-policy:csp.validation.message" />
 			</field>
 		</fieldset>
+		<fieldset id="test" sortorder="20">
+			<field sortorder="10" name="test_csp_mode"      control="enumRadioList" required="true" default="disabled" enum="cspConfigMode" toggleFields="manual:test_manual_policy" />
+			<field sortorder="20" name="test_manual_policy" control="textarea"      required="false">
+				<rule validator="contentSecurityPolicy" message="system-config.content-security-policy:csp.validation.message" />
+			</field>
+		</fieldset>
 	</tab>
 </form>

--- a/system/forms/system-config/content-security-policy.xml
+++ b/system/forms/system-config/content-security-policy.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--#!autodoc
+System config form: Content Security Policy
+
+This form is used for configuring how Content Security Policy is applied to the website
+-->
+<form i18nBaseUri="system-config.content-security-policy:" noTenancy="true">
+	<tab id="general" sortorder="10">
+		<fieldset id="general" sortorder="10">
+			<field sortorder="10" name="csp_mode"      control="enumRadioList" required="true" default="disabled" enum="cspConfigMode" toggleFields="manual:manual_policy" />
+			<field sortorder="20" name="manual_policy" control="textarea"      required="false" />
+		</fieldset>
+	</tab>
+</form>

--- a/system/i18n/enum/cspConfigMode.properties
+++ b/system/i18n/enum/cspConfigMode.properties
@@ -3,6 +3,3 @@ disabled.description=Content Security Policy is disabled. <strong>NOT RECOMMENDE
 
 manual.label=Manual (recommended)
 manual.description=Manually enter a valid Content Security Policy.
-
-strict.label=Strict: same site only
-strict.description=Only allow resources from the same domain. Use of external javacscript, images and CSS will be blocked and <em>features such as Google Analytics will not work.</em>

--- a/system/i18n/enum/cspConfigMode.properties
+++ b/system/i18n/enum/cspConfigMode.properties
@@ -1,0 +1,8 @@
+disabled.label=Disabled
+disabled.description=Content Security Policy is disabled. <strong>NOT RECOMMENDED.</strong>
+
+manual.label=Manual (recommended)
+manual.description=Manually enter a valid Content Security Policy.
+
+strict.label=Strict: same site only
+strict.description=Only allow resources from the same domain. Use of external javacscript, images and CSS will be blocked and <em>features such as Google Analytics will not work.</em>

--- a/system/i18n/enum/cspConfigMode.properties
+++ b/system/i18n/enum/cspConfigMode.properties
@@ -2,4 +2,4 @@ disabled.label=Disabled
 disabled.description=Content Security Policy is disabled. <strong>NOT RECOMMENDED.</strong>
 
 manual.label=Manual (recommended)
-manual.description=Manually enter a valid Content Security Policy.
+manual.description=Manually enter a valid Content Security Policy. Where possible, the system will also automatically add trusted sources that are included in the rendered page.

--- a/system/i18n/system-config/content-security-policy.properties
+++ b/system/i18n/system-config/content-security-policy.properties
@@ -2,9 +2,15 @@ name=Content Security Policy
 description=Configure how Content Security Policy is applied to the website.
 iconClass=fa-shield-alt
 
-fieldset.general.description=<p class="alert alert-warning"><i class="fa fa-info-circle"></i> When setting up a manual policy, we advise seeking advice and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a> or <a href="https://www.quantcdn.io/tools/automatic-csp-generator" target="_blank">Qant's CSP Generator</a> to ensure the policy is valid and appropriate for your website.</p>
+tab.general.description=<p class="alert alert-warning"><i class="fa fa-info-circle"></i> When setting up a manual policy, we advise seeking advice and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a> or <a href="https://www.quantcdn.io/tools/automatic-csp-generator" target="_blank">Qant's CSP Generator</a> to ensure the policy is valid and appropriate for your website.</p>
+fieldset.general.title=Default policy
+fieldset.admin.title=Admin pages policy
 
 field.csp_mode.title=Operation mode
+field.admin_csp_mode.title=Operation mode
 
 field.manual_policy.title=Manual policy
-field.manual_policy.placeholder=Enter a valid policy. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'unsafe-inline';\nimg-src 'self' data: https://www.google-analytics.com;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
+field.manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data: https://www.google-analytics.com;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
+
+field.admin_manual_policy.title=Manual policy
+field.admin_manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data: https://www.google-analytics.com;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"

--- a/system/i18n/system-config/content-security-policy.properties
+++ b/system/i18n/system-config/content-security-policy.properties
@@ -7,12 +7,18 @@ csp.validation.message=The policy you have entered is not valid. Common mistakes
 tab.general.description=<p class="alert alert-danger"><i class="fa fa-exclamation-triangle"></i> <strong>WARNING:</strong> Setting a Content Security Policy incorrectly can cause your website to break. When setting up a manual policy, we advise seeking expert assistance and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a>.</p>
 fieldset.general.title=Default policy
 fieldset.admin.title=Admin pages policy
+fieldset.test.title=Test policy
+fieldset.test.description=<p class="alert alert-info"><i class="fa fa-info-circle"></i> This policy can be used to test policies and policy changes. The policy will ONLY be applied to pages where <code>?testcsp=true</code> is present in the URL.</p>
 
-field.csp_mode.title=Operation mode
-field.admin_csp_mode.title=Operation mode
+field.csp_mode.title=Mode
+field.admin_csp_mode.title=Mode
 
-field.manual_policy.title=Manual policy
+field.manual_policy.title=Policy
 field.manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data:;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
 
-field.admin_manual_policy.title=Manual policy
+field.admin_manual_policy.title=Policy
 field.admin_manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data:;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
+
+field.test_csp_mode.title=Mode
+field.test_manual_policy.title=Policy
+field.test_manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data:;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"

--- a/system/i18n/system-config/content-security-policy.properties
+++ b/system/i18n/system-config/content-security-policy.properties
@@ -1,0 +1,10 @@
+name=Content Security Policy
+description=Configure how Content Security Policy is applied to the website.
+iconClass=fa-shield-alt
+
+fieldset.general.description=<p class="alert alert-warning"><i class="fa fa-info-circle"></i> When setting up a manual policy, we advise seeking advice and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a> or <a href="https://www.quantcdn.io/tools/automatic-csp-generator" target="_blank">Qant's CSP Generator</a> to ensure the policy is valid and appropriate for your website.</p>
+
+field.csp_mode.title=Operation mode
+
+field.manual_policy.title=Manual policy
+field.manual_policy.placeholder=Enter a valid policy. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'unsafe-inline';\nimg-src 'self' data: https://www.google-analytics.com;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"

--- a/system/i18n/system-config/content-security-policy.properties
+++ b/system/i18n/system-config/content-security-policy.properties
@@ -2,7 +2,7 @@ name=Content Security Policy
 description=Configure how Content Security Policy is applied to the website.
 iconClass=fa-shield-alt
 
-tab.general.description=<p class="alert alert-warning"><i class="fa fa-info-circle"></i> When setting up a manual policy, we advise seeking advice and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a> or <a href="https://www.quantcdn.io/tools/automatic-csp-generator" target="_blank">Qant's CSP Generator</a> to ensure the policy is valid and appropriate for your website.</p>
+tab.general.description=<p class="alert alert-danger"><i class="fa fa-exclamation-triangle"></i> <strong>WARNING:</strong> Setting a Content Security Policy incorrectly can cause your website to break. When setting up a manual policy, we advise seeking expert assistance and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a>.</p>
 fieldset.general.title=Default policy
 fieldset.admin.title=Admin pages policy
 

--- a/system/i18n/system-config/content-security-policy.properties
+++ b/system/i18n/system-config/content-security-policy.properties
@@ -2,6 +2,8 @@ name=Content Security Policy
 description=Configure how Content Security Policy is applied to the website.
 iconClass=fa-shield-alt
 
+csp.validation.message=The policy you have entered is not valid. Common mistakes include not surrounding non-uri resources in single quotes. e.g. 'self', 'none', 'unsafe-inline', 'unsafe-eval', etc. Please check the policy using a tool like <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a> and try again.
+
 tab.general.description=<p class="alert alert-danger"><i class="fa fa-exclamation-triangle"></i> <strong>WARNING:</strong> Setting a Content Security Policy incorrectly can cause your website to break. When setting up a manual policy, we advise seeking expert assistance and using 3rd party tools such as <a href="https://csp-evaluator.withgoogle.com/" target="_blank">Google's CSP evaluator</a>.</p>
 fieldset.general.title=Default policy
 fieldset.admin.title=Admin pages policy

--- a/system/i18n/system-config/content-security-policy.properties
+++ b/system/i18n/system-config/content-security-policy.properties
@@ -10,7 +10,7 @@ field.csp_mode.title=Operation mode
 field.admin_csp_mode.title=Operation mode
 
 field.manual_policy.title=Manual policy
-field.manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data: https://www.google-analytics.com;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
+field.manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data:;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
 
 field.admin_manual_policy.title=Manual policy
-field.admin_manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data: https://www.google-analytics.com;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"
+field.admin_manual_policy.placeholder=Enter a valid policy. For nonce values, use $nonce. You may split the policy into multiple lines. e.g.\n\ndefault-src 'self';\nscript-src 'self' 'nonce-$nonce' 'unsafe-eval' https://www.google-analytics.com;\nstyle-src 'self' 'nonce-$nonce';\nimg-src 'self' data:;\nfont-src 'self' data:;\nconnect-src 'self' wss://www.google-analytics.com;"

--- a/system/layouts/admin.cfm
+++ b/system/layouts/admin.cfm
@@ -41,6 +41,8 @@
 
 	htmlTitle = translateResource( uri="cms:cms.title" ) & " :: " & ( prc.pageTitle ?: translateResource( uri="cms:cms.tagline", defaultValue="" ) );
 
+	event.addToContentSecurityPolicy( "img-src", "//www.gravatar.com" );
+
 	header name="cache-control" value="no-store";
 	header name="expires"       value="Fri, 20 Nov 2015 00:00:00 GMT";
 </cfscript>

--- a/system/layouts/admin.cfm
+++ b/system/layouts/admin.cfm
@@ -68,7 +68,7 @@
 			#siteAlerts#
 
 			<div class="main-container" id="main-container">
-				<script type="text/javascript">
+				<script type="text/javascript" nonce="#event.getRequestNonce()#">
 					try{ace.settings.check('main-container' , 'fixed')}catch(e){}
 				</script>
 

--- a/system/services/rest/PresideRestService.cfc
+++ b/system/services/rest/PresideRestService.cfc
@@ -60,7 +60,7 @@ component {
 		var event        = $getRequestContext();
 
 		event.cachePage( false );
-		event.setContentSecurityPolicy( "default-src 'none'; frame-ancestors 'none'" );
+		event.setContentSecurityPolicy( "default-src 'none'; frame-ancestors 'none';" );
 		event.setRestResponse( restResponse );
 		event.setRestRequest( restRequest );
 

--- a/system/services/rest/PresideRestService.cfc
+++ b/system/services/rest/PresideRestService.cfc
@@ -60,6 +60,7 @@ component {
 		var event        = $getRequestContext();
 
 		event.cachePage( false );
+		event.setContentSecurityPolicy( "default-src 'none'; frame-ancestors 'none'" );
 		event.setRestResponse( restResponse );
 		event.setRestRequest( restRequest );
 

--- a/system/services/security/ContentSecurityPolicyManager.cfc
+++ b/system/services/security/ContentSecurityPolicyManager.cfc
@@ -24,6 +24,49 @@ component {
 		}
 	}
 
+	public boolean function validate( required string policy ) {
+		var directives       = _convertPolicyToDirectiveStructure( arguments.policy );
+		var validSrcPatterns = [ "^//", "^(http|https|ftp|wss|file)://", "^'[a-z0-9-\$_]+'$", "^data:" ];
+
+		for( var directive in directives ) {
+			// there are lots of directives with other rules. Avoid attempting a fully policy
+			// validator here to avoid false negatives that prevent valid rule generation.
+			// Instead, we will perform some basic checks on the values of the src directives.
+			if ( ReFind( "-src$", directive ) ) {
+				for( var src in directives[ directive ] ) {
+					var valid = false;
+					for( var pattern in validSrcPatterns ) {
+						if ( ReFindNoCase( pattern, src ) ) {
+							valid = true;
+							continue;
+						}
+					}
+					if ( !valid ) {
+						return false;
+					}
+				}
+			}
+		}
+
+		return true;
+	}
+
+// VALIDATION PROVIDER
+	/**
+	 * @validator true
+	 * @validationMessage system-config.content-security-policy:csp.validation.message
+	 */
+	public boolean function contentSecurityPolicy( required string fieldName, any value="" ) {
+		if ( IsEmpty( arguments.value ) ) {
+			return true;
+		}
+
+		return validate( arguments.value );
+	}
+	public string function contentSecurityPolicy_js() {
+		return "function( value, el, params ){ return true; }";
+	}
+
 // PRIVATE HELPERS
 	private function _getGlobalPolicy() {
 		var settings       = $getPresideCategorySettings( "content-security-policy" );

--- a/system/services/security/ContentSecurityPolicyManager.cfc
+++ b/system/services/security/ContentSecurityPolicyManager.cfc
@@ -24,7 +24,7 @@ component {
 		}
 	}
 
-	public boolean function validate( required string policy ) {
+	public boolean function validatePolicy( required string policy ) {
 		var directives       = _convertPolicyToDirectiveStructure( arguments.policy );
 		var validSrcPatterns = [ "^//", "^(http|https|ftp|wss|file)://", "^'[a-z0-9-\$_]+'$", "^data:" ];
 
@@ -61,7 +61,7 @@ component {
 			return true;
 		}
 
-		return validate( arguments.value );
+		return validatePolicy( arguments.value );
 	}
 	public string function contentSecurityPolicy_js() {
 		return "function( value, el, params ){ return true; }";
@@ -74,12 +74,21 @@ component {
 		var mode           = settings[ settingsPrefix & "csp_mode" ] ?: "";
 		var policy         = settings[ settingsPrefix & "manual_policy" ] ?: "";
 
+		if ( _isTestMode( settings ) ) {
+			policy = settings.test_manual_policy ?: "";
+			mode   = "manual";
+		}
+
 		switch( mode ) {
 			case "manual":
 				return ReReplace( Trim( policy ), "[\r\n]+", " ", "all" );
 		}
 
 		return "";
+	}
+
+	private function _isTestMode( required struct settings ) {
+		return ( arguments.settings.test_csp_mode ?: "" ) == "manual" && ( url.testcsp ?: "" ) == "true";
 	}
 
 	private function _injectNonce( required string policy ) {

--- a/system/services/security/ContentSecurityPolicyManager.cfc
+++ b/system/services/security/ContentSecurityPolicyManager.cfc
@@ -20,9 +20,7 @@ component {
 		}
 
 		if ( Len( Trim( policy ) ) ) {
-			policy = _injectNonce( policy );
-
-			header name="Content-Security-Policy" value=policy;
+			header name="Content-Security-Policy" value=_injectNonce( _injectAdditionalSources( policy ) );
 		}
 	}
 
@@ -45,5 +43,47 @@ component {
 		var nonce = $getRequestContext().getRequestNonce();
 
 		return ReplaceNoCase( arguments.policy, "$nonce", nonce, "all" );
+	}
+
+	private function _injectAdditionalSources( required string policy ) {
+		var additionalSources = $getRequestContext().getAdditionalCspSources();
+
+		if ( !StructCount( additionalSources ) ) {
+			return arguments.policy;
+		}
+
+		var directives = _convertPolicyToDirectiveStructure( arguments.policy );
+
+		for( var directive in additionalSources ) {
+			if ( !StructKeyExists( directives, directive ) ) {
+				directives[ directive ] = [ "'self'" ];
+			}
+
+			for( var src in additionalSources[ directive ] ) {
+				if ( !ArrayContains( directives[ directive ], src ) ) {
+					ArrayAppend( directives[ directive ], src );
+				}
+			}
+		}
+
+		return _convertDirectiveStructureToPolicy( directives );
+	}
+
+	private function _convertPolicyToDirectiveStructure( required string policy ) {
+		var directives = {};
+		for( var directiveAndValues in ListToArray( arguments.policy, ";" ) ) {
+			directives[ ListFirst( directiveAndValues, " " ) ] = ListToArray( ListRest( directiveAndValues, " " ), " " );
+		}
+		return directives;
+	}
+
+	private function _convertDirectiveStructureToPolicy( required struct directives ) {
+		var policy = [];
+
+		for( var directive in directives ) {
+			ArrayAppend( policy, directive & " " & ArrayToList( directives[ directive ], " " ) );
+		}
+
+		return ArrayToList( policy, "; " );
 	}
 }

--- a/system/services/security/ContentSecurityPolicyManager.cfc
+++ b/system/services/security/ContentSecurityPolicyManager.cfc
@@ -13,31 +13,39 @@ component {
 
 // PUBLIC API
 	public void function outputPolicyHeader() {
-		var requestPolicy = $getRequestContext().getContentSecurityPolicy();
+		var policy = $getRequestContext().getContentSecurityPolicy();
 
-		if ( Len( Trim( requestPolicy ) ) ) {
-			header name="Content-Security-Policy" value=requestPolicy;
-			return;
+		if ( !Len( Trim( policy ) ) ) {
+			policy = _getGlobalPolicy();
 		}
 
-		var globalPolicy = _getGlobalPolicy();
+		if ( Len( Trim( policy ) ) ) {
+			policy = _injectNonce( policy );
 
-		if ( Len( Trim( globalPolicy ) ) ) {
-			header name="Content-Security-Policy" value=globalPolicy;
+			header name="Content-Security-Policy" value=policy;
 		}
 	}
 
 // PRIVATE HELPERS
 	private function _getGlobalPolicy() {
-		var settings = $getPresideCategorySettings( "content-security-policy" );
+		var settings       = $getPresideCategorySettings( "content-security-policy" );
+		var settingsPrefix = $getRequestContext().isAdminRequest() ? "admin_" : "";
+		var mode           = settings[ settingsPrefix & "csp_mode" ] ?: "";
+		var policy         = settings[ settingsPrefix & "manual_policy" ] ?: "";
 
-		switch( settings.csp_mode ?: "" ) {
+		switch( mode ) {
 			case "strict":
-				return "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' wss:;";
+				return "default-src 'self'; script-src 'self' 'unsafe-inline' 'nonce-$nonce' 'unsafe-eval'; style-src 'self' 'unsafe-inline' 'nonce-$nonce'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' wss:;";
 			case "manual":
-				return ReReplace( Trim( settings.manual_policy ?: "" ), "[\r\n]+", " ", "all" );
+				return ReReplace( Trim( policy ), "[\r\n]+", " ", "all" );
 		}
 
 		return "";
+	}
+
+	private function _injectNonce( required string policy ) {
+		var nonce = $getRequestContext().getRequestNonce();
+
+		return ReplaceNoCase( arguments.policy, "$nonce", nonce, "all" );
 	}
 }

--- a/system/services/security/ContentSecurityPolicyManager.cfc
+++ b/system/services/security/ContentSecurityPolicyManager.cfc
@@ -1,0 +1,43 @@
+/**
+ * Manages the content security policy for the system
+ *
+ * @singleton      true
+ * @presideService true
+ */
+component {
+
+// CONSTRUCTOR
+	function init() {
+		return this;
+	}
+
+// PUBLIC API
+	public void function outputPolicyHeader() {
+		var requestPolicy = $getRequestContext().getContentSecurityPolicy();
+
+		if ( Len( Trim( requestPolicy ) ) ) {
+			header name="Content-Security-Policy" value=requestPolicy;
+			return;
+		}
+
+		var globalPolicy = _getGlobalPolicy();
+
+		if ( Len( Trim( globalPolicy ) ) ) {
+			header name="Content-Security-Policy" value=globalPolicy;
+		}
+	}
+
+// PRIVATE HELPERS
+	private function _getGlobalPolicy() {
+		var settings = $getPresideCategorySettings( "content-security-policy" );
+
+		switch( settings.csp_mode ?: "" ) {
+			case "strict":
+				return "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' wss:;";
+			case "manual":
+				return ReReplace( Trim( settings.manual_policy ?: "" ), "[\r\n]+", " ", "all" );
+		}
+
+		return "";
+	}
+}

--- a/system/services/security/ContentSecurityPolicyManager.cfc
+++ b/system/services/security/ContentSecurityPolicyManager.cfc
@@ -34,8 +34,6 @@ component {
 		var policy         = settings[ settingsPrefix & "manual_policy" ] ?: "";
 
 		switch( mode ) {
-			case "strict":
-				return "default-src 'self'; script-src 'self' 'unsafe-inline' 'nonce-$nonce' 'unsafe-eval'; style-src 'self' 'unsafe-inline' 'nonce-$nonce'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' wss:;";
 			case "manual":
 				return ReReplace( Trim( policy ), "[\r\n]+", " ", "all" );
 		}

--- a/system/services/sticker/StickerForPreside.cfc
+++ b/system/services/sticker/StickerForPreside.cfc
@@ -34,7 +34,11 @@ component {
 		if ( arguments.delayed && $isFeatureEnabled( "delayedViewlets" ) ) {
 			return _getDelayedStickerRendererService().renderDelayedStickerTag( argumentCollection=arguments, memento=_getSticker().getMemento() );
 		} else {
-			return _getSticker().renderIncludes( argumentCollection=arguments );
+			var rendered = _getSticker().renderIncludes( argumentCollection=arguments );
+
+			_addCspSourcesFromExternalRenderedIncludes( rendered );
+
+			return rendered;
 		}
 	}
 
@@ -68,6 +72,24 @@ component {
 		sticker.load();
 
 		_setSticker( sticker );
+	}
+
+	private void function _addCspSourcesFromExternalRenderedIncludes( required string rendered ) {
+		var event          = $getRequestContext();
+		var externalStyles = ReFind( '<link\s.*href="((https?://|//)[^"/]+)', arguments.rendered, 1, true, "all" );
+
+		for( var match in externalStyles ) {
+			if ( Len( Trim( match.match[ 2 ] ?: "" ) ) ) {
+				event.addToContentSecurityPolicy( "style-src", match.match[ 2 ] );
+			}
+		}
+
+		var externalScripts = ReFind( '<script src="((https?://|//)[^"/]+)', arguments.rendered, 1, true, "all" );
+		for( var match in externalScripts ) {
+			if ( Len( Trim( match.match[ 2 ] ?: "" ) ) ) {
+				event.addToContentSecurityPolicy( "script-src", match.match[ 2 ] );
+			}
+		}
 	}
 
 	private function _isDelayableContext() {

--- a/system/views/admin/layout/breadcrumbs.cfm
+++ b/system/views/admin/layout/breadcrumbs.cfm
@@ -6,7 +6,7 @@
 
 <cfoutput>
 	<div id="breadcrumbs" class="breadcrumbs">
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="#event.getRequestNonce()#">
 			try{ace.settings.check('breadcrumbs' , 'fixed')}catch(e){}
 		</script>
 

--- a/system/views/admin/layout/navbar.cfm
+++ b/system/views/admin/layout/navbar.cfm
@@ -11,7 +11,7 @@
 
 <cfoutput>
 	<div class="navbar navbar-default" id="navbar">
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="#event.getRequestNonce()#">
 			try{ace.settings.check( 'navbar', 'fixed' );}catch(e){}
 		</script>
 

--- a/system/views/admin/layout/sideBarNavigation.cfm
+++ b/system/views/admin/layout/sideBarNavigation.cfm
@@ -1,7 +1,7 @@
 <!---@feature admin--->
 <cfoutput>
 	<div class="sidebar" id="sidebar">
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="#event.getRequestNonce()#">
 			try{ace.settings.check('sidebar' , 'fixed')}catch(e){}
 		</script>
 
@@ -13,7 +13,7 @@
 			<i class="fa fa-angle-double-left" data-icon1="fa fa-angle-double-left" data-icon2="fa fa-angle-double-right"></i>
 		</div>
 
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="#event.getRequestNonce()#">
 			try{ace.settings.check('sidebar' , 'collapsed')}catch(e){}
 		</script>
 	</div>

--- a/system/views/errors/maintenanceMode.cfm
+++ b/system/views/errors/maintenanceMode.cfm
@@ -7,7 +7,7 @@
 		<title>#args.title#</title>
 		<meta charset="utf-8">
 		<meta name="robots" content="noindex,nofollow" />
-		<style type="text/css">
+		<style type="text/css" nonce="#event.getRequestNonce()#">
 			body {
 				background  : ##fff;
 				font-family : arial;

--- a/system/views/errors/sqlRebuild.cfm
+++ b/system/views/errors/sqlRebuild.cfm
@@ -4,7 +4,7 @@
 		<title>Preside: SQL Schema Synchronisation Required</title>
 		<meta charset="utf-8">
 		<meta name="robots" content="noindex,nofollow" />
-		<style type="text/css">
+		<style type="text/css" nonce="#event.getRequestNonce()#">
 			body {
 				background  : #fff;
 				font-family : arial;

--- a/system/views/formcontrols/simpleColourPicker/index.cfm
+++ b/system/views/formcontrols/simpleColourPicker/index.cfm
@@ -51,7 +51,7 @@
 
 
 <cfoutput>
-	<style type="text/css">
+	<style type="text/css" nonce="#event.getRequestNonce()#">
 		##simple-colour-picker-#controlId# .popover {
 			max-width : #paletteWidth#px;
 		}

--- a/system/views/general/_adminToolbar.cfm
+++ b/system/views/general/_adminToolbar.cfm
@@ -127,7 +127,7 @@
 			</div>
 		</div>
 
-		<script>
+		<script nonce="#event.getRequestNonce()#">
 			( function(){
 				var htmlElement    = document.querySelector( "html" )
 				  , bodyElement    = document.querySelector( "body" )

--- a/system/views/general/_adminToolbar.cfm
+++ b/system/views/general/_adminToolbar.cfm
@@ -2,9 +2,16 @@
 <cfscript>
 	if ( event.isAdminUser() ) {
 		prc.adminToolbarDisplayMode = prc.adminToolbarDisplayMode ?: getSystemSetting( "frontend-editing", "admin_toolbar_mode", "fixed" );
+		showToolBar = !getModel( "loginService" ).twoFactorAuthenticationRequired() && prc.adminToolbarDisplayMode neq "none";
+
+		if ( showToolBar ) {
+			event.addToContentSecurityPolicy( "img-src", "//www.gravatar.com" );
+		}
+	} else {
+		showToolBar = false;
 	}
 </cfscript>
-<cfif event.isAdminUser() and !getModel( "loginService" ).twoFactorAuthenticationRequired() and prc.adminToolbarDisplayMode neq "none">
+<cfif showToolBar>
 	<cfscript>
 		prc.hasCmsPageEditPermissions = prc.hasCmsPageEditPermissions ?: hasCmsPermission( permissionKey="sitetree.edit", context="page", contextKeys=event.getPagePermissionContext() );
 		prc.adminQuickEditDisabled    = prc.adminQuickEditDisabled    ?: isTrue( getSystemSetting( "frontend-editing", "disable_quick_edit" ) );

--- a/system/views/widgets/jssnippetwidget/index.cfm
+++ b/system/views/widgets/jssnippetwidget/index.cfm
@@ -8,6 +8,7 @@
 
 <cfoutput>
 	<cfif !IsEmpty( args.source_url )>
+		<cfset event.addToContentSecurityPolicy( "script-src", args.source_url ) />
 		<cfif IsTrue( args.async )>
 			<cfset method = " async" />
 		<cfelseif IsTrue( args.defer )>

--- a/system/views/widgets/jssnippetwidget/index.cfm
+++ b/system/views/widgets/jssnippetwidget/index.cfm
@@ -20,7 +20,7 @@
 	</cfif>
 
 	<cfif !IsEmpty( args.inline_script )>
-		<script type="text/javascript">
+		<script type="text/javascript" nonce="#event.getRequestNonce()#">
 			#args.inline_script#
 		</script>
 	</cfif>

--- a/tests/unit/api/rest/PresideRestServiceTest.cfc
+++ b/tests/unit/api/rest/PresideRestServiceTest.cfc
@@ -1193,6 +1193,7 @@ component extends="testbox.system.BaseSpec"{
 		restService.$( "authenticateRequest" );
 		restService.$( "$getRequestContext", mockRequestContext );
 		mockRequestContext.$( "cachePage" );
+		mockRequestContext.$( "setContentSecurityPolicy" );
 		mockRequestContext.$( "setRestResponse" );
 		mockRequestContext.$( "setRestRequest" );
 
@@ -1216,7 +1217,6 @@ component extends="testbox.system.BaseSpec"{
 		rc.$( "getHttpHeader", "" );
 		rc.$( "renderData", rc );
 		rc.$( "getCollection", {} );
-		rc.$( "setContentSecurityPolicy" );
 		rc.$( "getInstanceIdForComparison", CreateUUId() );
 
 		return rc;

--- a/tests/unit/api/rest/PresideRestServiceTest.cfc
+++ b/tests/unit/api/rest/PresideRestServiceTest.cfc
@@ -1216,6 +1216,7 @@ component extends="testbox.system.BaseSpec"{
 		rc.$( "getHttpHeader", "" );
 		rc.$( "renderData", rc );
 		rc.$( "getCollection", {} );
+		rc.$( "setContentSecurityPolicy" );
 		rc.$( "getInstanceIdForComparison", CreateUUId() );
 
 		return rc;


### PR DESCRIPTION
This allows:

* A super strict policy to be enabled with one click
* A manual policy to be entered
* Developers to set custom policies for particular websites

It:

* Sets a highly restrictive policy for REST APIs
* Is disabled by default so that websites do not break on upgrade

