### PR TITLE
PRESIDECMS-3166 serve as attachment not honoured

### DIFF
--- a/system/handlers/core/AssetDownload.cfc
+++ b/system/handlers/core/AssetDownload.cfc
@@ -114,16 +114,17 @@ component {
 					, asset          = asset
 				} );
 
+				if ( type.trackDownloads && isFeatureEnabled( "websiteUsers" ) ) {
+					websiteUserActionService.recordAction(
+						  action     = "download"
+						, type       = "asset"
+						, userId     = getLoggedInUserId()
+						, identifier = assetId
+					);
+				}
+
 				var filename = _getFilenameForAsset( Len( Trim( asset.file_name ) ) ? asset.file_name : asset.title, type.extension );
-				if ( type.trackDownloads ) {
-					if ( isFeatureEnabled( "websiteUsers" ) ) {
-						websiteUserActionService.recordAction(
-							  action     = "download"
-							, type       = "asset"
-							, userId     = getLoggedInUserId()
-							, identifier = assetId
-						);
-					}
+				if ( type.serveAsAttachment ) {
 					header name="Content-Disposition" value="attachment; filename=""#filename#""";
 				} else {
 					header name="Content-Disposition" value="inline; filename=""#filename#""";


### PR DESCRIPTION
A hasty fix for one issue introduced another. Using a single condition to mean two different things.

This change separates out the concerns of whether or not to track a download and how to serve the download.