### PR TITLE
Feature presidecms 3175 global date time formatting helpers

### DIFF
--- a/system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js
+++ b/system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js
@@ -12,15 +12,20 @@
 			countryCode = localeParts[0].toUpperCase();
 		}
 
-		var key = 'enum.isoCountries:' + countryCode + '.region';
-
-		var region = cfrequest.isoCountries[key];
+		var key                   = 'enum.isoCountries:' + countryCode + '.region';
+		var region                = cfrequest.isoCountries[key];
 		var defaultLocaleSettings = cfrequest.defaultLocaleSettings[region];
+
 		if( typeof defaultLocaleSettings != 'undefined' ) {
 			$('#short_date_format').data("uberSelect").select(defaultLocaleSettings.short_date_format);
 			$('#long_date_format').data("uberSelect").select(defaultLocaleSettings.long_date_format);
 			$("input[name=time_format]").prop("checked", false);
 			$("input[name=time_format][value='" + defaultLocaleSettings.time_format + "']").prop('checked', true);
+		} else {
+			$('#short_date_format').data("uberSelect").select(cfrequest.defaultLocaleSettings.uk.short_date_format);
+			$('#long_date_format').data("uberSelect").select(cfrequest.defaultLocaleSettings.uk.long_date_format);
+			$("input[name=time_format]").prop("checked", false);
+			$("input[name=time_format][value='" + cfrequest.defaultLocaleSettings.uk.time_format + "']").prop('checked', true);
 		}
 	});
 } )( presideJQuery );

--- a/system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js
+++ b/system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js
@@ -19,6 +19,8 @@
 		if( typeof defaultLocaleSettings != 'undefined' ) {
 			$('#short_date_format').data("uberSelect").select(defaultLocaleSettings.short_date_format);
 			$('#long_date_format').data("uberSelect").select(defaultLocaleSettings.long_date_format);
+			$("input[name=time_format]").prop("checked", false);
+			$("input[name=time_format][value='" + defaultLocaleSettings.time_format + "']").prop('checked', true);
 		}
 	});
-} )( jQuery || presideJQuery );
+} )( presideJQuery );

--- a/system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js
+++ b/system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js
@@ -1,0 +1,24 @@
+( function( $ ) {
+	$( '.site-locale-picker' ).on( 'change', function(e) {
+		var selectedLocale = $(this).val();
+		var localeParts = selectedLocale.split('_');
+
+		var countryCode = "";
+
+		if( localeParts.length === 2 ) {
+			countryCode = localeParts[1].toUpperCase();
+		}
+		else if ( localeParts.length === 1 ) {
+			countryCode = localeParts[0].toUpperCase();
+		}
+
+		var key = 'enum.isoCountries:' + countryCode + '.region';
+
+		var region = cfrequest.isoCountries[key];
+		var defaultLocaleSettings = cfrequest.defaultLocaleSettings[region];
+		if( typeof defaultLocaleSettings != 'undefined' ) {
+			$('#short_date_format').data("uberSelect").select(defaultLocaleSettings.short_date_format);
+			$('#long_date_format').data("uberSelect").select(defaultLocaleSettings.long_date_format);
+		}
+	});
+} )( jQuery || presideJQuery );

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -46,6 +46,7 @@ component {
 		__setupIgnoreFile();
 		__setupWebflow();
 		__loadConfigurationFromExtensions();
+		__setupLocaleSettings();
 	}
 
 // ENVIRONMENT SPECIFIC
@@ -1046,6 +1047,7 @@ component {
 		settings.enum.webflowSessionType          = [ "active", "activetimedout", "complete", "timedout", "adminarchive" ];
 		settings.enum.webflowPositionType         = [ "start", "middle", "end" ];
 		settings.enum.webflowProgressBarType      = [ "simpledot", "dotwithtext", "textbased" ];
+		settings.enum.timeFormatOptions                  = [ "12h", "24h" ];
 	}
 
 	private void function __setupFormValidationProviders() {
@@ -1240,6 +1242,29 @@ component {
 				CreateObject( cfcPath ).configure( config=variables );
 			}
 		}
+	}
+
+	private void function __setupLocaleSettings() {
+		settings.datetime.regionDefaults = {
+			  uk = {
+				  short_date_format = "dd/mm/yyyy"
+				, long_date_format = "DMY"
+			  }
+			, eu = {
+				  short_date_format = "dd.mm.yyyy"
+				, long_date_format = "DMY"
+			  }
+			, us = {
+				  short_date_format = "mm/dd/yyyy"
+				, long_date_format = "MDY"
+			  }
+
+		}
+
+		settings.datetime.formats = {
+			  short = ["dd/mm/yyyy","dd.mm.yyyy","mm/dd/yyyy","yyyy-mm-dd"]
+			, long = ["DMY","MDY"]
+		};
 	}
 
 

--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -1248,22 +1248,24 @@ component {
 		settings.datetime.regionDefaults = {
 			  uk = {
 				  short_date_format = "dd/mm/yyyy"
-				, long_date_format = "DMY"
+				, long_date_format  = "DMY"
+				, time_format       = "12h"
 			  }
 			, eu = {
 				  short_date_format = "dd.mm.yyyy"
-				, long_date_format = "DMY"
+				, long_date_format  = "DMY"
+				, time_format       = "24h"
 			  }
 			, us = {
 				  short_date_format = "mm/dd/yyyy"
-				, long_date_format = "MDY"
+				, long_date_format  = "MDY"
+				, time_format       = "12h"
 			  }
-
-		}
+		};
 
 		settings.datetime.formats = {
 			  short = ["dd/mm/yyyy","dd.mm.yyyy","mm/dd/yyyy","yyyy-mm-dd"]
-			, long = ["DMY","MDY"]
+			, long  = ["DMY","MDY"]
 		};
 	}
 

--- a/system/forms/preside-objects/site/admin.add.xml
+++ b/system/forms/preside-objects/site/admin.add.xml
@@ -13,11 +13,16 @@ This form is used for the "add site" form in the site manager
 			<field binding="site.path"     sortorder="40" control="textinput" />
 			<field binding="site.template" sortorder="50" control="sitetemplatepicker"  />
 		</fieldset>
-		<fieldset id="localisation" sortorder="20">
+	</tab>
+	<tab id="localisation" sortorder="20" title="preside-objects.site:localisation.tab.title">
+		<fieldset id="localisation" sortorder="10">
 			<field binding="site.locale" sortorder="10" control="siteLocalePicker" />
+			<field binding="site.short_date_format" sortorder="20" control="siteDateFormatPicker" dateFormatType="short" />
+			<field binding="site.long_date_format"  sortorder="30" control="siteDateFormatPicker" dateFormatType="long" />
+			<field binding="site.time_format"       sortorder="40" control="enumRadioList" />
 		</fieldset>
 	</tab>
-	<tab id="seo" sortorder="20" title="preside-objects.site:seo.tab.title">
+	<tab id="seo" sortorder="30" title="preside-objects.site:seo.tab.title">
 		<fieldset id="seo" sortorder="10">
 			<field binding="site.hide_from_search"     sortorder="10" />
 			<field binding="site.author"               sortorder="20" />
@@ -25,7 +30,7 @@ This form is used for the "add site" form in the site manager
 			<field binding="site.browser_title_suffix" sortorder="40" />
 		</fieldset>
 	</tab>
-	<tab id="advanced" sortorder="30" title="preside-objects.site:advanced.tab.title">
+	<tab id="advanced" sortorder="40" title="preside-objects.site:advanced.tab.title">
 		<fieldset id="advanced" sortorder="10">
 			<field name="alias_domains"    sortorder="10" control="textarea"    label="preside-objects.site:field.alias_domains.title"    help="preside-objects.site:field.alias_domains.help" />
 			<field name="redirect_domains" sortorder="20" control="textarea"    label="preside-objects.site:field.redirect_domains.title" help="preside-objects.site:field.redirect_domains.help" />

