### PR TITLE
PRESIDECMS_3207 background thread admin login

### DIFF
--- a/system/services/admin/LoginService.cfc
+++ b/system/services/admin/LoginService.cfc
@@ -10,6 +10,8 @@
  */
 component displayName="Admin login service" {
 
+	property name="dummySessionStorage" inject="dummySessionStorage";
+
 // CONSTRUCTOR
 	/**
 	 * @sessionStorage.inject      sessionStorage
@@ -62,17 +64,21 @@ component displayName="Admin login service" {
 	 */
 	public boolean function login(
 		  required string  loginId
-		, required string  password
+		,          string  password             = ""
 		,          boolean rememberLogin        = false
 		,          numeric rememberExpiryInDays = 9
 		,          boolean skipPasswordCheck    = false
+		,          boolean recordLogin          = true
 	) {
-		var usr = _getUserByLoginId( arguments.loginId );
+		var usr     = _getUserByLoginId( arguments.loginId );
 		var success = usr.recordCount && ( arguments.skipPasswordCheck || _getBCryptService().checkPw( arguments.password, usr.password ) );
 
 		if ( success ) {
 			_persistUserSession( usr );
-			recordLogin();
+
+			if ( arguments.recordLogin ) {
+				recordLogin();
+			}
 
 			if ( arguments.rememberLogin ) {
 				_setRememberMeCookie( userId=usr.id, loginId=usr.login_id, expiry=arguments.rememberExpiryInDays );
@@ -971,6 +977,9 @@ component displayName="Admin login service" {
 
 // GETTERS AND SETTERS
 	private any function _getSessionStorage() {
+		if ( $getRequestContext().isBackgroundThread() ) {
+			return dummySessionStorage;
+		}
 		return _sessionStorage;
 	}
 	private void function _setSessionStorage( required any sessionStorage ) {

--- a/system/services/admin/LoginService.cfc
+++ b/system/services/admin/LoginService.cfc
@@ -77,7 +77,7 @@ component displayName="Admin login service" {
 			_persistUserSession( usr );
 
 			if ( arguments.recordLogin ) {
-				recordLogin();
+				this.recordLogin();
 			}
 
 			if ( arguments.rememberLogin ) {

--- a/system/services/cfmlscopes/DummySessionStorage.cfc
+++ b/system/services/cfmlscopes/DummySessionStorage.cfc
@@ -1,0 +1,63 @@
+/**
+ * Exists as a dummy session storage for background threads that need to access the user's details
+ * etc. without creating an actual session.
+ *
+ * @presideService true
+ * @singleton      true
+ */
+component extends="SessionStorage" output=false {
+
+	public any function init() {
+		return super.init();
+	}
+
+	public any function restore() {
+		return;
+	}
+
+	public any function persist() {
+		return;
+	}
+
+	public void function rotate() {
+		return;
+	}
+
+	public any function getVar( name, default ) output=false {
+		var storage = getStorage();
+		return storage[ arguments.name ] ?: ( arguments.default ?: "" );
+	}
+
+	public any function setVar( name, value ) output=false {
+		var storage = getStorage();
+		storage[ arguments.name ] = arguments.value;
+	}
+
+	public any function deleteVar( name ) output=false {
+		var storage = getStorage();
+
+		return StructDelete( storage, arguments.name, true );
+	}
+
+	public any function exists( name ) output=false {
+		var storage = getStorage();
+
+		return StructKeyExists( storage, arguments.name );
+	}
+
+	public any function clearAll() output=false {
+		removeStorage();
+	}
+
+	public any function getStorage() output=false {
+		if ( !StructKeyExists( request, "__dummySessionStorage" ) ) {
+			request.__dummySessionStorage = {};
+		}
+
+		return request.__dummySessionStorage;
+	}
+
+	public any function removeStorage() output=false {
+		StructDelete( request, "__dummySessionStorage" );
+	}
+}

--- a/tests/unit/api/admin/LoginServiceTest.cfc
+++ b/tests/unit/api/admin/LoginServiceTest.cfc
@@ -12,6 +12,7 @@
 			mockCookieService = getMockBox().createEmptyMock( "preside.system.services.cfmlScopes.CookieService" );
 			mockGoogleAuthenticator = getMockBox().createEmptyMock( "preside.system.services.authentication.GoogleAuthenticator" );
 			mockQrCodeGenerator = getMockBox().createEmptyMock( "preside.system.services.qrcodes.QrCodeGenerator" );
+			mockRequestContext = getMockBox().createStub();
 			loginService = new preside.system.services.admin.loginService(
 				  logger              = _getTestLogger()
 				, userDao             = _getPresideObjectService( forceNewInstance=true ).getObject( "security_user" )
@@ -24,10 +25,12 @@
 				, qrCodeGenerator     = mockQrCodeGenerator
 			);
 
+			mockRequestContext.$( "isBackgroundThread", false );
 			loginService = getMockBox().createMock( object=loginService );
 			loginService.$( "$audit" );
 			loginService.$( "_autoLogin", false );
 			loginService.$( "_deleteRememberMeCookie" );
+			loginService.$( "$getRequestContext", mockRequestContext );
 		</cfscript>
 	</cffunction>
 


### PR DESCRIPTION
This change allows background threads to formally spoof an admin login without creating sessions and to bypass having logins registered as an audit event.

e.g.

```cfc
// in my bg thread

loginService.login( loginId=owner, bypassPasswordCheck=true, recordLogin=false ); 
```

The user will be logged in but only in the "request" (the life of the bg thread). No session records will be created + no audit actions of the login will be recorded. 

All the other login methods that rely on checking session, etc. will continue to work as normal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows admin login in background threads without creating sessions or audit records, by routing to a dummy session storage and adding a `recordLogin` flag and optional `password` in `login()`; tests updated.
> 
> - **Admin LoginService (`system/services/admin/LoginService.cfc`)**:
>   - Add `dummySessionStorage` and use it when `$getRequestContext().isBackgroundThread()`.
>   - Update `login()` signature: `password` now optional (`""` default); add `recordLogin` flag (defaults `true`) and only call `recordLogin()` when true.
> - **New Service**:
>   - `system/services/cfmlscopes/DummySessionStorage.cfc`: no-op session storage backed by request scope for background threads (implements `getVar/setVar/deleteVar/exists/clearAll`, `restore/persist/rotate` as no-ops).
> - **Tests**:
>   - `tests/unit/api/admin/LoginServiceTest.cfc`: stub `$getRequestContext().isBackgroundThread()` and inject into `LoginService` mock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d2ac163f043a9139070bce13559a02e1f79f3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->