### PR TITLE
PRESIDECMS-3141 add a random offset to task manager task runs

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -914,6 +914,7 @@ component {
 			, sticker                         = { enabled=true , siteTemplates=[ "*" ], widgets=[]                      , dependsOn=[ "admin" ] }
 			, urlRedirects                    = { enabled=true , siteTemplates=[ "*" ], widgets=[]                      , dependsOn=[ "cms" ] }
 			, taskManager                     = { enabled=true , siteTemplates=[ "*" ], widgets=[] }
+			, taskmanagerUseRandomOffset      = { enabled=false, siteTemplates=[ "*" ], widgets=[]                      , dependsOn=[ "taskmanager" ] }
 			, adhocTasks                      = { enabled=true , siteTemplates=[ "*" ], widgets=[] }
 			, assetManager                    = { enabled=true , siteTemplates=[ "*" ], widgets=[]                      , dependsOn=[ "admin" ] }
 			, websiteUsers                    = { enabled=true , siteTemplates=[ "*" ], widgets=[]                      , dependsOn=[ "cms"   ] }
@@ -971,6 +972,10 @@ component {
 			, "devtools.new"                  = { enabled=false, siteTemplates=[ "*" ], widgets=[]                      , dependsOn=[ "admin" ] }
 			, passwordVisibilityToggle        = { enabled=true , siteTemplates=[ "*" ]                                  , dependsOn=[ "admin" ] }
 		};
+
+		if ( IsBoolean( settings.env.TASKMANAGER_USE_RANDOM_OFFSET ?: "" ) ) {
+			settings.features.taskmanagerUseRandomOffset.enabled = settings.env.TASKMANAGER_USE_RANDOM_OFFSET;
+		}
 	}
 
 	private void function __setupEnums() {

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -51,6 +51,7 @@ component displayName="Task Manager Service" {
 
 		_initialiseDb();
 		_setRunningTasks({});
+		_setTaskOffsets({});
 
 		return this;
 	}
@@ -565,7 +566,7 @@ component displayName="Task Manager Service" {
 		var runDate    = _getCronUtil().getNextRunDate( schedule, arguments.lastRun );
 
 		if ( $isFeatureEnabled( "taskmanagerUseRandomOffset" ) ) {
-			runDate = DateAdd( "s", _getRandomOffset(), runDate );
+			runDate = DateAdd( "s", _getRandomOffset( arguments.taskKey ), runDate );
 		}
 
 		return runDate;
@@ -852,45 +853,53 @@ component displayName="Task Manager Service" {
 		}
 	}
 
+	private numeric function _getAverageWorkTimeFromClusteredTimes( required array runTimes ) {
+		var centroids = [runTimes[RandRange(1, ArrayLen(runTimes))], runTimes[RandRange(1, arrayLen(RunTimes))]];
+		var clusters  = ArrayNew(1);
 
+		maxIterations = 100;
 
-private numeric function _getAverageWorkTimeFromClusteredTimes( required array runTimes ) {
-	var centroids = [runTimes[RandRange(1, ArrayLen(runTimes))], runTimes[RandRange(1, arrayLen(RunTimes))]];
-	var clusters  = ArrayNew(1);
+		for (i = 1; i <= maxIterations; i++) {
+			clusters = ArrayNew(1);
+			clusters[1] = [];
+			clusters[2] = [];
 
-	maxIterations = 100;
+			for (time in runTimes) {
+				distanceToCluster1 = Abs(time - centroids[1]);
+				distanceToCluster2 = Abs(time - centroids[2])
+				if (distanceToCluster1 < distanceToCluster2) {
+					ArrayAppend(clusters[1], time);
+				} else {
+					ArrayAppend(clusters[2], time);
+				}
+			}
 
-	for (i = 1; i <= maxIterations; i++) {
-		clusters = ArrayNew(1);
-		clusters[1] = [];
-		clusters[2] = [];
+			newCentroids = [ArrayAvg(clusters[1]), ArrayAvg(clusters[2])];
 
-		for (time in runTimes) {
-			distanceToCluster1 = Abs(time - centroids[1]);
-			distanceToCluster2 = Abs(time - centroids[2])
-			if (distanceToCluster1 < distanceToCluster2) {
-				ArrayAppend(clusters[1], time);
+			if ( newCentroids.equals( centroids ) ) {
+				break;
 			} else {
-				ArrayAppend(clusters[2], time);
+				centroids = newCentroids;
 			}
 		}
 
-		newCentroids = [ArrayAvg(clusters[1]), ArrayAvg(clusters[2])];
+		// Identify which cluster is "work" (the one with the higher average)
+		workClusterIndex = (ArrayAvg(clusters[1]) > ArrayAvg(clusters[2])) ? 1 : 2;
+		workTimes = clusters[workClusterIndex];
 
-		if ( newCentroids.equals( centroids ) ) {
-			break;
-		} else {
-			centroids = newCentroids;
-		}
+		return ArrayAvg(workTimes);
 	}
 
-	// Identify which cluster is "work" (the one with the higher average)
-	workClusterIndex = (ArrayAvg(clusters[1]) > ArrayAvg(clusters[2])) ? 1 : 2;
-	workTimes = clusters[workClusterIndex];
+	private numeric function _getRandomOffset( required string taskKey ) {
+		var taskOffsets = _getTaskOffsets();
+		if ( !StructKeyExists( taskOffsets, arguments.taskKey ) ) {
+			taskOffsets[ arguments.taskKey ] = RandRange( 0, 59 );
 
-	return ArrayAvg(workTimes);
-}
+			_setTaskOffsets( taskOffsets );
+		}
 
+		return taskOffsets[ arguments.taskKey ];
+	}
 
 // GETTERS AND SETTERS
 	private struct function _getConfiguredTasks() {
@@ -999,8 +1008,11 @@ private numeric function _getAverageWorkTimeFromClusteredTimes( required array r
 	    _cronUtil = arguments.cronUtil;
 	}
 
-	private numeric function _getRandomOffset() {
-		return RandRange( 0, 59 );
+	private struct function _getTaskOffsets() {
+		return _taskOffsets;
+	}
+	private void function _setTaskOffsets( required struct taskOffsets ) {
+		_taskOffsets = arguments.taskOffsets;
 	}
 
 }

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -24,17 +24,17 @@ component displayName="Task Manager Service" {
 	 *
 	 */
 	public any function init(
-		  required any     configWrapper
-		, required any     controller
-		, required any     taskDao
-		, required any     taskHistoryDao
-		, required any     systemConfigurationService
-		, required any     logger
-		, required any     errorLogService
-		, required any     siteService
-		, required any     threadUtil
-		, required any     executor
-		, required any     cronUtil
+		  required any configWrapper
+		, required any controller
+		, required any taskDao
+		, required any taskHistoryDao
+		, required any systemConfigurationService
+		, required any logger
+		, required any errorLogService
+		, required any siteService
+		, required any threadUtil
+		, required any executor
+		, required any cronUtil
 	) {
 		_setConfiguredTasks( arguments.configWrapper.getConfiguredTasks() );
 		_setController( arguments.controller );

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -24,17 +24,17 @@ component displayName="Task Manager Service" {
 	 *
 	 */
 	public any function init(
-		  required any configWrapper
-		, required any controller
-		, required any taskDao
-		, required any taskHistoryDao
-		, required any systemConfigurationService
-		, required any logger
-		, required any errorLogService
-		, required any siteService
-		, required any threadUtil
-		, required any executor
-		, required any cronUtil
+		  required any     configWrapper
+		, required any     controller
+		, required any     taskDao
+		, required any     taskHistoryDao
+		, required any     systemConfigurationService
+		, required any     logger
+		, required any     errorLogService
+		, required any     siteService
+		, required any     threadUtil
+		, required any     executor
+		, required any     cronUtil
 	) {
 		_setConfiguredTasks( arguments.configWrapper.getConfiguredTasks() );
 		_setController( arguments.controller );
@@ -562,8 +562,13 @@ component displayName="Task Manager Service" {
 
 		var taskConfig = getTaskConfiguration( arguments.taskKey );
 		var schedule   = Len( Trim( taskConfig.crontab_definition ?: "" ) ) ? taskConfig.crontab_definition : task.schedule;
+		var runDate    = _getCronUtil().getNextRunDate( schedule, arguments.lastRun );
 
-		return _getCronUtil().getNextRunDate( schedule, arguments.lastRun );
+		if ( $isFeatureEnabled( "taskmanagerUseRandomOffset" ) ) {
+			runDate = DateAdd( "s", _getRandomOffset(), runDate );
+		}
+
+		return runDate;
 	}
 
 	public array function getAllTaskDetails( string locale="EN" ) {
@@ -992,6 +997,10 @@ private numeric function _getAverageWorkTimeFromClusteredTimes( required array r
 	}
 	private void function _setCronUtil( required any cronUtil ) {
 	    _cronUtil = arguments.cronUtil;
+	}
+
+	private numeric function _getRandomOffset() {
+		return RandRange( 0, 59 );
 	}
 
 }

--- a/tests/unit/api/taskmanager/TaskManagerServiceTest.cfc
+++ b/tests/unit/api/taskmanager/TaskManagerServiceTest.cfc
@@ -300,7 +300,7 @@ component extends="testbox.system.BaseSpec" {
 		} );
 
 		describe( "getNextRunDate()", function(){
-			it( "should take a cron expression and last run date and run that through our java cron library", function(){
+			it( "should take a cron expression and last run date and run that through our java cron library, adding offset if enabled", function(){
 				var tm             = _getTaskManagerService();
 				var lastRun        = "2014-10-24T09:03:13";
 				var taskKey        = "someKey";
@@ -309,6 +309,22 @@ component extends="testbox.system.BaseSpec" {
 
 				tm.$( "getTask" ).$args( taskKey ).$results( task );
 				tm.$( "getTaskConfiguration" ).$args( taskKey ).$results( config );
+
+				var nextRun = tm.getNextRunDate( taskKey, lastRun );
+
+				expect( nextRun ).toBe( "2014-10-24T09:05:#NumberFormat( mockTaskRunOffsetSeconds, '00' )#" );
+			} );
+
+			it( "should not add an offset if the feature is disabled", function(){
+				var tm             = _getTaskManagerService();
+				var lastRun        = "2014-10-24T09:03:13";
+				var taskKey        = "someKey";
+				var task           = { schedule = "* */5 * * * *", isScheduled=true };
+				var config         = { crontab_definition = "", timeout=100 };
+
+				tm.$( "getTask" ).$args( taskKey ).$results( task );
+				tm.$( "getTaskConfiguration" ).$args( taskKey ).$results( config );
+				tm.$( "$isFeatureEnabled" ).$args( "taskmanagerUseRandomOffset" ).$results( false );
 
 				var nextRun = tm.getNextRunDate( taskKey, lastRun );
 
@@ -342,7 +358,7 @@ component extends="testbox.system.BaseSpec" {
 
 				var nextRun = tm.getNextRunDate( taskKey, lastRun );
 
-				expect( nextRun ).toBe( "2014-10-24T09:10:00" );
+				expect( nextRun ).toBe( "2014-10-24T09:10:#NumberFormat( mockTaskRunOffsetSeconds, '00' )#" );
 			} );
 
 			it( "should return an empty string when task is not a scheduled task", function(){
@@ -620,18 +636,19 @@ component extends="testbox.system.BaseSpec" {
 	private any function _getTaskManagerService( struct dummyConfig={} ) {
 		var mockBox = getMockBox();
 
-		mockColdbox          = mockbox.createStub();
-		mockRc               = mockbox.createStub();
-		mockTaskDao          = mockbox.createStub();
-		mockTaskHistoryDao   = mockbox.createStub();
-		configWrapper        = mockbox.createStub();
-		mockSysConfigService = mockbox.createStub();
-		mockErrorLogService  = mockbox.createStub();
-		mockSiteService      = mockbox.createStub();
-		mockThreadUtil       = mockbox.createStub();
-		mockExecutor         = mockbox.createStub();
-		cronUtil             = new preside.system.services.taskmanager.CronUtil();
-		mockLogger           = _getMockLogger();
+		mockColdbox              = mockbox.createStub();
+		mockRc                   = mockbox.createStub();
+		mockTaskDao              = mockbox.createStub();
+		mockTaskHistoryDao       = mockbox.createStub();
+		configWrapper            = mockbox.createStub();
+		mockSysConfigService     = mockbox.createStub();
+		mockErrorLogService      = mockbox.createStub();
+		mockSiteService          = mockbox.createStub();
+		mockThreadUtil           = mockbox.createStub();
+		mockExecutor             = mockbox.createStub();
+		mockTaskRunOffsetSeconds = RandRange( 1, 59 );
+		cronUtil                 = new preside.system.services.taskmanager.CronUtil();
+		mockLogger               = _getMockLogger();
 
 		configWrapper.$( "getConfiguredTasks", arguments.dummyConfig );
 		mockSysConfigService.$( "getSetting" ).$args( "taskmanager", "scheduledtasks_enabled", false ).$results( true );
@@ -648,6 +665,8 @@ component extends="testbox.system.BaseSpec" {
 		tm.$( "$getErrorLogService", mockErrorLogService );
 		tm.$( "$isFeatureEnabled" ).$args( "sslInternalHttpCalls" ).$results( true );
 		tm.$( "$isFeatureEnabled" ).$args( "sites" ).$results( true );
+		tm.$( "$isFeatureEnabled" ).$args( "taskmanagerUseRandomOffset" ).$results( true );
+		tm.$( "_getRandomOffset", mockTaskRunOffsetSeconds );
 		tm.$( "_setActiveSite" );
 		mockRc.$( "setUseQueryCache" );
 		mockRc.$( "isBackgroundThread", false );


### PR DESCRIPTION
* Only when feature enabled, either env var: `TASKMANAGER_USE_RANDOM_OFFSET=true` or `settings.features.taskmanagerUseRandomOffset.enabled=true` explicitly
* in order to not always kick off tasks at the exact same time (problem magnified when lots of preside apps connected to the same database)