--- a/system/forms/preside-objects/site/admin.edit.xml
+++ b/system/forms/preside-objects/site/admin.edit.xml
@@ -13,11 +13,16 @@ This form is used for the "edit site" form in the site manager
 			<field binding="site.path"     sortorder="40" control="textinput" />
 			<field binding="site.template" sortorder="50" control="sitetemplatepicker"  />
 		</fieldset>
-		<fieldset id="localisation" sortorder="20">
+	</tab>
+	<tab id="localisation" sortorder="20" title="preside-objects.site:localisation.tab.title">
+		<fieldset id="localisation" sortorder="10">
 			<field binding="site.locale" sortorder="10" control="siteLocalePicker" />
+			<field binding="site.short_date_format" sortorder="20" control="siteDateFormatPicker" dateFormatType="short" />
+			<field binding="site.long_date_format"  sortorder="30" control="siteDateFormatPicker" dateFormatType="long" />
+			<field binding="site.time_format"       sortorder="40" control="enumRadioList" />
 		</fieldset>
 	</tab>
-	<tab id="seo" sortorder="20" title="preside-objects.site:seo.tab.title">
+	<tab id="seo" sortorder="30" title="preside-objects.site:seo.tab.title">
 		<fieldset id="seo" sortorder="10">
 			<field binding="site.hide_from_search"     sortorder="10" />
 			<field binding="site.author"               sortorder="20" />
@@ -25,7 +30,7 @@ This form is used for the "edit site" form in the site manager
 			<field binding="site.browser_title_suffix" sortorder="40" />
 		</fieldset>
 	</tab>
-	<tab id="advanced" sortorder="30" title="preside-objects.site:advanced.tab.title">
+	<tab id="advanced" sortorder="40" title="preside-objects.site:advanced.tab.title">
 		<fieldset id="advanced" sortorder="10">
 			<field name="alias_domains"    sortorder="10" control="textarea"    label="preside-objects.site:field.alias_domains.title"    help="preside-objects.site:field.alias_domains.help" />
 			<field name="redirect_domains" sortorder="20" control="textarea"    label="preside-objects.site:field.redirect_domains.title" help="preside-objects.site:field.redirect_domains.help" />

--- a/system/handlers/admin/Sites.cfc
+++ b/system/handlers/admin/Sites.cfc
@@ -89,6 +89,18 @@ component extends="preside.system.base.AdminHandler" {
 			prc.record.redirect_domains = ValueList( redirectDomains.domain, Chr(13) & Chr(10) );
 		}
 
