### PR TITLE
PRESIDECMS-3135 Formbuilder post action condition new no longer works

### DIFF
--- a/system/assets/js/admin/specific/rulesEngineConditionBuilder/conditionBuilder.js
+++ b/system/assets/js/admin/specific/rulesEngineConditionBuilder/conditionBuilder.js
@@ -242,7 +242,7 @@
 			var definition = this.getExpression( expression.expression );
 
 			if ( typeof definition === "undefined" || definition == null ) {
-				return '<em class="red"><i class="fa fa-fw fa-exclamation-triangle"></i> ' + i18n.translateResource( "cms:rulesEngine.invalid.expression" ) + '</em>';
+				return '<em class="red"><i class="fa fa-fw fa-exclamation-triangle"></i> ' + i18n.translateResource( "cms:rulesEngine.invalid.expression", { data:[ expression.expression ] } ) + '</em>';
 			}
 
 			var text       = definition.text || ""

--- a/system/handlers/rules/contexts/FormbuilderSubmission.cfc
+++ b/system/handlers/rules/contexts/FormbuilderSubmission.cfc
@@ -14,7 +14,7 @@ component {
 			return { formbuilderSubmission=formBuilderService.getFormBuilderSubmissionContextData() };
 		}
 
-		return { formbuilderSubmission={ id=formId, data=rc } };
+		return { formbuilderSubmission={ id=formId, formId=formId, submissionId="", data=rc } };
 	}
 
 }

--- a/system/handlers/rules/expressions/question/DateFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/DateFieldMatches.cfc
@@ -1,11 +1,13 @@
 /**
  * Expression handler for "Date {question} matches"
  *
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder
  */
