### PR TITLE
PRESIDECMS-3197 rich editor content in quick edit not saved

### DIFF
--- a/system/assets/Gruntfile.js
+++ b/system/assets/Gruntfile.js
@@ -81,7 +81,7 @@ module.exports = function( grunt ) {
 					  	"js/admin/lib/plugins/jquery.moment.js", // must come first
 					  	"js/admin/lib/plugins/*.js"
 					  ]
-					, dest : "js/admin/lib/plugins-1.8.000.min.js"
+					, dest : "js/admin/lib/plugins-1.8.001.min.js"
 				},{
 					  src  : ["js/admin/lib/ace/ace.js", "js/admin/lib/ace/ace-elements.js"]
 					, dest : "js/admin/lib/ace-1.0.0.min.js"

--- a/system/assets/js/admin/lib/plugins/jquery.serialize-object.js
+++ b/system/assets/js/admin/lib/plugins/jquery.serialize-object.js
@@ -94,6 +94,10 @@
     function addPair(pair) {
       if (!patterns.validate.test(pair.name)) return this;
       var obj = makeObject(pair.name, encode(pair));
+
+      if ( $('[name="' + pair.name + '"]', $form).attr("type") == "checkbox" && data.hasOwnProperty( pair.name ) ) {
+        obj[ pair.name ] = data[ pair.name ] + ',' + obj[ pair.name ];
+      }
       data = helper.extend(true, data, obj);
       return this;
     }

--- a/system/assets/js/admin/lib/plugins/jquery.serialize-object.js
+++ b/system/assets/js/admin/lib/plugins/jquery.serialize-object.js
@@ -3,33 +3,41 @@
  * @copyright 2014, macek <paulmacek@gmail.com>
  * @link https://github.com/macek/jquery-serialize-object
  * @license BSD
- * @version 2.2.0
+ * @version 2.5.0
  *
- * Slightly modified for use in Preside, May 2014. Using safe presideJQuery global namespace instead of jQuery + detecting CKEditor textareas
+ * Slightly modified for use in Preside, May 2014 (added to 2.5.0 Nov 2025). Using safe presideJQuery global namespace instead of jQuery + detecting CKEditor textareas
  */
 (function(root, factory) {
 
   // AMD
   if (typeof define === "function" && define.amd) {
-    define(["presideJQuery", "exports"], function($, exports) {
-      factory(root, exports, $);
+    define(["exports", "presideJQuery"], function(exports, $) {
+      return factory(exports, $);
     });
   }
 
   // CommonJS
   else if (typeof exports !== "undefined") {
     var $ = require("presideJQuery");
-    factory(root, exports, $);
+    factory(exports, $);
   }
 
   // Browser
   else {
-    root.FormSerializer = factory(root, {}, (root.presideJQuery || root.Zepto || root.ender || root.$));
+    factory(root, (root.presideJQuery || root.Zepto || root.ender || root.$));
   }
 
-}(this, function(root, exports, $) {
+}(this, function(exports, $) {
 
-  var FormSerializer = exports.FormSerializer = function FormSerializer(helper) {
+  var patterns = {
+    validate: /^[a-z_][a-z0-9_]*(?:\[(?:\d*|[a-z0-9_]+)\])*$/i,
+    key:      /[a-z0-9_]+|(?=\[\])/gi,
+    push:     /^$/,
+    fixed:    /^\d+$/,
+    named:    /^[a-z0-9_]+$/i
+  };
+
+  function FormSerializer(helper, $form) {
 
     // private variables
     var data     = {},
@@ -43,23 +51,23 @@
 
     function makeObject(root, value) {
 
-      var keys = root.match(FormSerializer.patterns.key), k;
+      var keys = root.match(patterns.key), k;
 
       // nest, nest, ..., nest
       while ((k = keys.pop()) !== undefined) {
         // foo[]
-        if (FormSerializer.patterns.push.test(k)) {
+        if (patterns.push.test(k)) {
           var idx = incrementPush(root.replace(/\[\]$/, ''));
           value = build([], idx, value);
         }
 
         // foo[n]
-        else if (FormSerializer.patterns.fixed.test(k)) {
+        else if (patterns.fixed.test(k)) {
           value = build([], k, value);
         }
 
         // foo; foo[bar]
-        else if (FormSerializer.patterns.named.test(k)) {
+        else if (patterns.named.test(k)) {
           value = build({}, k, value);
         }
       }
@@ -74,9 +82,18 @@
       return pushes[key]++;
     }
 
+    function encode(pair) {
+      switch ($('[name="' + pair.name + '"]', $form).attr("type")) {
+        case "checkbox":
+          return pair.value === "on" ? true : pair.value;
+        default:
+          return pair.value;
+      }
+    }
+
     function addPair(pair) {
-      if (!FormSerializer.patterns.validate.test(pair.name)) return this;
-      var obj = makeObject(pair.name, pair.value);
+      if (!patterns.validate.test(pair.name)) return this;
+      var obj = makeObject(pair.name, encode(pair));
       data = helper.extend(true, data, obj);
       return this;
     }
@@ -119,31 +136,19 @@
     this.serialize = serialize;
     this.serializeJSON = serializeJSON;
     this.addCKEditorFields = addCKEditorFields;
-  };
+  }
 
-  FormSerializer.patterns = {
-    validate: /^[a-z][a-z0-9_]*(?:\[(?:\d*|[a-z0-9_]+)\])*$/i,
-    key:      /[a-z0-9_]+|(?=\[\])/gi,
-    push:     /^$/,
-    fixed:    /^\d+$/,
-    named:    /^[a-z0-9_]+$/i
-  };
+  FormSerializer.patterns = patterns;
 
   FormSerializer.serializeObject = function serializeObject() {
-    if (this.length > 1) {
-      return new Error("jquery-serialize-object can only serialize one form at a time");
-    }
-    return new FormSerializer($).
+    return new FormSerializer($, this).
       addPairs(this.serializeArray()).
       addCKEditorFields(this).
       serialize();
   };
 
   FormSerializer.serializeJSON = function serializeJSON() {
-    if (this.length > 1) {
-      return new Error("jquery-serialize-object can only serialize one form at a time");
-    }
-    return new FormSerializer($).
+    return new FormSerializer($, this).
       addPairs(this.serializeArray()).
       addCKEditorFields(this).
       serializeJSON();
@@ -153,6 +158,8 @@
     $.fn.serializeObject = FormSerializer.serializeObject;
     $.fn.serializeJSON   = FormSerializer.serializeJSON;
   }
+
+  exports.FormSerializer = FormSerializer;
 
   return FormSerializer;
 }));

--- a/system/assets/js/admin/specific/datamanager/quickEditForm/quickEditFormHandler.js
+++ b/system/assets/js/admin/specific/datamanager/quickEditForm/quickEditFormHandler.js
@@ -12,31 +12,17 @@
 		submitForm();
 	};
 
-    submitForm = function(){
-        if ( $quickEditForm.valid() ) {
-            var pairs = $quickEditForm.serializeArray();
-            var data  = {};
-
-            for ( var i=0; i<pairs.length; i++ ) {
-                var name  = pairs[i].name;
-                var value = pairs[i].value;
-
-                if ( data.hasOwnProperty( name ) ) {
-                    data[ name ] = data[ name ] + "," + value;
-                } else {
-                    data[ name ] = value;
-                }
-            }
-
-            $.ajax({
-                  type    : "POST"
-                , url     : $quickEditForm.attr( 'action' )
-                , data    : data
-                , success : ajaxSuccessHandler
-                , error   : ajaxErrorHandler
-            });
-        }
-    };
+	submitForm = function(){
+		if ( $quickEditForm.valid() ) {
+			$.ajax({
+				  type    : "POST"
+				, url     : $quickEditForm.attr( 'action' )
+				, data    : $quickEditForm.serializeObject()
+				, success : ajaxSuccessHandler
+				, error   : ajaxErrorHandler
+			});
+		}
+	};
 
 	ajaxSuccessHandler = function( data ){
 		if ( typeof data === "object" ) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch quick edit submission to serializeObject() and upgrade jquery.serialize-object to v2.5.0; bump plugins bundle filename.
> 
> - **Frontend**
>   - **Quick Edit Form**: Replace manual form data assembly with `$quickEditForm.serializeObject()` in `js/admin/specific/datamanager/quickEditForm/quickEditFormHandler.js`.
>   - **Form Serialization Plugin**: Upgrade `jquery.serialize-object` to `v2.5.0` in `js/admin/lib/plugins/jquery.serialize-object.js` with updated module wrapper, consolidated `patterns`, per-field encoding (checkbox handling), CKEditor field inclusion, and explicit export of `FormSerializer`; update `serializeObject/serializeJSON` to pass the form instance.
> - **Build**
>   - Bump plugins bundle output to `js/admin/lib/plugins-1.8.001.min.js` in `Gruntfile.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5a959c1a0f5d0f8d41a954530ef20b11ea8d97d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->