+		var defaultLocaleSettings = getDefaultSettingsForLocale();
+		
+		if ( IsEmpty( prc.record.short_date_format ) ) {
+			prc.record.short_date_format = defaultLocaleSettings.short_date_format;
+		}
+		if ( IsEmpty( prc.record.long_date_format ) ) {
+			prc.record.long_date_format = defaultLocaleSettings.long_date_format;
+		}
+		if ( IsEmpty( prc.record.time_format ) ) {
+			prc.record.time_format = defaultLocaleSettings.time_format;
+		}
+
 		_addRootBreadcrumb( event );
 		event.addAdminBreadCrumb(
 			  title = translateResource( uri="cms:sites.editsite.breadcrumb", data=[ prc.record.name ] )

--- a/system/handlers/formcontrols/SiteDateFormatPicker.cfc
+++ b/system/handlers/formcontrols/SiteDateFormatPicker.cfc
@@ -1,0 +1,34 @@
+/**
+ * @feature presideForms and sites
+ */
+component {
+
+	property name="i18n"              inject="i18n";
+
+	public string function index( event, rc, prc, args={} ) output=false {
+		var settings       = getSetting( "datetime.formats" );
+		var dateFormatType = args.dateFormatType ?: "";
+		var items          = settings[dateFormatType];
+		args.labels        = [ "" ];
+		args.values        = [ "" ];
+
+		if ( !items.len() ) {
+		    return "";
+		}
+
+		for( var item in items ) {
+			args.values.append( item );
+
+			var label = translateResource(uri="preside-objects.site:option.#item#.label", defaultValue="");
+			if( Len(label) ) {
+				args.labels.append( label );
+			}
+			else {
+				var newLabel = item & " (" & DateFormat("2025-09-20", item) & ")";
+				args.labels.append( newLabel );
+			}
+		}
+		
+		return renderView( view="formcontrols/select/index", args=args );
+	}
+}

--- a/system/handlers/formcontrols/SiteDateFormatPicker.cfc
+++ b/system/handlers/formcontrols/SiteDateFormatPicker.cfc
@@ -17,15 +17,14 @@ component {
 		}
 
 		for( var item in items ) {
-			args.values.append( item );
+			ArrayAppend(args.values, item);
 
 			var label = translateResource(uri="preside-objects.site:option.#item#.label", defaultValue="");
 			if( Len(label) ) {
-				args.labels.append( label );
-			}
-			else {
+				ArrayAppend(args.labels, label);
+			} else {
 				var newLabel = item & " (" & DateFormat("2025-09-20", item) & ")";
-				args.labels.append( newLabel );
+				ArrayAppend(args.labels, newLabel);
 			}
 		}
 		

--- a/system/handlers/formcontrols/SiteLocalePicker.cfc
+++ b/system/handlers/formcontrols/SiteLocalePicker.cfc
@@ -3,10 +3,12 @@
  */
 component {
 
-	property name="i18n"              inject="i18n";
-	property name="frontendLanguages" inject="coldbox:setting:frontendLanguages";
+	property name="i18n"                  inject="i18n";
+	property name="frontendLanguages"     inject="coldbox:setting:frontendLanguages";
+	property name="resourceBundleService" inject="resourceBundleService";
 
 	public string function index( event, rc, prc, args={} ) output=false {
+		args.extraClasses = "site-locale-picker";
 		args.adminLocales = false;
 		args.locales      = frontendLanguages;
 		args.defaultValue = args.defaultValue ?: i18n.getDefaultLocale();
@@ -14,6 +16,19 @@ component {
 		if ( ArrayLen( args.locales ) == 1 ) {
 			return "";
 		}
+
+		var isoCountriesJson = resourceBundleService.getBundleAsJson(
+			bundle   = "enum.isoCountries"
+		);
+
+		var defaultLocaleSettings = getSetting( "datetime.regionDefaults" );
+
+		event.includeData( {
+			  isoCountries = deserializeJson(isoCountriesJson)
+			, defaultLocaleSettings = defaultLocaleSettings
+		} );
+
+		event.include( "/js/admin/specific/siteLocalePicker/" );
 
 		return renderViewlet( event="formcontrols.localePicker.index", args=args );
 	}

--- a/system/helpers/dateUtils.cfm
+++ b/system/helpers/dateUtils.cfm
@@ -13,7 +13,7 @@
 <cffunction name="getShortDate" access="public" returntype="string" output="false">
 	<cfargument name="date" type="date" required="true" /><cfsilent>
 	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getShortDate( arguments.date ) />
+	<cfreturn dfService.getShortDate( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDateFormatMask" access="public" returntype="string" output="false"><cfsilent>
@@ -45,7 +45,7 @@
 	<cfargument name="date" type="date" required="true" />
 	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
 	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDate( arguments.date, arguments.includeOrdinal ) />
+	<cfreturn dfService.getLongDate( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getDateRange" access="public" returntype="string" output="false">
@@ -55,7 +55,7 @@
 	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
 
 	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getDateRange( arguments.date1, arguments.date2, arguments.showYear, arguments.includeOrdinal ) />
+	<cfreturn dfService.getDateRange( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getSplitDate" access="public" returntype="string" output="false">
@@ -65,19 +65,24 @@
 	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
 
 	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getSplitDate( arguments.dates, arguments.compact, arguments.compactThreshold, arguments.includeOrdinal ) />
+	<cfreturn dfService.getSplitDate( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getDateDayOrdinal" access="public" returntype="string" output="false">
 	<cfargument name="date" type="date" required="true" /><cfsilent>
 		
 	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getDateDayOrdinal( arguments.date ) />
+	<cfreturn dfService.getDateDayOrdinal( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getSiteLocaleSettings" access="public" returntype="query" output="false"><cfsilent>
 	<cfset var dfService = getSingleton( "dateFormatService" ) />
 	<cfreturn dfService.getSiteLocaleSettings() />
+</cfsilent></cffunction>
+
+<cffunction name="getDefaultSettingsForLocale" access="public" returntype="struct" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getDefaultSettingsForLocale() />
 </cfsilent></cffunction>
 
 <cffunction name="getTimeFormatMask" access="public" returntype="string" output="false"><cfsilent>
@@ -88,5 +93,5 @@
 <cffunction name="roundHours" access="public" returntype="string" output="false">
 	<cfargument name="formattedTime" type="string" required="true" /><cfsilent>
 	<cfset var tfService = getSingleton( "timeFormatService" ) />
-	<cfreturn tfService.roundHours( arguments.formattedTime ) />
+	<cfreturn tfService.roundHours( argumentCollection=arguments ) />
 </cfsilent></cffunction>

--- a/system/helpers/dateUtils.cfm
+++ b/system/helpers/dateUtils.cfm
@@ -4,3 +4,89 @@
 
 	<cfreturn DateFormat( arguments.date, "ddd, dd MMM YYYY " ) & TimeFormat( arguments.date, "HH:mm:ss " ) & arguments.timezone />
 </cfsilent></cffunction>
+
+<cffunction name="getShortDateFormatMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getShortDateFormatMask() />
+</cfsilent></cffunction>
+
+<cffunction name="getShortDate" access="public" returntype="string" output="false">
+	<cfargument name="date" type="date" required="true" /><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getShortDate( arguments.date ) />
+</cfsilent></cffunction>
+
+<cffunction name="getLongDateFormatMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getLongDateFormatMask() />
+</cfsilent></cffunction>
+
+<cffunction name="getLongDateFormatDayMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getLongDateFormatDayMask() />
+</cfsilent></cffunction>
+
+<cffunction name="getLongDateFormatMonthMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getLongDateFormatMonthMask() />
+</cfsilent></cffunction>
+
+<cffunction name="getLongDateFormatYearMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getLongDateFormatYearMask() />
+</cfsilent></cffunction>
+
+<cffunction name="getLongDateFormatDayMonthMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getLongDateFormatDayMonthMask() />
+</cfsilent></cffunction>
+
+<cffunction name="getLongDate" access="public" returntype="string" output="false">
+	<cfargument name="date" type="date" required="true" />
+	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getLongDate( arguments.date, arguments.includeOrdinal ) />
+</cfsilent></cffunction>
+
+<cffunction name="getDateRange" access="public" returntype="string" output="false">
+	<cfargument name="date1" type="date" required="true" />
+	<cfargument name="date2" type="date" required="true" />
+	<cfargument name="showYear" type="boolean" required="false" default="false" />
+	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
+
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getDateRange( arguments.date1, arguments.date2, arguments.showYear, arguments.includeOrdinal ) />
+</cfsilent></cffunction>
+
+<cffunction name="getSplitDate" access="public" returntype="string" output="false">
+	<cfargument name="dates" type="array" required="true" />
+	<cfargument name="compact" type="boolean" required="false" default="false" />
+	<cfargument name="compactThreshold" type="numeric" required="false" default="30" />
+	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
+
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getSplitDate( arguments.dates, arguments.compact, arguments.compactThreshold, arguments.includeOrdinal ) />
+</cfsilent></cffunction>
+
+<cffunction name="getDateDayOrdinal" access="public" returntype="string" output="false">
+	<cfargument name="date" type="date" required="true" /><cfsilent>
+		
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getDateDayOrdinal( arguments.date ) />
+</cfsilent></cffunction>
+
+<cffunction name="getSiteLocaleSettings" access="public" returntype="query" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getSiteLocaleSettings() />
+</cfsilent></cffunction>
+
+<cffunction name="getTimeFormatMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var tfService = getSingleton( "timeFormatService" ) />
+	<cfreturn tfService.getTimeFormatMask() />
+</cfsilent></cffunction>
+
+<cffunction name="roundHours" access="public" returntype="string" output="false">
+	<cfargument name="formattedTime" type="string" required="true" /><cfsilent>
+	<cfset var tfService = getSingleton( "timeFormatService" ) />
+	<cfreturn tfService.roundHours( arguments.formattedTime ) />
+</cfsilent></cffunction>

--- a/system/i18n/enum/isoCountries.properties
+++ b/system/i18n/enum/isoCountries.properties
@@ -1,0 +1,740 @@
+AF.label=Afghanistan
+AF.region=uk
+
+AX.label=Aland Islands
+AX.region=uk
+
+AL.label=Albania
+AL.region=uk
+
+DZ.label=Algeria
+DZ.region=uk
+
+AS.label=American Samoa
+AS.region=uk
+
+AD.label=Andorra
+AD.region=uk
+
+AO.label=Angola
+AO.region=uk
+
+AI.label=Anguilla
+AI.region=uk
+
+AQ.label=Antarctica
+AQ.region=uk
+
+AG.label=Antigua and Barbuda
+AG.region=uk
+
+AR.label=Argentina
+AR.region=uk
+
+AM.label=Armenia
+AM.region=uk
+
+AW.label=Aruba
+AW.region=uk
+
+AU.label=Australia
+AU.region=uk
+
+AT.label=Austria
+AT.region=uk
+
+AZ.label=Azerbaijan
+AZ.region=uk
+
+BS.label=Bahamas
+BS.region=uk
+
+BH.label=Bahrain
+BH.region=uk
+
+BD.label=Bangladesh
+BD.region=uk
+
+BB.label=Barbados
+BB.region=uk
+
+BY.label=Belarus
+BY.region=uk
+
+BE.label=Belgium
+BE.region=uk
+
+BZ.label=Belize
+BZ.region=uk
+
+BJ.label=Benin
+BJ.region=uk
+
+BM.label=Bermuda
+BM.region=uk
+
+BT.label=Bhutan
+BT.region=uk
+
+BO.label=Bolivia
+BO.region=uk
+
+BA.label=Bosnia and Herzegovina
+BA.region=uk
+
+BW.label=Botswana
+BW.region=uk
+
+BV.label=Bouvet Island
+BV.region=uk
+
+BR.label=Brazil
+BR.region=uk
+
+IO.label=British Indian Ocean Territory
+IO.region=uk
+
+BN.label=Brunei Darussalam
+BN.region=uk
+
+BG.label=Bulgaria
+BG.region=uk
+
+BF.label=Burkina Faso
+BF.region=uk
+
+BI.label=Burundi
+BI.region=uk
+
+KH.label=Cambodia
+KH.region=uk
+
+CM.label=Cameroon
+CM.region=uk
+
+CA.label=Canada
+CA.region=uk
+
+CV.label=Cape Verde
+CV.region=uk
+
+KY.label=Cayman Islands
+KY.region=uk
+
+CF.label=Central African Republic
+CF.region=uk
+
+TD.label=Chad
+TD.region=uk
+
+CL.label=Chile
+CL.region=uk
+
+CN.label=China
+CN.region=uk
+
+CX.label=Christmas Island
+CX.region=uk
+
+CC.label=Cocos (Keeling) Islands
+CC.region=uk
+
+CO.label=Colombia
+CO.region=uk
+
+KM.label=Comoros
+KM.region=uk
+
+CG.label=Congo
+CG.region=uk
+
+CD.label=Congo, The Democratic Republic of the
+CD.region=uk
+
+CK.label=Cook Islands
+CK.region=uk
+
+CR.label=Costa Rica
+CR.region=uk
+
+CI.label=C\u00F4te d'Ivoire
+CI.region=uk
+
+HR.label=Croatia
+HR.region=uk
+
+CU.label=Cuba
+CU.region=uk
+
+CY.label=Cyprus
+CY.region=uk
+
+CZ.label=Czech Republic
+CZ.region=uk
+
+DK.label=Denmark
+DK.region=uk
+
+DJ.label=Djibouti
+DJ.region=uk
+
+DM.label=Dominica
+DM.region=uk
+
+DO.label=Dominican Republic
+DO.region=uk
+
+EC.label=Ecuador
+EC.region=uk
+
+EG.label=Egypt
+EG.region=uk
+
+SV.label=El Salvador
+SV.region=uk
+
+GQ.label=Equatorial Guinea
+GQ.region=uk
+
+ER.label=Eritrea
+ER.region=uk
+
+EE.label=Estonia
+EE.region=uk
+
+ET.label=Ethiopia
+ET.region=uk
+
+FK.label=Falkland Islands (Malvinas)
+FK.region=uk
+
+FO.label=Faroe Islands
+FO.region=uk
+
+FJ.label=Fiji
+FJ.region=uk
+
+FI.label=Finland
+FI.region=uk
+
+FR.label=France
+FR.region=eu
+
+GF.label=French Guiana
+GF.region=uk
+
+PF.label=French Polynesia
+PF.region=uk
+
+TF.label=French Southern Territories
+TF.region=uk
+
+GA.label=Gabon
+GA.region=uk
+
+GM.label=Gambia
+GM.region=uk
+
+GE.label=Georgia
+GE.region=uk
+
+DE.label=Germany
+DE.region=eu
+
+GH.label=Ghana
+GH.region=uk
+
+GI.label=Gibraltar
+GI.region=uk
+
+GR.label=Greece
+GR.region=uk
+
+GL.label=Greenland
+GL.region=uk
+
+GD.label=Grenada
+GD.region=uk
+
+GP.label=Guadeloupe
+GP.region=uk
+
+GU.label=Guam
+GU.region=uk
+
+GT.label=Guatemala
+GT.region=uk
+
+GG.label=Guernsey
+GG.region=uk
+
+GN.label=Guinea
+GN.region=uk
+
+GW.label=Guinea-Bissau
+GW.region=uk
+
+GY.label=Guyana
+GY.region=uk
+
+HT.label=Haiti
+HT.region=uk
+
+HM.label=Heard Island and McDonald Islands
+HM.region=uk
+
+VA.label=Holy See (Vatican City State)
+VA.region=uk
+
+HN.label=Honduras
+HN.region=uk
+
+HK.label=Hong Kong
+HK.region=uk
+
+HU.label=Hungary
+HU.region=uk
+
+IS.label=Iceland
+IS.region=uk
+
+IN.label=India
+IN.region=uk
+
+ID.label=Indonesia
+ID.region=uk
+
+IR.label=Iran, Islamic Republic of
+IR.region=uk
+
+IQ.label=Iraq
+IQ.region=uk
+
+IE.label=Ireland
+IE.region=uk
+
+IM.label=Isle of Man
+IM.region=uk
+
+IL.label=Israel
+IL.region=uk
+
+IT.label=Italy
+IT.region=uk
+
+JM.label=Jamaica
+JM.region=uk
+
+JP.label=Japan
+JP.region=uk
+
+JE.label=Jersey
+JE.region=uk
+
+JO.label=Jordan
+JO.region=uk
+
+KZ.label=Kazakhstan
+KZ.region=uk
+
+KE.label=Kenya
+KE.region=uk
+
+KI.label=Kiribati
+KI.region=uk
+
+KP.label=Korea, Democratic People's Republic of
+KP.region=uk
+
+KR.label=Korea, Republic of
+KR.region=uk
+
+XK.label=Kosovo
+XK.region=uk
+
+KW.label=Kuwait
+KW.region=uk
+
+KG.label=Kyrgyzstan
+KG.region=uk
+
+LA.label=Lao People's Democratic Republic
+LA.region=uk
+
+LV.label=Latvia
+LV.region=uk
+
+LB.label=Lebanon
+LB.region=uk
+
+LS.label=Lesotho
+LS.region=uk
+
+LR.label=Liberia
+LR.region=uk
+
+LY.label=Libyan Arab Jamahiriya
+LY.region=uk
+
+LI.label=Liechtenstein
+LI.region=uk
+
+LT.label=Lithuania
+LT.region=uk
+
+LU.label=Luxembourg
+LU.region=uk
+
+MO.label=Macao
+MO.region=uk
+
+MK.label=Macedonia, The Former Yugoslav Republic of
+MK.region=uk
+
+MG.label=Madagascar
+MG.region=uk
+
+MW.label=Malawi
+MW.region=uk
+
+MY.label=Malaysia
+MY.region=uk
+
+MV.label=Maldives
+MV.region=uk
+
+ML.label=Mali
+ML.region=uk
+
+MT.label=Malta
+MT.region=uk
+
+MH.label=Marshall Islands
+MH.region=uk
+
+MQ.label=Martinique
+MQ.region=uk
+
+MR.label=Mauritania
+MR.region=uk
+
+MU.label=Mauritius
+MU.region=uk
+
+YT.label=Mayotte
+YT.region=uk
+
+MX.label=Mexico
+MX.region=uk
+
+FM.label=Micronesia, Federated States of
+FM.region=uk
+
+MD.label=Moldova
+MD.region=uk
+
+MC.label=Monaco
+MC.region=uk
+
+MN.label=Mongolia
+MN.region=uk
+
+ME.label=Montenegro
+ME.region=uk
+
+MS.label=Montserrat
+MS.region=uk
+
+MA.label=Morocco
+MA.region=uk
+
+MZ.label=Mozambique
+MZ.region=uk
+
+MM.label=Myanmar
+MM.region=uk
+
+NA.label=Namibia
+NA.region=uk
+
+NR.label=Nauru
+NR.region=uk
+
+NP.label=Nepal
+NP.region=uk
+
+NL.label=Netherlands
+NL.region=uk
+
+AN.label=Netherlands Antilles
+AN.region=uk
+
+NC.label=New Caledonia
+NC.region=uk
+
+NZ.label=New Zealand
+NZ.region=uk
+
+NI.label=Nicaragua
+NI.region=uk
+
+NE.label=Niger
+NE.region=uk
+
+NG.label=Nigeria
+NG.region=uk
+
+NU.label=Niue
+NU.region=uk
+
+NF.label=Norfolk Island
+NF.region=uk
+
+MP.label=Northern Mariana Islands
+MP.region=uk
+
+NO.label=Norway
+NO.region=uk
+
+OM.label=Oman
+OM.region=uk
+
+PK.label=Pakistan
+PK.region=uk
+
+PW.label=Palau
+PW.region=uk
+
+PS.label=Palestinian Territory, Occupied
+PS.region=uk
+
+PA.label=Panama
+PA.region=uk
+
+PG.label=Papua New Guinea
+PG.region=uk
+
+PY.label=Paraguay
+PY.region=uk
+
+PE.label=Peru
+PE.region=uk
+
+PH.label=Philippines
+PH.region=uk
+
+PN.label=Pitcairn
+PN.region=uk
+
+PL.label=Poland
+PL.region=uk
+
+PT.label=Portugal
+PT.region=uk
+
+PR.label=Puerto Rico
+PR.region=uk
+
+QA.label=Qatar
+QA.region=uk
+
+RE.label=R\u00E9union
+RE.region=uk
+
+RO.label=Romania
+RO.region=uk
+
+RU.label=Russian Federation
+RU.region=uk
+
+RW.label=Rwanda
+RW.region=uk
+
+BL.label=Saint Barth\u00E9lemy
+BL.region=uk
+
+SH.label=Saint Helena
+SH.region=uk
+
+KN.label=Saint Kitts and Nevis
+KN.region=uk
+
+LC.label=Saint Lucia
+LC.region=uk
+
+MF.label=Saint Martin
+MF.region=uk
+
+PM.label=Saint Pierre and Miquelon
+PM.region=uk
+
+VC.label=Saint Vincent and the Grenadines
+VC.region=uk
+
+WS.label=Samoa
+WS.region=uk
+
+SM.label=San Marino
+SM.region=uk
+
+ST.label=Sao Tome and Principe
+ST.region=uk
+
+SA.label=Saudi Arabia
+SA.region=uk
+
+SN.label=Senegal
+SN.region=uk
+
+RS.label=Serbia
+RS.region=uk
+
+SC.label=Seychelles
+SC.region=uk
+
+SL.label=Sierra Leone
+SL.region=uk
+
+SG.label=Singapore
+SG.region=uk
+
+SK.label=Slovakia
+SK.region=uk
+
+SI.label=Slovenia
+SI.region=uk
+
+SB.label=Solomon Islands
+SB.region=uk
+
+SO.label=Somalia
+SO.region=uk
+
+ZA.label=South Africa
+ZA.region=uk
+
+GS.label=South Georgia and the South Sandwich Islands
+GS.region=uk
+
+ES.label=Spain
+ES.region=eu
+
+LK.label=Sri Lanka
+LK.region=uk
+
+SD.label=Sudan
+SD.region=uk
+
+SR.label=Suriname
+SR.region=uk
+
+SJ.label=Svalbard and Jan Mayen
+SJ.region=uk
+
+SZ.label=Swaziland
+SZ.region=uk
+
+SE.label=Sweden
+SE.region=uk
+
+CH.label=Switzerland
+CH.region=uk
+
+SY.label=Syrian Arab Republic
+SY.region=uk
+
+TW.label=Taiwan
+TW.region=uk
+
+TJ.label=Tajikistan
+TJ.region=uk
+
+TZ.label=Tanzania, United Republic of
+TZ.region=uk
+
+TH.label=Thailand
+TH.region=uk
+
+TL.label=Timor-Leste
+TL.region=uk
+
+TG.label=Togo
+TG.region=uk
+
+TK.label=Tokelau
+TK.region=uk
+
+TO.label=Tonga
+TO.region=uk
+
+TT.label=Trinidad and Tobago
+TT.region=uk
+
+TN.label=Tunisia
+TN.region=uk
+
+TR.label=Turkey
+TR.region=uk
+
+TM.label=Turkmenistan
+TM.region=uk
+
+TC.label=Turks and Caicos Islands
+TC.region=uk
+
+TV.label=Tuvalu
+TV.region=uk
+
+UG.label=Uganda
+UG.region=uk
+
+UA.label=Ukraine
+UA.region=uk
+
+AE.label=United Arab Emirates
+AE.region=uk
+
+GB.label=United Kingdom
+GB.region=uk
+
+US.label=United States
+US.region=us
+
+UM.label=United States Minor Outlying Islands
+UM.region=uk
+
+UY.label=Uruguay
+UY.region=uk
+
+UZ.label=Uzbekistan
+UZ.region=uk
+
+VU.label=Vanuatu
+VU.region=uk
+
+VE.label=Venezuela
+VE.region=uk
+
+VN.label=Viet Nam
+VN.region=uk
+
+VG.label=Virgin Islands, British
+VG.region=uk
+
+VI.label=Virgin Islands, U.S.
+VI.region=uk
+
+WF.label=Wallis and Futuna
+WF.region=uk
+
+EH.label=Western Sahara
+EH.region=uk
+
+YE.label=Yemen
+YE.region=uk
+
+ZM.label=Zambia
+ZM.region=uk
+
+ZW.label=Zimbabwe
+ZW.region=uk

--- a/system/i18n/enum/timeFormatOptions.properties
+++ b/system/i18n/enum/timeFormatOptions.properties
@@ -1,0 +1,2 @@
+12h.label=12h
+24h.label=24h

--- a/system/i18n/preside-objects/site.properties
+++ b/system/i18n/preside-objects/site.properties
@@ -5,6 +5,7 @@ iconClass=fa-globe
 basic.tab.title=Core settings
 seo.tab.title=Metadata and SEO
 advanced.tab.title=Advanced
+localisation.tab.title=Localisation
 
 fieldset.basic.title=General
 fieldset.localisation.title=Localisation
@@ -37,6 +38,12 @@ field.browser_title_prefix.help=Prepend this text to the browser title of every 
 field.browser_title_suffix.title=Browser title suffix
 field.browser_title_suffix.help=Append this text to the browser title of every page in your site
 field.deleted.title=Deleted
+field.short_date_format.title=Short date format
+field.short_date_format.help=The short date format is used for displaying dates in a short format, e.g. 20/09/2025
+field.long_date_format.title=Long date format
+field.long_date_format.help=The long date format is used for displaying dates in a long format, e.g. 20 September 2025 or September 20, 2025
+field.time_format.title=Time format
+field.time_format.help=The time format is used for displaying times in either 12 hour or 24 hour format, e.g. 2:00PM or 14:00
 
 field.locale.title=Locale
 field.locale.help=Specifies the default locale for this site. This determines the language and regional settings used for content display, formatting, and localization.
@@ -54,3 +61,8 @@ validation.path.presideObjectUniqueIndex.message=Combination of domain and path 
 validation.domain.match.message=Invalid domain
 validation.path.match.message=Invalid path
 validation.protocol.match.message=Protocol must be either http or https
+
+option.DMY.label=Day Month Year (20 September 2025)
+option.DMY.mask=d mmmm yyyy
+option.MDY.label=Month Day, Year (September 20, 2025)
+option.MDY.mask=mmmm d, yyyy

--- a/system/preside-objects/core/site.cfc
+++ b/system/preside-objects/core/site.cfc
@@ -7,12 +7,15 @@
  * @feature        sites
  */
 component extends="preside.system.base.SystemPresideObject" labelfield="name" displayName="Site"  {
-	property name="name"     type="string" dbtype="varchar" maxlength="200" required=true  uniqueindexes="sitename";
-	property name="domain"   type="string" dbtype="varchar" maxlength="255" required=true  uniqueindexes="sitepath|1" format="regex:^[a-zA-Z0-9][a-zA-Z0-9-_\.]+$";
-	property name="path"     type="string" dbtype="varchar" maxlength="255" required=true  uniqueindexes="sitepath|2" format="regex:^\/[a-zA-Z0-9\/-_]*$";
-	property name="protocol" type="string" dbtype="varchar" maxlength="5"   required=false enum="siteProtocol";
-	property name="template" type="string" dbtype="varchar" maxlength="50"  required=false;
-	property name="locale"   type="string" dbtype="varchar" maxlength="50"  required=false;
+	property name="name"                 type="string"  dbtype="varchar" maxlength="200"  required=true  uniqueindexes="sitename";
+	property name="domain"               type="string"  dbtype="varchar" maxlength="255"  required=true  uniqueindexes="sitepath|1" format="regex:^[a-zA-Z0-9][a-zA-Z0-9-_\.]+$";
+	property name="path"                 type="string"  dbtype="varchar" maxlength="255"  required=true  uniqueindexes="sitepath|2" format="regex:^\/[a-zA-Z0-9\/-_]*$";
+	property name="protocol"             type="string"  dbtype="varchar" maxlength="5"    required=false enum="siteProtocol";
+	property name="template"             type="string"  dbtype="varchar" maxlength="50"   required=false;
+	property name="locale"               type="string"  dbtype="varchar" maxlength="50"   required=false;
+	property name="short_date_format"    type="string"  dbtype="varchar" maxlength="50"   required=false;
+	property name="long_date_format"     type="string"  dbtype="varchar" maxlength="50"   required=false;
+	property name="time_format"          type="string"  dbtype="varchar" maxlength="10"   required=false enum="timeFormatOptions";
 
 	property name="auto_redirect"        type="boolean" dbtype="boolean"                  required=false default=true;
 	property name="hide_from_search"     type="boolean" dbtype="boolean"                  required=false default=false;

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -1,0 +1,317 @@
+/**
+ * @singleton true
+ * @presideService true
+ */
+component {
+
+    function init() {
+		return this;
+	}
+
+    
+
+//SHORT DATE FORMAT FUNCTIONS
+    public string function getShortDateFormatMask() {
+        return LCase(getSiteLocaleSettings().short_date_format);
+    }
+
+    public string function getShortDate( required date date ) {
+        return LSdateFormat( arguments.date, getShortDateFormatMask() );
+    }
+
+//LONG DATE FORMAT FUNCTIONS
+    public string function getLongDateFormatMask() {
+        if( _getLongDateFormat() == "DMY" ) {
+            return "d mmmm yyyy";
+        }
+        else {
+            return "mmmm d, yyyy";
+        }
+    }
+
+    public string function getLongDateFormatDayMask() {
+        return "d";
+    }
+
+    public string function getLongDateFormatMonthMask() {
+        return "mmmm";
+    }
+
+    public string function getLongDateFormatYearMask() {
+        return "yyyy";
+    }
+
+    public string function getLongDateFormatDayMonthMask() {
+        if( _getLongDateFormat() == "DMY" ) {
+            return "d mmmm";
+        }
+        else {
+            return "mmmm d";
+        }
+    }
+
+    public string function getLongDate( required date date, boolean includeOrdinal=false ) {
+        var longFormat    = _getLongDateFormat();
+        var mask          = getLongDateFormatMask();
+        var formattedDate = LSdateFormat( arguments.date, mask );
+
+        if( arguments.includeOrdinal && longFormat == "DMY" ) {
+            var dateOrdinal = getDateDayOrdinal( arguments.date );
+            formattedDate   = ReReplace( formattedDate, "(\d{1,2})", "\1#dateOrdinal#" ); 
+        }
+
+        return formattedDate;
+    }
+
+//DATE RANGE FUNCTIONS
+    public string function getDateRange( required date date1, required date date2, boolean showYear=false, boolean includeOrdinal=false ) {
+        var longFormat = _getLongDateFormat();
+        var mask       = getLongDateFormatMask();
+        var maskNoYear = getLongDateFormatDayMonthMask();
+        var dayMask    = getLongDateFormatDayMask();
+        var yearMask   = getLongDateFormatYearMask();
+
+        if( arguments.includeOrdinal && longFormat == "MDY" ) {
+            arguments.includeOrdinal = false;
+        }
+
+        if( month( arguments.date1 ) == month( arguments.date2 ) ) {
+            return getDateRangeWithSameMonth( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
+        }
+        else {
+            if( year( arguments.date1 ) == year( arguments.date2 ) ) {
+                return getDateRangeWithDifferentMonthAndSameYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
+            }
+            else {
+                return getDateRangeWithDifferentMonthAndDifferentYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
+            }
+        }
+        
+    }
+
+    public string function getDateRangeWithSameMonth( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
+        var longFormat         = _getLongDateFormat();
+        var mask               = getLongDateFormatMask();
+		var maskNoYear         = getLongDateFormatDayMonthMask();
+		var dayMask            = getLongDateFormatDayMask();
+		var yearMask           = getLongDateFormatYearMask();
+
+		if( longFormat == "DMY" ) {
+            var dateRange = LSDateFormat( arguments.date1, dayMask );
+            if( arguments.includeOrdinal ) {
+                dateRange &= getDateDayOrdinal( arguments.date1 );
+            }
+
+            var date2Part = "";
+            
+            if( arguments.showYear ) {
+                date2Part = LSDateFormat( arguments.date2, mask );
+            }
+            else {
+                date2Part = LSDateFormat( arguments.date2, maskNoYear );
+            }
+
+            if( arguments.includeOrdinal ) {
+                var date2Ordinal = getDateDayOrdinal( arguments.date2 );
+                date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
+            }
+
+            dateRange &= " - " & date2Part;
+
+            return dateRange;
+		}
+		else {
+            var dateRange = "#LSDateFormat( arguments.date1, maskNoYear )# - #LSDateFormat( arguments.date2, dayMask )#";
+            if( arguments.showYear ) {
+                dateRange &= " " & LSDateFormat( arguments.date1, yearMask );
+            }
+            return dateRange;
+		}
+    }
+
+    public string function getDateRangeWithDifferentMonthAndSameYear( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
+        var longFormat         = _getLongDateFormat();
+        var mask               = getLongDateFormatMask();
+		var maskNoYear         = getLongDateFormatDayMonthMask();
+		var dayMonthMask       = getLongDateFormatDayMonthMask();
+
+        if( !arguments.showYear ) {
+            mask = maskNoYear;
+        }
+
+        if( longFormat == "DMY" ) {
+            var date1Part = LSDateFormat( date1, dayMonthMask );
+            var date2Part = LSDateFormat( date2, mask );
+
+            if( arguments.includeOrdinal ) {
+                var date1Ordinal = getDateDayOrdinal( arguments.date1 );
+                date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
+
+                var date2Ordinal = getDateDayOrdinal( arguments.date2 );
+                date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
+            }
+            
+			return "#date1Part# - #date2Part#";
+		}
+		else {
+			return "#LSDateFormat( date1, maskNoYear )# - #LSDateFormat( date2, mask )#";
+		}
+    }
+
+    public string function getDateRangeWithDifferentMonthAndDifferentYear( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
+        var mask        = getLongDateFormatMask();
+        var maskNoYear  = getLongDateFormatDayMonthMask();
+
+        if( !arguments.showYear ) {
+            mask = maskNoYear;
+        }
+
+        var date1Part = LSDateFormat( date1, mask );
+        var date2Part = LSDateFormat( date2, mask );
+
+        if( arguments.includeOrdinal ) {
+            var date1Ordinal = getDateDayOrdinal( arguments.date1 );
+            date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
+
+            var date2Ordinal = getDateDayOrdinal( arguments.date2 );
+            date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
+        }
+
+        return "#date1Part# - #date2Part#";
+    }
+
+    public string function getSplitDate( required array dates, boolean compact=false, numeric compactThreshold=30, boolean includeOrdinal=false ) {
+        var dayMask   = getLongDateFormatDayMask();
+        var dmyOrder  = _getLongDateFormat();
+        var delimiter = ", ";
+        
+        //sort the dates by year
+		ArraySort(arguments.dates, function(a,b) {
+			return DateCompare(a,b, "y");
+		});
+		
+        //get the unique years from the dates
+        var years = [];
+		for( var date in arguments.dates ) {
+			if( !ArrayContains(years, year(date)) ) {
+				ArrayAppend(years, year(date));
+			}
+		}
+        
+		var formattedDates = [];
+        //loop through the years
+		for(var year in years) {
+			var formattedYearDates = "";
+			var monthDates   = {};
+			var monthNumbers = [];
+
+            //get the dates for the current year
+			var yearDates = ArrayFilter(arguments.dates, function(date) {
+				return year(date) == year;
+			});
+
+			//loop through the dates for the current year
+			for( var date in yearDates ) {
+				var monthNumber = month(date);
+				if( !ArrayContains(monthNumbers, monthNumber) ) {
+					ArrayAppend(monthNumbers, monthNumber);
+				}
+
+				if( !StructKeyExists(monthDates, monthNumber) ) {
+					monthDates[monthNumber] = [];
+				}
+
+                var monthDate = LSDateFormat(date, dayMask);
+
+                if( arguments.includeOrdinal && dmyOrder == "DMY" ) {
+                    var dayOrdinal  = getDateDayOrdinal( date );
+                    monthDate &= dayOrdinal;
+                }
+
+				monthDates[monthNumber].append(monthDate);
+			}
+
+			//sort the month numbers numerically ascending
+			ArraySort(monthNumbers, "numeric", "asc");
+
+			//loop through the month numbers
+			for( var i=1; i<=ArrayLen(monthNumbers); i++ ) {
+				//get the month number
+				var monthNumber = monthNumbers[i];
+                
+
+				if( dmyOrder == "DMY" ) {
+					formattedYearDates &= ArrayToList(monthDates[monthNumber], delimiter) & " " & MonthAsString(monthNumber) & delimiter;
+				}
+				else if( dmyOrder == "MDY" || dmyOrder == "YMD" ) {
+					formattedYearDates &= MonthAsString(monthNumber) & " " & ArrayToList(monthDates[monthNumber], delimiter) & delimiter;
+				}
+			}
+
+            //strip the trailing delimiter
+			if( Right(formattedYearDates, 2) == delimiter ) {
+				formattedYearDates = Left(formattedYearDates, Len(formattedYearDates) - Len(delimiter));
+			}
+
+            //add the year
+			if( dmyOrder == "MDY" ) {
+                formattedYearDates &= ",";
+			}
+            formattedYearDates &= " " & year;
+
+			ArrayAppend(formattedDates, formattedYearDates);
+		}
+
+        return ArrayToList(formattedDates, delimiter);
+    }
+
+    public query function getSiteLocaleSettings() {
+        var event                  = $getRequestContext();
+        var currentSite            = event.getSite();
+        var siteId                 = currentSite.id;
+
+        return $getPresideObject( "site" ).selectData(
+              filter = { id=siteId }
+        );
+    }
+
+    public struct function getDefaultSettingsForLocale(){
+        var localeSettings  = getSiteLocaleSettings();
+        var defaultSettings = $getColdbox().getSetting( "datetime.regionDefaults" );
+        var countryCode     = ListLast(localeSettings.locale, "_");
+        var regionCode      = $translateResource( uri="enum.isoCountries:#countryCode#.region");
+        
+        if(Len(countryCode) && Len(regionCode) && Structkeyexists(defaultSettings, regionCode)){
+            return defaultSettings[regionCode];
+        }
+        else {
+            return defaultSettings["uk"];
+        }
+    }
+
+    public string function getDateDayOrdinal( required date date ){
+        var ordinalTypeA = [ "st", "nd", "rd" ];
+        var ordinal      = "th"
+        var date         = DateFormat( arguments.date, "dd" );
+
+        if( ( val( date[1] ) != 1 ) && ( date[2] > 0 && date[2] <= arrayLen( ordinalTypeA) ) ) {
+            ordinal = ordinalTypeA[date[2]];
+        }
+
+        return ordinal
+    }
+    
+//PRIVATE FUNCTIONS
+    private string function _getLongDateFormat() {
+        var defaults = getDefaultSettingsForLocale();
+
+        if( Len(getSiteLocaleSettings().long_date_format)) {
+            return getSiteLocaleSettings().long_date_format;
+        }
+        else {
+            return defaults.long_date_format;
+        }
+    }
+
+    
+}

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -21,10 +21,9 @@ component {
 
 //LONG DATE FORMAT FUNCTIONS
     public string function getLongDateFormatMask() {
-        if( _getLongDateFormat() == "DMY" ) {
+        if ( _getLongDateFormat() == "DMY" ) {
             return "d mmmm yyyy";
-        }
-        else {
+        } else {
             return "mmmm d, yyyy";
         }
     }
@@ -42,10 +41,9 @@ component {
     }
 
     public string function getLongDateFormatDayMonthMask() {
-        if( _getLongDateFormat() == "DMY" ) {
+        if ( _getLongDateFormat() == "DMY" ) {
             return "d mmmm";
-        }
-        else {
+        } else {
             return "mmmm d";
         }
     }
@@ -55,7 +53,7 @@ component {
         var mask          = getLongDateFormatMask();
         var formattedDate = LSdateFormat( arguments.date, mask );
 
-        if( arguments.includeOrdinal && longFormat == "DMY" ) {
+        if ( arguments.includeOrdinal && longFormat == "DMY" ) {
             var dateOrdinal = getDateDayOrdinal( arguments.date );
             formattedDate   = ReReplace( formattedDate, "(\d{1,2})", "\1#dateOrdinal#" ); 
         }
@@ -71,18 +69,16 @@ component {
         var dayMask    = getLongDateFormatDayMask();
         var yearMask   = getLongDateFormatYearMask();
 
-        if( arguments.includeOrdinal && longFormat == "MDY" ) {
+        if ( arguments.includeOrdinal && longFormat == "MDY" ) {
             arguments.includeOrdinal = false;
         }
 
-        if( month( arguments.date1 ) == month( arguments.date2 ) ) {
+        if ( month( arguments.date1 ) == month( arguments.date2 ) ) {
             return getDateRangeWithSameMonth( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
-        }
-        else {
-            if( year( arguments.date1 ) == year( arguments.date2 ) ) {
+        } else {
+            if ( year( arguments.date1 ) == year( arguments.date2 ) ) {
                 return getDateRangeWithDifferentMonthAndSameYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
-            }
-            else {
+            } else {
                 return getDateRangeWithDifferentMonthAndDifferentYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
             }
         }
@@ -96,22 +92,21 @@ component {
 		var dayMask            = getLongDateFormatDayMask();
 		var yearMask           = getLongDateFormatYearMask();
 
-		if( longFormat == "DMY" ) {
+		if ( longFormat == "DMY" ) {
             var dateRange = LSDateFormat( arguments.date1, dayMask );
-            if( arguments.includeOrdinal ) {
+            if ( arguments.includeOrdinal ) {
                 dateRange &= getDateDayOrdinal( arguments.date1 );
             }
 
             var date2Part = "";
             
-            if( arguments.showYear ) {
+            if ( arguments.showYear ) {
                 date2Part = LSDateFormat( arguments.date2, mask );
-            }
-            else {
+            } else {
                 date2Part = LSDateFormat( arguments.date2, maskNoYear );
             }
 
-            if( arguments.includeOrdinal ) {
+            if ( arguments.includeOrdinal ) {
                 var date2Ordinal = getDateDayOrdinal( arguments.date2 );
                 date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
             }
@@ -119,11 +114,10 @@ component {
             dateRange &= " - " & date2Part;
 
             return dateRange;
-		}
-		else {
+		} else {
             var dateRange = "#LSDateFormat( arguments.date1, maskNoYear )# - #LSDateFormat( arguments.date2, dayMask )#";
-            if( arguments.showYear ) {
-                dateRange &= " " & LSDateFormat( arguments.date1, yearMask );
+            if ( arguments.showYear ) {
+                dateRange &= ", " & LSDateFormat( arguments.date1, yearMask );
             }
             return dateRange;
 		}
@@ -135,15 +129,15 @@ component {
 		var maskNoYear         = getLongDateFormatDayMonthMask();
 		var dayMonthMask       = getLongDateFormatDayMonthMask();
 
-        if( !arguments.showYear ) {
+        if ( !arguments.showYear ) {
             mask = maskNoYear;
         }
 
-        if( longFormat == "DMY" ) {
+        if ( longFormat == "DMY" ) {
             var date1Part = LSDateFormat( date1, dayMonthMask );
             var date2Part = LSDateFormat( date2, mask );
 
-            if( arguments.includeOrdinal ) {
+            if ( arguments.includeOrdinal ) {
                 var date1Ordinal = getDateDayOrdinal( arguments.date1 );
                 date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
 
@@ -152,8 +146,7 @@ component {
             }
             
 			return "#date1Part# - #date2Part#";
-		}
-		else {
+		} else {
 			return "#LSDateFormat( date1, maskNoYear )# - #LSDateFormat( date2, mask )#";
 		}
     }
@@ -162,14 +155,14 @@ component {
         var mask        = getLongDateFormatMask();
         var maskNoYear  = getLongDateFormatDayMonthMask();
 
-        if( !arguments.showYear ) {
+        if ( !arguments.showYear ) {
             mask = maskNoYear;
         }
 
         var date1Part = LSDateFormat( date1, mask );
         var date2Part = LSDateFormat( date2, mask );
 
-        if( arguments.includeOrdinal ) {
+        if ( arguments.includeOrdinal ) {
             var date1Ordinal = getDateDayOrdinal( arguments.date1 );
             date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
 
@@ -193,7 +186,7 @@ component {
         //get the unique years from the dates
         var years = [];
 		for( var date in arguments.dates ) {
-			if( !ArrayContains(years, year(date)) ) {
+			if ( !ArrayContains(years, year(date)) ) {
 				ArrayAppend(years, year(date));
 			}
 		}
@@ -213,22 +206,22 @@ component {
 			//loop through the dates for the current year
 			for( var date in yearDates ) {
 				var monthNumber = month(date);
-				if( !ArrayContains(monthNumbers, monthNumber) ) {
+				if ( !ArrayContains(monthNumbers, monthNumber) ) {
 					ArrayAppend(monthNumbers, monthNumber);
 				}
 
-				if( !StructKeyExists(monthDates, monthNumber) ) {
+				if ( !StructKeyExists(monthDates, monthNumber) ) {
 					monthDates[monthNumber] = [];
 				}
 
                 var monthDate = LSDateFormat(date, dayMask);
 
-                if( arguments.includeOrdinal && dmyOrder == "DMY" ) {
+                if ( arguments.includeOrdinal && dmyOrder == "DMY" ) {
                     var dayOrdinal  = getDateDayOrdinal( date );
                     monthDate &= dayOrdinal;
                 }
 
-				monthDates[monthNumber].append(monthDate);
+                ArrayAppend(monthDates[monthNumber], monthDate);
 			}
 
 			//sort the month numbers numerically ascending
@@ -240,21 +233,20 @@ component {
 				var monthNumber = monthNumbers[i];
                 
 
-				if( dmyOrder == "DMY" ) {
+				if ( dmyOrder == "DMY" ) {
 					formattedYearDates &= ArrayToList(monthDates[monthNumber], delimiter) & " " & MonthAsString(monthNumber) & delimiter;
-				}
-				else if( dmyOrder == "MDY" || dmyOrder == "YMD" ) {
+				} else if ( dmyOrder == "MDY" || dmyOrder == "YMD" ) {
 					formattedYearDates &= MonthAsString(monthNumber) & " " & ArrayToList(monthDates[monthNumber], delimiter) & delimiter;
 				}
 			}
 
             //strip the trailing delimiter
-			if( Right(formattedYearDates, 2) == delimiter ) {
+			if ( Right(formattedYearDates, 2) == delimiter ) {
 				formattedYearDates = Left(formattedYearDates, Len(formattedYearDates) - Len(delimiter));
 			}
 
             //add the year
-			if( dmyOrder == "MDY" ) {
+			if ( dmyOrder == "MDY" ) {
                 formattedYearDates &= ",";
 			}
             formattedYearDates &= " " & year;
@@ -275,40 +267,38 @@ component {
         );
     }
 
-    public struct function getDefaultSettingsForLocale(){
+    public struct function getDefaultSettingsForLocale() {
         var localeSettings  = getSiteLocaleSettings();
         var defaultSettings = $getColdbox().getSetting( "datetime.regionDefaults" );
         var countryCode     = ListLast(localeSettings.locale, "_");
         var regionCode      = $translateResource( uri="enum.isoCountries:#countryCode#.region");
         
-        if(Len(countryCode) && Len(regionCode) && Structkeyexists(defaultSettings, regionCode)){
+        if ( Len(countryCode) && Len(regionCode) && Structkeyexists(defaultSettings, regionCode) ) {
             return defaultSettings[regionCode];
-        }
-        else {
+        } else {
             return defaultSettings["uk"];
         }
     }
 
-    public string function getDateDayOrdinal( required date date ){
+    public string function getDateDayOrdinal( required date date ) {
         var ordinalTypeA = [ "st", "nd", "rd" ];
         var ordinal      = "th"
         var date         = DateFormat( arguments.date, "dd" );
 
-        if( ( val( date[1] ) != 1 ) && ( date[2] > 0 && date[2] <= arrayLen( ordinalTypeA) ) ) {
+        if ( ( val( date[1] ) != 1 ) && ( date[2] > 0 && date[2] <= arrayLen( ordinalTypeA) ) ) {
             ordinal = ordinalTypeA[date[2]];
         }
 
-        return ordinal
+        return ordinal;
     }
     
 //PRIVATE FUNCTIONS
     private string function _getLongDateFormat() {
         var defaults = getDefaultSettingsForLocale();
 
-        if( Len(getSiteLocaleSettings().long_date_format)) {
+        if ( Len(getSiteLocaleSettings().long_date_format)) {
             return getSiteLocaleSettings().long_date_format;
-        }
-        else {
+        } else {
             return defaults.long_date_format;
         }
     }

--- a/system/services/l10n/TimeFormatService.cfc
+++ b/system/services/l10n/TimeFormatService.cfc
@@ -9,12 +9,13 @@ component {
 	}
 
     public string function getTimeFormatMask(  ){
-        var localeSettings = $helpers.getSiteLocaleSettings();
+        var localeSettings  = $helpers.getSiteLocaleSettings();
+        var defaultSettings = $helpers.getDefaultSettingsForLocale();
+        var time_format     = Len(localeSettings.time_format) ? localeSettings.time_format : defaultSettings.time_format;
         
-        if(localeSettings.time_format == "12h") {
+        if( time_format == "12h" ) {
             return "h:mmtt";
-        }
-        else {
+        }else {
             return "HH:mm";
         }
     }
@@ -22,7 +23,7 @@ component {
     public string function roundHours( string formattedTime ){
         var localeSettings = $helpers.getSiteLocaleSettings();
         
-        if(localeSettings.time_format == "12h") {
+        if ( localeSettings.time_format == "12h" ) {
             return Replace(arguments.formattedTime, ":00", "", "all");
         }
 

--- a/system/services/l10n/TimeFormatService.cfc
+++ b/system/services/l10n/TimeFormatService.cfc
@@ -1,0 +1,36 @@
+/**
+ * @singleton true
+ * @presideService true
+ */
+component {
+
+    function init() {
+		return this;
+	}
+
+    public string function getTimeFormatMask(  ){
+        var localeSettings = $helpers.getSiteLocaleSettings();
+        
+        if(localeSettings.time_format == "12h") {
+            return "h:mmtt";
+        }
+        else {
+            return "HH:mm";
+        }
+    }
+
+    public string function roundHours( string formattedTime ){
+        var localeSettings = $helpers.getSiteLocaleSettings();
+        
+        if(localeSettings.time_format == "12h") {
+            return Replace(arguments.formattedTime, ":00", "", "all");
+        }
+
+        return arguments.formattedTime;
+    }
+
+    public string function getFormattedTime( required date date ){
+        return LSTimeFormat(arguments.date, getTimeFormatMask());
+    }
+
+}


### PR DESCRIPTION
This update adds a new "Localisation" tab to Add/Edit Site forms.
Localisation contains: 
- Locale
- Short date format
- Long date format
- Time format

Locales drop down is populated by adding to `settings.frontendLanguages` array
Default settings for a locale can be configured in the `__setupLocaleSettings` function in config.cfc
The `SiteLocalePicker` form control has been updated to find the region for the selected locale and auto-populate the short and long date format fields.
A new `SiteDateFormatPicker` form control has been added to render a select control with example dates for each option.

New DateFormatService and TimeFormatService services added along with relevant helpers added to dateUtils.cfm
A new `isoCountries` enum properties file has been added to allow a mapping between a locale country and the regions specified in the new `__setupLocaleSettings` function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces site-level localisation (locale, short/long date and time formats) with new form controls, services, i18n/enums, JS auto-population, and helper APIs.
> 
> - **Admin UI (Sites)**:
>   - Add new **Localisation** tab to `admin.add.xml` and `admin.edit.xml` with `site.locale`, `site.short_date_format`, `site.long_date_format`, `site.time_format` (enum).
>   - Update `Sites.cfc` to prefill missing date/time fields from locale defaults.
> - **Form controls & JS**:
>   - New `SiteDateFormatPicker.cfc` to render date-format selects with example labels.
>   - Enhance `SiteLocalePicker.cfc` to load `isoCountries` and default locale settings, include JS, and tag control with `site-locale-picker`.
>   - New JS `system/assets/js/admin/specific/siteLocalePicker/siteLocalePicker.js` auto-selects formats/time based on selected locale's region.
> - **Configuration**:
>   - Add `__setupLocaleSettings()` in `Config.cfc` defining `settings.datetime.regionDefaults` and available `settings.datetime.formats`; call during configure.
>   - Add enum `timeFormatOptions = [ "12h", "24h" ]`.
> - **Data model**:
>   - Extend `preside-objects/core/site.cfc` with `short_date_format`, `long_date_format`, and `time_format` (enum).
> - **Services & helpers**:
>   - New `DateFormatService.cfc` and `TimeFormatService.cfc` providing masks/formatting and locale-default resolution.
>   - Expose helper functions in `system/helpers/dateUtils.cfm` (short/long date, ranges, ordinals, time mask/rounding, site/default locale access).
> - **i18n**:
>   - Add `enum/isoCountries.properties` (country->region mapping) and `enum/timeFormatOptions.properties`.
>   - Update `preside-objects/site.properties` with localisation field labels and long date option labels/masks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bec47f3920ffe2be2fd40927bacec68ab07beaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->