### PR TITLE
PRESIDECMS-3187 Inaccurate asset date information when uploaded new asset version

### DIFF
--- a/system/handlers/dbmigrations/AssetVersionFirstDate.cfc
+++ b/system/handlers/dbmigrations/AssetVersionFirstDate.cfc
@@ -1,0 +1,40 @@
+/**
+ * @feature assetManager
+ */
+component {
+
+	property name="dsn"       inject="coldbox:setting:dsn";
+	property name="sqlRunner" inject="SqlRunner";
+
+	private void function runAsync() {
+		var records = sqlRunner.runSql(
+				  dsn = dsn
+				, sql = "
+					SELECT
+						  v1.id    as version_id
+						, v1.asset as asset_id
+					FROM
+						psys_asset_version v1
+					JOIN
+						psys_asset_version v2 ON v1.asset = v2.asset
+							AND v1.version_number = 1
+							AND v2.version_number = 2
+							AND v1.datecreated = v2.datecreated
+		" );
+
+		for ( var record in records ) {
+			var asset = getPresideObject( "asset" ).selectData( id=record.asset_id, selectFields=[ "datecreated", "datemodified" ] );
+
+			if ( asset.recordCount ) {
+				getPresideObject( "asset_version" ).updateData(
+					  id   = record.version_id
+					, data = {
+						  datecreated  = asset.datecreated
+						, datemodified = asset.datemodified
+					  }
+				);
+			}
+		}
+	}
+
+}

--- a/system/services/assetManager/AssetManagerService.cfc
+++ b/system/services/assetManager/AssetManagerService.cfc
@@ -2471,6 +2471,8 @@ component displayName="AssetManager Service" {
 			, "resize_no_crop"
 			, "created_by"
 			, "updated_by"
+			, "datecreated"
+			, "datemodified"
 		] );
 
 		if ( !Len( Trim( asset.active_version ) ) ) {
@@ -2488,6 +2490,8 @@ component displayName="AssetManager Service" {
 				, resize_no_crop   = asset.resize_no_crop
 				, created_by       = asset.created_by
 				, updated_by       = asset.updated_by
+				, datecreated      = asset.datecreated
+				, datemodified     = asset.datemodified
 			} );
 
 			_getAssetDao().updateData( id=arguments.assetId, data={ active_version=versionId } );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates `datecreated`/`datemodified` from `asset` to the first `asset_version`, and introduces a migration to backfill incorrect timestamps.
> 
> - **Backend**
>   - **Asset version initialization**: In `_setupFirstVersionForAssetIfNoActiveVersion()` (in `system/services/assetManager/AssetManagerService.cfc`), include `datecreated` and `datemodified` when selecting the `asset` and insert them into the initial `asset_version`.
> - **DB Migration**
>   - **`system/handlers/dbmigrations/AssetVersionFirstDate.cfc`**: Adds `runAsync()` to detect assets where versions 1 and 2 share `datecreated`, then updates version 1’s `datecreated`/`datemodified` to match the parent `asset`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cb2aa2cfc805d80198bba9990ad701930ab2f69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->