### PR TITLE
PRESIDECMS-3140 Formbuilder tweak layout validation and data

### DIFF
--- a/system/handlers/formbuilder/item-types/FileUpload.cfc
+++ b/system/handlers/formbuilder/item-types/FileUpload.cfc
@@ -7,13 +7,14 @@ component {
 	property name="storageProviderService"     inject="storageProviderService";
 
 	private any function renderResponse( event, rc, prc, args={} ) {
-		var fileName = Trim( ReReplace( args.response ?: "", "^""(.*?)""$", "\1" ) );
+		var filePath = Trim( ReReplace( args.response ?: "", "^""(.*?)""$", "\1" ) );
+		var fileName = ListLast( filePath, "/" );
 
-		if ( !isEmptyString( fileName ) && fileName != "{}" ) {
+		if ( !isEmptyString( filePath ) && filePath != "{}" ) {
 			if ( args.buildLink ?: true ) {
 				var downloadLink = event.buildLink(
 					  fileStorageProvider = 'formBuilderStorageProvider'
-					, fileStoragePath     = fileName
+					, fileStoragePath     = filePath
 					, fileStoragePrivate  = formBuilderStorageProvider.objectExists( path=args.response ?: "", private=true )
 				);
 
@@ -25,7 +26,6 @@ component {
 
 		return translateResource( "formbuilder.item-types.fileupload:render.empty.response" );
 	}
-
 
 	private array function renderResponseForExport( event, rc, prc, args={} ) {
 		var fileName = Listlast( args.response ?: "", '/\' );
@@ -92,7 +92,7 @@ component {
 		var fieldData  = args.requestData[ fieldName ] ?: "";
 		var fieldValue = rc[ fieldName ]               ?: "";
 
-		if ( IsEmptyString( fieldValue ) && IsStruct( fieldData ) ) {
+		if ( ( IsSimpleValue( fieldValue ) && IsEmptyString( fieldValue ) ) && IsStruct( fieldData ) ) {
 			return fieldData;
 		}
 
@@ -110,7 +110,7 @@ component {
 		var response = args.response ?: "";
 
 		if ( FileExists( response.path ?: "" ) ) {
-			var savedPath = "/#( args.formId ?: '' )#/#CreateUUId()#/#( Len( response.tempFileInfo.clientFile ?: '' ) ? urlEncode( response.tempFileInfo.clientFile ) : 'uploaded.file' )#";
+			var savedPath = "/#( args.formId ?: '' )#/#CreateUUID()#/#( Len( response.tempFileInfo.clientFile ?: '' ) ? urlEncode( response.tempFileInfo.clientFile ) : 'uploaded.file' )#";
 
 			if ( storageProviderService.providerSupportsFileSystem( formBuilderStorageProvider ) ) {
 				formBuilderStorageProvider.putObjectFromLocalPath(
@@ -129,7 +129,7 @@ component {
 			return savedPath;
 		}
 
-		return SerializeJson( response );
+		return IsEmpty( response ) ? "" :  SerializeJson( response );
 	}
 
 	private string function renderV2ResponsesForDb( event, rc, prc, args={} ) {

--- a/system/services/formbuilder/FormBuilderService.cfc
+++ b/system/services/formbuilder/FormBuilderService.cfc
@@ -712,7 +712,7 @@ component {
 		), "field_id" );
 
 		if ( ArrayLen( fileFields ) && !arguments.withFileUpload ) {
-			for( var field in dataToStore ) {
+			for ( var field in dataToStore ) {
 				if ( ArrayFind( fileFields, field ) ) {
 					StructDelete( dataToStore, field );
 				}
@@ -757,16 +757,16 @@ component {
 	 */
 	public string function renderForm(
 		  required string formId
-		,          string layout           = "default"
-		,          struct configuration    = {}
-		,          any    validationResult = ""
+		,          string layout            = "default"
+		,          struct configuration     = {}
+		,          any    validationResult  = ""
+		,          string coreLayoutViewlet = "formbuilder.core.formLayout"
 	) {
 		var formConfiguration = getForm( id=arguments.formId );
 		var formPageNumber    = arguments.configuration.formPageNumber ?: 0;
 		var items             = getFormItems( id=arguments.formId, pageNumber=formPageNumber );
 		var renderedItems     = CreateObject( "java", "java.lang.StringBuffer" );
 		var coreLayoutArgs    = Duplicate( arguments.configuration );
-		var coreLayoutViewlet = "formbuilder.core.formLayout";
 		var formLayoutArgs    = Duplicate( arguments.configuration );
 		var formLayoutViewlet = _getFormBuilderRenderingService().getFormLayoutViewlet( layout=arguments.layout );
 		var idPrefixForFields = _createIdPrefix( formId=arguments.formId );
@@ -809,7 +809,7 @@ component {
 		}
 
 		formLayoutArgs.renderedForm = $renderViewlet(
-			  event = coreLayoutViewlet
+			  event = arguments.coreLayoutViewlet
 			, args  = coreLayoutArgs
 		);
 
@@ -912,9 +912,9 @@ component {
 		var renderedPages = CreateObject( "java", "java.lang.StringBuffer" );
 
 		for ( var pageNumber=1; pageNumber<=formPageCount; pageNumber++ ) {
-			if ( evaluateConditionForPage( formId=arguments.formId, pageNumber=pageNumber ) ) {
+			if ( evaluateConditionForPage( formId=arguments.formId, pageNumber=pageNumber, payload=arguments.submission ) ) {
 				var renderedItems = CreateObject( "java", "java.lang.StringBuffer" );
-				var formItems = getFormItems( id=arguments.formId, pageNumber=pageNumber );
+				var formItems     = getFormItems( id=arguments.formId, pageNumber=pageNumber );
 
 				for ( var formItem in formItems ) {
 					var formItemResponse = _getFormItemResponsFromSubmission( formItem=formItem, submission=arguments.submission );
@@ -1058,7 +1058,6 @@ component {
 		return render;
 	}
 
-
 	/**
 	 * Returns the submission success message saved
 	 * against the form for the given form ID
@@ -1172,16 +1171,19 @@ component {
 		,          string  ipAddress       = Trim( ListLast( cgi.remote_addr ?: "" ) )
 		,          string  userAgent       = ( cgi.http_user_agent ?: "" )
 		,          boolean validateCaptcha = true
+		,          boolean validateForm    = true
+		,          boolean recordAction    = true
 		,          array   formItems       = []
+		,          struct  data            = {}
 	) {
 		var submissionId      = "";
 		var formConfiguration = getForm( arguments.formId );
 		var formItems         = ArrayLen( arguments.formItems ) ? arguments.formItems : getFormItems( arguments.formId );
 		var formData          = getRequestDataForForm( arguments.formId, arguments.requestData );
-		var validationResult  = _getFormBuilderValidationService().validateFormSubmission(
+		var validationResult  = arguments.validateForm ? _getFormBuilderValidationService().validateFormSubmission(
 			  formItems      = formItems
 			, submissionData = formData
-		);
+		) : validationEngine.newValidationResult();
 
 		if ( arguments.validateCaptcha && $helpers.isTrue( formConfiguration.use_captcha ?: "" ) ) {
 			if ( !_getRecaptchaService().validate( arguments.requestData[ "g-recaptcha-response" ] ?: "" ) ){
@@ -1199,16 +1201,17 @@ component {
 		} );
 
 		if ( validationResult.validated() ) {
-			if ( isV2Form( arguments.formid ) ) {
+			if ( isV2Form( arguments.formId ) ) {
 				submissionId = $getPresideObject( "formbuilder_formsubmission" ).insertData( data={
-					  form          = arguments.formId
-					, submitted_by  = $getWebsiteLoggedInUserId()
-					, form_instance = arguments.instanceId
-					, form_site     = arguments.instanceSite
-					, form_url      = arguments.instanceUrl
-					, form_page     = arguments.instancePage
-					, ip_address    = arguments.ipAddress
-					, user_agent    = arguments.userAgent
+					  form           = arguments.formId
+					, submitted_by   = $getWebsiteLoggedInUserId()
+					, form_instance  = arguments.instanceId
+					, form_site      = arguments.instanceSite
+					, form_url       = arguments.instanceUrl
+					, form_page      = arguments.instancePage
+					, ip_address     = arguments.ipAddress
+					, user_agent     = arguments.userAgent
+					, submitted_data = IsEmpty( arguments.data ) ? NullValue() : SerializeJson( arguments.data )
 				} );
 
 				saveV2Responses( formId=arguments.formId, formData=formData, formItems=formItems, submissionId=submissionId );
@@ -1230,7 +1233,7 @@ component {
 			setFormBuilderSubmissionContextData( formId=arguments.formId, submissionId=submissionId, data=arguments.requestData );
 
 			var submission = getSubmission( submissionId );
-			for( var s in submission ) { submission = s; }
+			for ( var s in submission ) { submission = s; }
 
 			if ( isV2Form( formId=arguments.formId ) ) {
 				submission.submitted_data = SerializeJSON( getV2Responses( formId=arguments.formId, submissionId=submissionId ) );
@@ -1241,12 +1244,14 @@ component {
 				, submissionData = submission
 			);
 
-			$recordWebsiteUserAction(
-				  type       = "formbuilder"
-				, action     = "submitform"
-				, identifier = arguments.formId
-				, detail     = submission
-			);
+			if ( arguments.recordAction ) {
+				$recordWebsiteUserAction(
+					  type       = "formbuilder"
+					, action     = "submitform"
+					, identifier = arguments.formId
+					, detail     = submission
+				);
+			}
 
 			if ( $helpers.isTrue( formConfiguration.notification_enabled ?: false ) ) {
 				$createNotification(
@@ -1275,19 +1280,22 @@ component {
 	public any function saveTempSubmission(
 		  required string  formId
 		, required struct  requestData
-		,          array   formItems  = []
-		,          numeric pageNumber = 0
-		,          numeric pageNext   = 0
+		,          boolean validateForm = true
+		,          array   formItems    = []
+		,          numeric pageNumber   = 0
+		,          numeric pageNext     = 0
 	) {
 		var formConfiguration = getForm( arguments.formId );
 		var formData          = getRequestDataForForm( formId=arguments.formId, requestData=arguments.requestData, pageNumber=arguments.pageNumber );
 		var validationResult  = _getValidationEngine().newValidationResult();
 
 		if ( arguments.pageNext > 0 ) {
-			validationResult = _getFormBuilderValidationService().validateFormSubmission(
-				  formItems      = arguments.formItems
-				, submissionData = formData
-			);
+			if ( arguments.validateForm ) {
+				validationResult = _getFormBuilderValidationService().validateFormSubmission(
+					  formItems      = arguments.formItems
+					, submissionData = formData
+				);
+			}
 
 			if ( arguments.pageNumber == 1 && $helpers.isTrue( formConfiguration.use_captcha ?: "" ) ) {
 				if ( !_getRecaptchaService().validate( arguments.requestData[ "g-recaptcha-response" ] ?: "" ) ){
@@ -2735,7 +2743,7 @@ component {
 	}
 
 	private string function _createIdPrefix( required string formId ) {
-		return "formbuilder_" & LCase( Hash( Now() & arguments.formId ) );
+		return "formbuilder_" & LCase( Hash( Now() & arguments.formId ) ) & "_";
 	}
 
 	private struct function _getItemConfigurationForV2Question( required string questionId ) {

--- a/system/views/formbuilder/general/progressbar.cfm
+++ b/system/views/formbuilder/general/progressbar.cfm
@@ -2,7 +2,7 @@
 	formPageCount  = args.formPageCount  ?: 0;
 	formPageNumber = args.formPageNumber ?: 0;
 
-	progress = args.progress ?: Round( ( ( formPageNumber - 1 ) / formPageCount ) * 100 );
+	progress = args.progress ?: Ceiling( ( ( formPageNumber - 1 ) / formPageCount ) * 100 );
 </cfscript>
 
 <cfoutput>


### PR DESCRIPTION
To improve flexibility and control over formbuilder behaviour:

- Allow usage of different core layouts
- Enable toggling of validation when saving submissions
- Enable toggling of record action
- Support saving of additional data alongside submissions