### PR TITLE
PRESIDECMS-3176 null filtering with similar columns

### DIFF
--- a/system/services/database/SqlRunner.cfc
+++ b/system/services/database/SqlRunner.cfc
@@ -101,7 +101,7 @@ component singleton=true {
 
 		do {
 			try {
-				result = QueryExecute(
+				result = _queryExecute(
 					  sql     = arguments.sql
 					, params  = params
 					, options = options
@@ -153,8 +153,8 @@ component singleton=true {
 		var preClause  = arguments.sql.reReplaceNoCase( "^(.*?\swhere)\s.*$", "\1" );
 		var postClause = arguments.sql.reReplaceNoCase( "^.*?\swhere\s", " " );
 
-		postClause = postClause.reReplaceNoCase("\s!= :#arguments.paramName#", " is not null", "all" );
-		postClause = postClause.reReplaceNoCase("\s= :#arguments.paramName#", " is null", "all" );
+		postClause = postClause.reReplaceNoCase("\s!= :#arguments.paramName#\b", " is not null", "all" );
+		postClause = postClause.reReplaceNoCase("\s= :#arguments.paramName#\b", " is null", "all" );
 
 		return preClause & postClause
 	}
@@ -179,6 +179,11 @@ component singleton=true {
 			return _getDefaultBgQueryTimeout();
 		}
 		return _getDefaultQueryTimeout();
+	}
+
+	// here to help mocking with tests
+	private any function _queryExecute( sql, params, options ) {
+		return QueryExecute( sql=arguments.sql, params=arguments.params, options=arguments.options );
 	}
 
 // GETTERS AND SETTERS

--- a/system/services/database/SqlRunner.cfc
+++ b/system/services/database/SqlRunner.cfc
@@ -45,7 +45,6 @@ component singleton=true {
 		_getLogger().debug( arguments.sql );
 
 		if ( arguments.returntype == "info" ) {
-			var info = "";
 			options.result = "info";
 		} else if ( arguments.returntype == "array" ) {
 			options.returntype = "array";
@@ -102,9 +101,10 @@ component singleton=true {
 		do {
 			try {
 				result = _queryExecute(
-					  sql     = arguments.sql
-					, params  = params
-					, options = options
+					  sql        = arguments.sql
+					, params     = params
+					, options    = options
+					, returnType = arguments.returntype
 				);
 				break;
 			} catch( database e ) {
@@ -116,11 +116,7 @@ component singleton=true {
 			}
 		} while( ++connectionAttempts <= connectionRetries );
 
-		if ( arguments.returntype eq "info" ) {
-			return info;
-		} else {
-			return result;
-		}
+		return result;
 	}
 
 	public string function obfuscateSqlForPreside( required string sql ) {
@@ -182,8 +178,11 @@ component singleton=true {
 	}
 
 	// here to help mocking with tests
-	private any function _queryExecute( sql, params, options ) {
-		return QueryExecute( sql=arguments.sql, params=arguments.params, options=arguments.options );
+	private any function _queryExecute( sql, params, options, returntype ) {
+		var info   = "";
+		var result = QueryExecute( sql=arguments.sql, params=arguments.params, options=arguments.options );
+
+		return arguments.returntype == "info" ? info : result;
 	}
 
 // GETTERS AND SETTERS

--- a/tests/unit/api/database/SqlRunnerTest.cfc
+++ b/tests/unit/api/database/SqlRunnerTest.cfc
@@ -155,6 +155,26 @@
 		</cfscript>
 	</cffunction>
 
+	<cffunction name="test07_runSql_should_turn_empty_string_filters_to_null_filters" access="public" returntype="any" output="false">
+		<cfscript>
+			var logger = new tests.resources.HelperObjects.TestLogger( logLevel = "INFORMATION" );
+			var runner = _getRunner( logger=logger );
+
+
+			runner.$( "_queryExecute", QueryNew( "id" ) );
+
+			var result = runner.runSql( dsn=application.dsn, sql="select id from test where some_value = :some_value and some_value_other = :some_value_other and another != :another", params=[
+				{ name="some_value", value="", type="cf_sql_varchar" },
+				{ name="some_value_other", value="test", type="cf_sql_varchar" },
+				{ name="another", value="", type="cf_sql_varchar" },
+			] );
+
+			var callLog = runner.$callLog()._queryExecute;
+
+			super.assertEquals( 1, ArrayLen( callLog ) );
+			super.assertEquals( "select id from test where some_value is null and some_value_other = :some_value_other and another is not null", callLog[1].sql );
+		</cfscript>
+	</cffunction>
 
 
 <!--- private --->
@@ -163,11 +183,11 @@
 		<cfargument name="defaultTimeout" type="numeric" required="false" default="0" />
 
 		<cfscript>
-			return new preside.system.services.database.SqlRunner(
+			return CreateMock( object=new preside.system.services.database.SqlRunner(
 				  logger                = arguments.logger
 				, defaultQueryTimeout   = arguments.defaultTimeout
 				, defaultBgQueryTimeout = arguments.defaultTimeout
-			);
+			) );
 		</cfscript>
 	</cffunction>
 


### PR DESCRIPTION
Fix + tests for an issue where null filtering breaks with similar column names. i.e. this breaks:

```cfc
selectData( filter={ myfield="", myfield_type="something" } );
```

Giving query output like `myfield is null and myfield is null_type = :myfield`. Simple fix but some refactoring to help with setting up tests for this.

