### PR TITLE
PRESIDECMS-3209 error after reloading user session

### DIFF
--- a/system/services/websiteUsers/WebsiteLoginService.cfc
+++ b/system/services/websiteUsers/WebsiteLoginService.cfc
@@ -600,7 +600,7 @@ component displayName="Website login service" {
 		for( var u in user ){
 			u.session_authenticated = $helpers.isTrue( existingSession.session_authenticated ?: "" );
 
-			_setUserSession( user );
+			_setUserSession( u );
 
 			return;
 		}

--- a/system/services/websiteUsers/WebsiteLoginService.cfc
+++ b/system/services/websiteUsers/WebsiteLoginService.cfc
@@ -193,7 +193,9 @@ component displayName="Website login service" {
 	 *
 	 */
 	public boolean function isAutoLoggedIn() autodoc=true {
-		return _getSessionStorage().exists( name=_getSessionKey() ) && !getLoggedInUserDetails().session_authenticated;
+		var user = getLoggedInUserDetails();
+
+		return StructCount( user ) && $helpers.isFalse( user.session_authenticated ?: "" );
 	}
 
 	/**
@@ -589,13 +591,18 @@ component displayName="Website login service" {
 	}
 
 	public void function reloadLoggedInUserDetails( string userId=getLoggedInUserId() ) {
-		var user = _getUserDao().selectData(
+		var existingSession = getLoggedInUserDetails();
+		var user            = _getUserDao().selectData(
 			  filter   = { id=arguments.userId, active=true }
 			, useCache = false
 		);
 
-		if ( user.recordCount ) {
-			_setUserSession( $helpers.queryRowToStruct( user ) );
+		for( var u in user ){
+			u.session_authenticated = $helpers.isTrue( existingSession.session_authenticated ?: "" );
+
+			_setUserSession( user );
+
+			return;
 		}
 	}
 

--- a/system/services/websiteUsers/WebsiteLoginService.cfc
+++ b/system/services/websiteUsers/WebsiteLoginService.cfc
@@ -599,6 +599,7 @@ component displayName="Website login service" {
 
 		for( var u in user ){
 			u.session_authenticated = $helpers.isTrue( existingSession.session_authenticated ?: "" );
+			u.impersonated          = $helpers.isTrue( existingSession.impersonated          ?: "" );
 
 			_setUserSession( u );
 

--- a/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
+++ b/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
@@ -472,6 +472,7 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		mockResetDao          = getMockbox().createStub();
 		mockUserLoginTokenDao = getMockbox().createStub();
 		mockRequestContext    = getMockbox().createStub();
+		mockHelpers           = getMockbox().createStub();
 		mockBCryptService     = getMockBox().createEmptyMock( "preside.system.services.encryption.bcrypt.BCryptService" );
 		mockSysConfigService  = getMockBox().createEmptyMock( "preside.system.services.configuration.SystemConfigurationService" );
 		mockEmailService      = getMockBox().createEmptyMock( "preside.system.services.email.EmailService" );
@@ -497,6 +498,14 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		mockResetDao.$( "insertData", 1 );
 		mockResetDao.$( "deleteData", 1 );
 		mockRequestContext.$( "isBackgroundThread", false );
+		service.$property( propertyName="$helpers", mock=mockHelpers );
+		mockHelpers.$( method="isTrue", callBack=function( val ){
+			return IsBoolean( arguments.val ) && arguments.val;
+		} );
+		mockHelpers.$( method="isFalse", callBack=function( val ){
+			return !IsBoolean( arguments.val ) || !arguments.val;
+		} );
+
 
 		return service;
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Preserves `session_authenticated` and `impersonated` flags when reloading logged-in user details and updates auto-login detection to use `$helpers` against current user details; tests updated to mock `$helpers`.
> 
> - **Website login service (`system/services/websiteUsers/WebsiteLoginService.cfc`)**:
>   - **Session reload**: `reloadLoggedInUserDetails()` now preserves `session_authenticated` and `impersonated` using `$helpers.isTrue()` when refreshing the session.
>   - **Auto-login check**: `isAutoLoggedIn()` now evaluates `getLoggedInUserDetails()` and uses `$helpers.isFalse()` on `session_authenticated`.
> - **Tests (`tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc`)**:
>   - Injects and mocks `$helpers` with `isTrue`/`isFalse` to support the new logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 801237c0064d336b60c2704cf749947d5cde36a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->