### PR TITLE
PRESIDECMS-3190 Formbuilder rule expression fails to evaluate when multiple options are checked

### DIFF
--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -97,11 +97,11 @@ component {
 
 				switch ( ruleOperator ) {
 					case "anyof"    :
-						ruleResult = ArrayContainsNoCase( ruleValues, formFieldValue );
+						ruleResult = _arrayContainsAnyNoCase( ruleValues, formFieldValues );
 						break;
 
 					case "notanyof" :
-						ruleResult = !ArrayContainsNoCase( ruleValues, formFieldValue );
+						ruleResult = !_arrayContainsAnyNoCase( ruleValues, formFieldValues );
 						break;
 
 					case "allof"    :
@@ -124,25 +124,21 @@ component {
 			case "string"  :
 			default        :
 				if ( formItem.item_type == "date" ) {
-					if ( IsDate( formFieldValue ) ) {
-						var dateTimeValue  = ParseDateTime( formFieldValue );
-						var dateRangeValue = rulesEngineTimePeriodService.convertTimePeriodToDateRange( arguments.formbuilderAnswer );
+					var dateTimeValue  = ParseDateTime( formFieldValue );
+					var dateRangeValue = rulesEngineTimePeriodService.convertTimePeriodToDateRange( arguments.formbuilderAnswer );
 
-						ruleResult = true;
+					ruleResult = true;
 
-						if ( IsDate( dateRangeValue.from ?: "" ) ) {
-							if ( DateCompare( dateTimeValue, dateRangeValue.from ) == -1 ) {
-								ruleResult = false;
-							}
+					if ( IsDate( dateRangeValue.from ?: "" ) ) {
+						if ( DateCompare( dateTimeValue, dateRangeValue.from ) == -1 ) {
+							ruleResult = false;
 						}
+					}
 
-						if ( IsDate( dateRangeValue.to ?: "" ) ) {
-							if ( DateCompare( dateTimeValue, dateRangeValue.to ) == 1 ) {
-								ruleResult = false;
-							}
+					if ( IsDate( dateRangeValue.to ?: "" ) ) {
+						if ( DateCompare( dateTimeValue, dateRangeValue.to ) == 1 ) {
+							ruleResult = false;
 						}
-					} else {
-						ruleResult = false;
 					}
 				} else {
 					ruleResult = rulesEngineOperatorService.compareStrings(
@@ -171,6 +167,16 @@ component {
 		}
 
 		return {};
+	}
+
+	private boolean function _arrayContainsAnyNoCase( required array ruleValues, required array formFieldValues ) {
+		for ( var ruleValue in arguments.ruleValues ) {
+			if ( ArrayContainsNoCase( arguments.formFieldValues, ruleValue ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean function _arrayContainsAllNoCase( required array ruleValues, required array formFieldValues ) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes array anyof/notanyof to handle multiple selections and simplifies date-range comparisons in `FormbuilderFormPageAnswerMatches.cfc`.
> 
> - **Formbuilder rule evaluation (`system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc`)**:
>   - **Array operators**:
>     - `anyof`/`notanyof` now check against all selected values using `_arrayContainsAnyNoCase( ruleValues, formFieldValues )` instead of a single value.
>     - Adds private helper `_arrayContainsAnyNoCase()`; reuses existing `_arrayContainsAllNoCase()`.
>   - **Date comparisons**:
>     - Parses `formFieldValue` and compares within computed `from`/`to` range without an outer `IsDate` guard; defaults `ruleResult` true, then invalidates if out of range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28fb3841bb736de57ecaff00e1d56898dc6823db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->