### PR TITLE
PRESIDECMS-2864 Start heartbeats after everything else has successfully loaded

### DIFF
--- a/system/handlers/General.cfc
+++ b/system/handlers/General.cfc
@@ -37,7 +37,6 @@ component {
 		_configureVariousServices(); // important for this to happen first
 		_populateDefaultLanguages();
 		_setupCatchAllAdminUserGroup();
-		_startHeartbeats();
 		_setupValidators();
 		_performDbMigrations();
 		_setupDatamanagerWorkflow();
@@ -46,6 +45,8 @@ component {
 		_writeIgnoreFile();
 
 		announceInterception( "onApplicationStart" );
+
+		_startHeartbeats();
 	}
 
 	public void function applicationEnd( event, rc, prc ) {


### PR DESCRIPTION
This prevents errors with various caches being preserved with references in background threads when an error happens after the heartbeats have started but before the application is registered as fully started.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `_startHeartbeats()` to run after `announceInterception("onApplicationStart")`, ensuring heartbeats start only after all startup tasks complete.
> 
> - **Startup order**:
>   - Move `General.applicationStart()` call to `_startHeartbeats()` from earlier in the method to after `announceInterception("onApplicationStart")`, so heartbeats begin only after services/config, migrations, setup, alerts, and ignore file writing finish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b06b05fe65e9e86c6bc3b69c67f4c6922a0f0180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->