### PR TITLE
PRESIDECMS-3214 ObjectRelatedRecordsList does not render when data exists

### DIFF
--- a/system/handlers/admin/DataHelpers.cfc
+++ b/system/handlers/admin/DataHelpers.cfc
@@ -164,17 +164,33 @@ component extends="preside.system.base.adminHandler" {
 		var objectName    = args.objectName   ?: "";
 		var propertyName  = args.propertyName ?: "";
 		var recordId      = args.recordId     ?: "";
+		var data          = args.data         ?: "";
 		var relatedObject = presideObjectService.getObjectPropertyAttribute( objectName=objectName, propertyName=propertyName, attributeName="relatedTo" );
 		var labelRenderer = presideObjectService.getObjectAttribute( objectName=relatedObject, attributeName="labelRenderer" );
 		var hasNoLabel    = isTrue( presideObjectService.getObjectAttribute( objectName=relatedObject, attributeName="noLabel" ) );
 		var labelField    = hasNoLabel ? "id" : "${labelfield}";
-		var selectFields  = [ "#propertyName#.id", "#propertyName#.#labelField# as label" ];
-		var records       = presideObjectService.selectData( objectName=objectName, id=recordId, selectFields=selectFields, forceJoins="inner" );
-		var baseLink      = event.buildadminLink( objectName=relatedObject, recordId="{recordId}" );
+		var records       = QueryNew( "" );
+		var baseLink      = event.buildAdminLink( objectName=relatedObject, recordId="{recordId}" );
 		var list          = [];
 		var label         = "";
 
-		for( var record in records ) {
+		if ( isEmptyString( data ) ) {
+			records = presideObjectService.selectData(
+				  objectName   = objectName
+				, id           = recordId
+				, selectFields = [ "#propertyName#.id", "#propertyName#.#labelField# as label" ]
+				, forceJoins   = "inner"
+			);
+		} else {
+			records = presideObjectService.selectData(
+				  objectName   = relatedObject
+				, selectFields = [ "id", "#labelField# as label" ]
+				, filter       = "id in ( :relatedRecordIds )"
+				, filterParams = { relatedRecordIds={ type="cf_sql_varchar", value=data, list=true } }
+			);
+		}
+
+		for ( var record in records ) {
 			label = Len( labelRenderer ) ? renderLabel( relatedObject, record.id ) : record.label;
 			if ( !isEmptyString( label ) ) {
 				if ( Len( baseLink ) ) {

--- a/system/handlers/admin/DraftManager.cfc
+++ b/system/handlers/admin/DraftManager.cfc
@@ -47,7 +47,11 @@ component extends="preside.system.base.AdminHandler" {
 		var draftId    = prc.record.id           ?: "";
 
 		if ( !IsEmpty( prc.record._data ?: {} ) ) {
-			StructAppend( rc, DeserializeJSON( prc.record._data ), true );
+			var data = DeserializeJSON( prc.record._data );
+
+			StructAppend( data, rc, true );
+
+			rc = data;
 		}
 
 		StructAppend( rc, { _draft_id=draftId }, true );

--- a/system/handlers/admin/DraftManager.cfc
+++ b/system/handlers/admin/DraftManager.cfc
@@ -51,7 +51,9 @@ component extends="preside.system.base.AdminHandler" {
 
 			StructAppend( data, rc, true );
 
-			rc = data;
+			for ( var k in data ) {
+				event.setValue( name=k, value=data[ k ] );
+			}
 		}
 
 		StructAppend( rc, { _draft_id=draftId }, true );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **`DataHelpers.relatedRecordsList`**: Adds support for `args.data` (list of IDs) to fetch labels directly from the related object using a filtered query; falls back to the original join when `data` is empty. Initializes `records` safely and uses `event.buildAdminLink` for links.
> - **`DraftManager._publishDraftRecordAction`**: Deserializes draft `_data`, merges it with `rc`, and sets values via `event.setValue` to ensure fields are populated during publish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a465289b685a8c8831d15c3656dc4b1956c9361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->