### PR TITLE
PRESIDECMS-3201 Missing any type or images type of file upload file type

### DIFF
--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -98,7 +98,7 @@ component {
 						if ( IsStruct( formFieldValue ) ) {
 							var tempFileInfo = formFieldValue.tempFileInfo ?: {};
 
-							if ( ( tempFileInfo.serverFileExt ?: "" ) == ( tempFileInfo.contentSubType ?: "" ) ) {
+							if ( ( tempFileInfo.serverFileExt ?: "" ) == ( tempFileInfo.clientFileExt ?: "" ) ) {
 								formFieldValues = [ tempFileInfo.serverFileExt ];
 							}
 						}

--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -8,6 +8,7 @@ component {
 	property name="formBuilderService"           inject="FormBuilderService";
 	property name="rulesEngineOperatorService"   inject="RulesEngineOperatorService";
 	property name="rulesEngineTimePeriodService" inject="RulesEngineTimePeriodService";
+	property name="fileTypesService"             inject="FileTypesService";
 
 	/**
 	 * @formbuilderForm.fieldType   formbuilderForm
@@ -44,7 +45,6 @@ component {
 		var formFieldName   = formItem.configuration.name        ?: "";
 		var formFieldName   = formItem.configuration.name        ?: "";
 		var formFieldValue  = formData[ formFieldName ]          ?: "";
-		var formFieldValues = IsJSON( formFieldValue )           ? [] : ListToArray( formFieldValue );
 
 		var ruleConfig   = DeserializeJSON( arguments.formbuilderAnswer );
 		var ruleDataType = ruleConfig.dataType ?: "";
@@ -62,37 +62,58 @@ component {
 				break;
 
 			case "array"   :
-				var ruleValues       = [];
-				var formConfigValues = ListToArray( formItem.configuration.values ?: "", Chr( 10 ) & Chr( 13 ) );
+				var ruleValues      = [];
+				var formFieldValues = [];
 
+				var formConfigValues = ListToArray( formItem.configuration.values ?: "", Chr( 10 ) & Chr( 13 ) );
 				for ( var formConfigValue in formConfigValues ) {
 					if ( Find( formConfigValue, ruleValue ) ) {
 						ArrayAppend( ruleValues, formConfigValue );
 					}
 				}
 
-				if ( formItem.item_type == "matrix" ) {
-					var matrix = runEvent(
-						  event          = "formbuilder.item-types.matrix._getQuestionsAndAnswers"
-						, prePostExempt  = true
-						, private        = true
-						, eventArguments = { args={
-							  itemConfiguration = formItem.configuration ?: {}
-							, response          = formFieldValue
-						  } }
-					);
+				switch ( formItem.item_type ) {
+					case "matrix":
+						var matrix = runEvent(
+							  event          = "formbuilder.item-types.matrix._getQuestionsAndAnswers"
+							, prePostExempt  = true
+							, private        = true
+							, eventArguments = { args={
+								  itemConfiguration = formItem.configuration ?: {}
+								, response          = formFieldValue
+							  } }
+						);
 
-					var ruleProperty = ruleConfig.property ?: "";
-					for ( var item in matrix ) {
-						if ( ruleProperty == ( item.question ?: "" ) && !isEmptyString( item.answer ?: "" ) ) {
-							if ( ArrayContainsNoCase( [ "allof", "noneof" ], ruleOperator ) ) {
-								ArrayAppend( formFieldValues, item.answer );
-							} else {
-								formFieldValue = item.answer;
-								break;
+						var ruleProperty = ruleConfig.property ?: "";
+						for ( var item in matrix ) {
+							if ( ruleProperty == ( item.question ?: "" ) && !isEmptyString( item.answer ?: "" ) ) {
+								if ( ArrayContainsNoCase( [ "allof", "noneof" ], ruleOperator ) ) {
+									ArrayAppend( formFieldValues, item.answer );
+								} else {
+									formFieldValue = item.answer;
+									break;
+								}
 							}
 						}
-					}
+						break;
+
+					case "fileUpload":
+						ruleValues = fileTypesService.expandTypeList( types=ListToArray( ruleValue ) );
+
+						if ( IsStruct( formFieldValue ) ) {
+							var tempFileInfo = formFieldValue.tempFileInfo ?: {};
+
+							if ( ( tempFileInfo.serverFileExt ?: "" ) == ( tempFileInfo.contentSubType ?: "" ) ) {
+								formFieldValues = [ tempFileInfo.serverFileExt ];
+							}
+						}
+						break;
+
+					default:
+						if ( IsSimpleValue( formFieldValue ) && !IsJSON( formFieldValue ) ) {
+							formFieldValues = ListToArray( formFieldValue );
+						}
+						break;
 				}
 
 				switch ( ruleOperator ) {

--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -67,6 +67,8 @@ component {
 
 				switch ( formItem.item_type ) {
 					case "matrix":
+						ruleValues = ListToArray( ruleValue );
+
 						var matrix = runEvent(
 							  event          = "formbuilder.item-types.matrix._getQuestionsAndAnswers"
 							, prePostExempt  = true
@@ -83,7 +85,7 @@ component {
 								if ( ArrayContainsNoCase( [ "allof", "noneof" ], ruleOperator ) ) {
 									ArrayAppend( formFieldValues, item.answer );
 								} else {
-									formFieldValue = item.answer;
+									formFieldValues = [ item.answer ];
 									break;
 								}
 							}

--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -65,13 +65,6 @@ component {
 				var ruleValues      = [];
 				var formFieldValues = [];
 
-				var formConfigValues = ListToArray( formItem.configuration.values ?: "", Chr( 10 ) & Chr( 13 ) );
-				for ( var formConfigValue in formConfigValues ) {
-					if ( Find( formConfigValue, ruleValue ) ) {
-						ArrayAppend( ruleValues, formConfigValue );
-					}
-				}
-
 				switch ( formItem.item_type ) {
 					case "matrix":
 						var matrix = runEvent(
@@ -110,8 +103,15 @@ component {
 						break;
 
 					default:
-						if ( IsSimpleValue( formFieldValue ) && !IsJSON( formFieldValue ) ) {
-							formFieldValues = ListToArray( formFieldValue );
+						var formConfigValues = ListToArray( formItem.configuration.values ?: "", Chr( 10 ) & Chr( 13 ) );
+						for ( var formConfigValue in formConfigValues ) {
+							if ( Find( formConfigValue, ruleValue ) ) {
+								ArrayAppend( ruleValues, formConfigValue );
+							}
+
+							if ( Find( formConfigValue, formFieldValue ) ) {
+								ArrayAppend( formFieldValues, formConfigValue );
+							}
 						}
 						break;
 				}

--- a/system/handlers/rules/fieldtypes/formbuilderPageAnswer.cfc
+++ b/system/handlers/rules/fieldtypes/formbuilderPageAnswer.cfc
@@ -138,26 +138,8 @@ component {
 
 					case "fileupload":
 						config.multiple = true;
-						config.sortable = true;
 						config.dataType = "array";
-						config.type     = "select";
-						config.values   = [];
-						config.labels   = [];
-
-						if ( isEmptyString( formItem.configuration.accept ?: "" ) ) {
-							var assetTypes = getSetting( name="assetManager.types", defaultValue=[] );
-							for ( var assetType in assetTypes ) {
-								for ( var fileType in assetTypes[ assetType ] ) {
-									ArrayAppend( config.values, fileType );
-								}
-							}
-						} else {
-							config.values = assetManagerService.expandTypeList( ListToArray( formItem.configuration.accept, "," ) );
-						}
-
-						for ( var fileType in config.values ) {
-							ArrayAppend( config.labels, translateResource( "filetypes:#fileType#.picker.label" ) );
-						}
+						config.type     = "fileTypePicker";
 						break;
 
 					case "checkbox":


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds array matching for file uploads (via file type expansion and extension extraction) and replaces file upload rule config with a fileTypePicker; also refines matrix/array matching logic.
> 
> - **Rules Engine (Formbuilder answer matching)**:
>   - **File uploads**:
>     - Injects `fileTypesService` and handles `fileUpload` items by expanding rule `types` via `fileTypesService.expandTypeList(...)` and extracting the uploaded file extension from `tempFileInfo`.
>   - **Matrix items**:
>     - Builds `ruleValues` from `ruleValue` list and collects `formFieldValues` per-question, respecting `allof/noneof` vs single-value operators.
>   - **Default array items**:
>     - Derives `ruleValues` and `formFieldValues` by matching against `configuration.values` and current response.
> - **Rule fieldtype config (`formbuilderPageAnswer`)**:
>   - For `fileupload`, switches config to `type: fileTypePicker` with `multiple` + `dataType: array` (drops manual values/labels construction and sorting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0175e4ef199940f9a12b167d9e95515a5b4f5b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->