### PR TITLE
PRESIDECMS-3185 Flow diagram SVG fails to render

### DIFF
--- a/system/handlers/admin/DatamanagerWorkflow.cfc
+++ b/system/handlers/admin/DatamanagerWorkflow.cfc
@@ -81,11 +81,17 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	public void function flowDiagram( event, rc, prc ) {
-		content reset=true type="image/svg+xml";
-		echo( datamanagerWorkflowService.renderFlowDiagram(
+		var svg = datamanagerWorkflowService.renderFlowDiagram(
 			  objectName = rc.objectName ?: ""
 			, recordId   = rc.recordId   ?: ""
-		) );
+		);
+
+		svg = REReplace( svg, "^\uFEFF"                 , "", "one" );
+		svg = REReplace( svg, "^\s+"                    , "", "one" );
+		svg = REReplace( svg, "(?s)(?!\A)<\?xml[^>]*\?>", "", "all" );
+
+		content reset=true type="image/svg+xml";
+		echo( svg );
 		abort;
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sanitizes the flow diagram SVG response by stripping BOM, leading whitespace, and XML declaration before returning it.
> 
> - **Admin handler (`system/handlers/admin/DatamanagerWorkflow.cfc`)**:
>   - Updates `flowDiagram` to post-process SVG from `datamanagerWorkflowService.renderFlowDiagram(...)`:
>     - Strip BOM (`\uFEFF`), leading whitespace, and any XML declaration via `REReplace`.
>     - Then set `content type="image/svg+xml"` and echo the cleaned SVG.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeed1c9c0cba0dc8c9ef6e2c09c2240e492c3f95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->