+
+
 component {
 
 	property name="formBuilderFilterService" inject="formBuilderFilterService";

--- a/system/handlers/rules/expressions/question/FileUploadTypeMatches.cfc
+++ b/system/handlers/rules/expressions/question/FileUploadTypeMatches.cfc
@@ -1,7 +1,7 @@
 /**
  * Expression handler for "File type for {question} matches"
  *
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/HasResponse.cfc
+++ b/system/handlers/rules/expressions/question/HasResponse.cfc
@@ -1,7 +1,7 @@
 /**
  * Expression handler for "Has responded"
  *
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/HasUploaded.cfc
+++ b/system/handlers/rules/expressions/question/HasUploaded.cfc
@@ -1,7 +1,7 @@
 /**
  * Expression handler for "Has uploaded"
  *
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/MatrixAllRowsMatch.cfc
+++ b/system/handlers/rules/expressions/question/MatrixAllRowsMatch.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/MatrixAnyRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/MatrixAnyRowMatches.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/MatrixRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/MatrixRowMatches.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/MultiChoiceFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/MultiChoiceFieldMatches.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/NumericFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/NumericFieldMatches.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/SingleChoiceFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/SingleChoiceFieldMatches.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/StarRatingMatches.cfc
+++ b/system/handlers/rules/expressions/question/StarRatingMatches.cfc
@@ -1,5 +1,5 @@
 /**
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/TextFieldMatches.cfc
+++ b/system/handlers/rules/expressions/question/TextFieldMatches.cfc
@@ -1,7 +1,7 @@
 /**
  * Expression handler for "Textfield {question} text matches"
  *
- * @expressionContexts webrequest
+ * @expressionContexts formbuilderSubmission
  * @expressionCategory formbuilder
  * @expressionTags     formbuilderV2Form
  * @feature            rulesEngine and formbuilder

--- a/system/handlers/rules/expressions/question/UserLatestResponseToDate.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToDate.cfc
@@ -16,7 +16,7 @@ component {
 	 */
 	private boolean function evaluateExpression(
 		  required string question
-		,          string formId = ""
+		,          string formId = ( payload.formbuilderSubmission.formId ?: "" )
 		,          struct _time  = {}
 	) {
 		var userId = payload.user.id ?: "";
@@ -28,8 +28,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = payload.formId ?: ""
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAllRowsMatch.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAllRowsMatch.cfc
@@ -18,7 +18,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string question
 		, required string value
-		,          string formId = ( payload.formId ?: "" )
+		,          string formId = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string _all   = false
 	) {
 		var userId = payload.user.id ?: "";
@@ -30,8 +30,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = arguments.formId
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAnyRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMatrixAnyRowMatches.cfc
@@ -18,7 +18,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string question
 		, required string value
-		,          string formId = ( payload.formId ?: "" )
+		,          string formId = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string _all   = false
 	) {
 		var userId = payload.user.id ?: "";
@@ -30,8 +30,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = arguments.formId
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMatrixRowMatches.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMatrixRowMatches.cfc
@@ -19,7 +19,7 @@ component {
 		  required string question
 		, required string row
 		, required string value
-		,          string formId = ( payload.formId ?: "" )
+		,          string formId = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string _all   = false
 	) {
 		var userId = payload.user.id ?: "";
@@ -31,8 +31,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = arguments.formId
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToMultiChoice.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToMultiChoice.cfc
@@ -17,7 +17,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string question
 		, required string value
-		,          string formId = ""
+		,          string formId = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string  _all  = false
 	) {
 		var userId = payload.user.id ?: "";
@@ -29,8 +29,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = payload.formId ?: ""
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToNumber.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToNumber.cfc
@@ -16,7 +16,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string  question
 		, required numeric value
-		,          string  formId           = ""
+		,          string  formId           = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string  _numericOperator = "eq"
 	) {
 		var userId = payload.user.id ?: "";
@@ -28,8 +28,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = payload.formId ?: ""
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToSingleChoice.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToSingleChoice.cfc
@@ -17,7 +17,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string question
 		, required string value
-		,          string formId = ( payload.formId ?: "" )
+		,          string formId = ( payload.formbuilderSubmission.formId ?: "" )
 	) {
 		var userId = payload.user.id ?: "";
 
@@ -28,8 +28,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = arguments.formId
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToStarRating.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToStarRating.cfc
@@ -17,7 +17,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string  question
 		, required numeric value
-		,          string  formId           = ( payload.formId ?: "" )
+		,          string  formId           = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string  _numericOperator = "eq"
 	) {
 		var userId = payload.user.id ?: "";
@@ -29,8 +29,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = arguments.formid
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/handlers/rules/expressions/question/UserLatestResponseToTextField.cfc
+++ b/system/handlers/rules/expressions/question/UserLatestResponseToTextField.cfc
@@ -16,7 +16,7 @@ component {
 	private boolean function evaluateExpression(
 		  required string question
 		, required string value
-		,          string formId
+		,          string formId           = ( payload.formbuilderSubmission.formId ?: "" )
 		,          string  _stringOperator = "eq"
 	) {
 		var userId = payload.user.id ?: "";
@@ -28,8 +28,6 @@ component {
 		return formBuilderFilterService.evaluateQuestionUserLatestResponseMatch(
 			  argumentCollection = arguments
 			, userId             = userId
-			, formId             = payload.formId ?: ""
-			, submissionId       = payload.submissionId ?: ""
 			, extraFilters       = prepareFilters( argumentCollection=arguments )
 		);
 	}

--- a/system/i18n/cms.properties
+++ b/system/i18n/cms.properties
@@ -1547,7 +1547,7 @@ rulesEngine.months.10=October
 rulesEngine.months.11=November
 rulesEngine.months.12=December
 
-rulesEngine.invalid.expression=This expression is no longer valid and will always be false. Please delete this expression.
+rulesEngine.invalid.expression=This expression, {1}, is no longer valid and will always be false. Please delete this expression.
 
 rulesengine.filters.groupFilters=Group filters:
 rulesengine.filters.individualFilters=Your personal filters:

--- a/system/services/formbuilder/FormBuilderFilterService.cfc
+++ b/system/services/formbuilder/FormBuilderFilterService.cfc
@@ -310,9 +310,9 @@ component {
 
 	public boolean function evaluateQuestionSubmissionResponseMatch(
 			  required array  extraFilters
-			,          string userId
-			,          string formId
-			,          string submissionId
+			,          string userId       = ""
+			,          string formId       = ""
+			,          string submissionId = ""
 
 	) {
 		var submissionsDao = $getPresideObject( "formbuilder_formsubmission" );

--- a/system/services/formbuilder/FormBuilderService.cfc
+++ b/system/services/formbuilder/FormBuilderService.cfc
@@ -1174,8 +1174,6 @@ component {
 		,          boolean validateCaptcha = true
 		,          array   formItems       = []
 	) {
-		setFormBuilderSubmissionContextData( arguments.formId, arguments.requestData );
-
 		var submissionId      = "";
 		var formConfiguration = getForm( arguments.formId );
 		var formItems         = ArrayLen( arguments.formItems ) ? arguments.formItems : getFormItems( arguments.formId );
@@ -1228,6 +1226,8 @@ component {
 					, user_agent     = arguments.userAgent
 				} );
 			}
+
+			setFormBuilderSubmissionContextData( formId=arguments.formId, submissionId=submissionId, data=arguments.requestData );
 
 			var submission = getSubmission( submissionId );
 			for( var s in submission ) { submission = s; }
@@ -2421,10 +2421,19 @@ component {
 	public struct function getFormBuilderSubmissionContextData() {
 		return $getRequestContext().getValue( name="_formBuilderContext", private=true, defaultValue={} );
 	}
-	public void function setFormBuilderSubmissionContextData( required string formId, required struct data ) {
+	public void function setFormBuilderSubmissionContextData(
+		  required string formId
+		, required struct data
+		,          string submissionId = ""
+	) {
 		$getRequestContext().setValue(
 			  name    = "_formBuilderContext"
-			, value   = { id=arguments.formId, data=arguments.data }
+			, value   = {
+				  id           = arguments.formId // for compatibility
+				, formId       = arguments.formId
+				, submissionId = arguments.submissionId
+				, data         = arguments.data
+			  }
 			, private = true
 		);
 	}


### PR DESCRIPTION
Change question rules context to formbuilder submission.
Update i18n for invalid expressions to display the expression ID.
Update to set formbuilder submission context payload with formId and submissionId.
Remove unused arguments from the rules filter.