### PR TITLE
PRESIDECMS-3174 quick edit resets checkbox options for multi line text input formbuilder questions

### DIFF
--- a/system/assets/js/admin/specific/datamanager/quickEditForm/quickEditFormHandler.js
+++ b/system/assets/js/admin/specific/datamanager/quickEditForm/quickEditFormHandler.js
@@ -12,17 +12,31 @@
 		submitForm();
 	};
 
-	submitForm = function(){
-		if ( $quickEditForm.valid() ) {
-			$.ajax({
-				  type    : "POST"
-				, url     : $quickEditForm.attr( 'action' )
-				, data    : $quickEditForm.serializeObject()
-				, success : ajaxSuccessHandler
-				, error   : ajaxErrorHandler
-			});
-		}
-	};
+    submitForm = function(){
+        if ( $quickEditForm.valid() ) {
+            var pairs = $quickEditForm.serializeArray();
+            var data  = {};
+
+            for ( var i=0; i<pairs.length; i++ ) {
+                var name  = pairs[i].name;
+                var value = pairs[i].value;
+
+                if ( data.hasOwnProperty( name ) ) {
+                    data[ name ] = data[ name ] + "," + value;
+                } else {
+                    data[ name ] = value;
+                }
+            }
+
+            $.ajax({
+                  type    : "POST"
+                , url     : $quickEditForm.attr( 'action' )
+                , data    : data
+                , success : ajaxSuccessHandler
+                , error   : ajaxErrorHandler
+            });
+        }
+    };
 
 	ajaxSuccessHandler = function( data ){
 		if ( typeof data === "object" ) {

--- a/system/views/admin/datamanager/quickEditForm.cfm
+++ b/system/views/admin/datamanager/quickEditForm.cfm
@@ -20,10 +20,11 @@
 
 <cfoutput>
 	<form id="#formId#" data-auto-focus-form="true" data-dirty-form="protect" class="form-horizontal quick-edit-form" method="post" action="#args.editRecordAction#">
-		<input name="id" type="hidden" value="#( rc.id ?: '' )#" />
+		<input name="id"        type="hidden" value="#( rc.id ?: '' )#" />
+		<input name="item_type" type="hidden" value="#( args.record.item_type ?: '' )#" />
 
 		#args.preForm#
-		
+
 		#renderForm(
 			  formName                = args.formName
 			, context                 = "admin"
@@ -34,8 +35,8 @@
 			, permissionContext       = args.permissionContext
 			, permissionContextKeys   = args.permissionContextKeys
 		)#
-		
+
 		#args.postForm#
-		
+
 	</form>
 </cfoutput>


### PR DESCRIPTION
Fix: resolve formbuilder question quick edit checkbox persistence

- Add item_type hidden field to quick edit form for config rebuilding
- Fix multi-checkbox serialization to create comma-delimited lists
- Ensures wysiwyg toolbar options persist in multi-line text questions