### PR TITLE
PRESIDECMS-3217 Draft properties section is incorrectly shown

### DIFF
--- a/system/config/Config.cfc
+++ b/system/config/Config.cfc
@@ -327,6 +327,8 @@ component {
 		interceptorSettings.customInterceptionPoints.append( "preEditRecord" );
 		interceptorSettings.customInterceptionPoints.append( "postEditRecord" );
 		interceptorSettings.customInterceptionPoints.append( "postEditRecordAction" );
+		interceptorSettings.customInterceptionPoints.append( "preRenderRecordForViewRecord" );
+		interceptorSettings.customInterceptionPoints.append( "postRenderRecordForViewRecord" );
 	}
 
 	private void function __setupCachebox() {

--- a/system/handlers/admin/DataHelpers.cfc
+++ b/system/handlers/admin/DataHelpers.cfc
@@ -19,7 +19,9 @@ component extends="preside.system.base.adminHandler" {
 	private string function viewRecord( event, rc, prc, args={} ) {
 		var objectName = args.objectName ?: "";
 
-		args.viewGroups = adminDataViewsService.listViewGroupsForObject( objectName );
+		args.viewGroups = StructCopy( adminDataViewsService.listViewGroupsForObject( objectName ) );
+
+		announceInterception( "preRenderRecordForViewRecord", args );
 
 		args.preRenderRecord         = customizationService.runCustomization( objectName=objectName, action="preRenderRecord"        , args=args, defaultResult="" );
 		args.preRenderRecordLeftCol  = customizationService.runCustomization( objectName=objectName, action="preRenderRecordLeftCol" , args=args, defaultResult="" );
@@ -43,6 +45,8 @@ component extends="preside.system.base.adminHandler" {
 		args.postRenderRecordLeftCol  = customizationService.runCustomization( objectName=objectName, action="postRenderRecordLeftCol" , args=args, defaultResult="" );
 		args.postRenderRecordRightCol = customizationService.runCustomization( objectName=objectName, action="postRenderRecordRightCol", args=args, defaultResult="" );
 		args.postRenderRecord         = customizationService.runCustomization( objectName=objectName, action="postRenderRecord"        , args=args, defaultResult="" );
+
+		announceInterception( "postRenderRecordForViewRecord", args );
 
 		return renderView( view="/admin/dataHelpers/viewRecord", args=args );
 	}

--- a/system/interceptors/DraftManagerInterceptor.cfc
+++ b/system/interceptors/DraftManagerInterceptor.cfc
@@ -84,11 +84,11 @@ component extends="coldbox.system.Interceptor" {
 			var draft = draftManagerService.getDraftForObject( objectName=objectName, recordId=( interceptData.recordId ?: "" ) );
 
 			showDraftViewGroup = !IsEmpty( draft );
+
+			interceptData.viewGroups = StructCopy( adminDataViewsService.listViewGroupsForObject( objectName=objectName ) );
 		}
 
-		if ( showDraftViewGroup ) {
-			interceptData.viewGroups = StructCopy( adminDataViewsService.listViewGroupsForObject( objectName=objectName ) );
-		} else {
+		if ( !showDraftViewGroup ) {
 			for ( var i=1; i<=ArrayLen( interceptData.viewGroups.right ); i++ ) {
 				if ( interceptData.viewGroups.right[ i ].id == "draftManager" ) {
 					ArrayDeleteAt( interceptData.viewGroups.right, i );

--- a/system/interceptors/DraftManagerInterceptor.cfc
+++ b/system/interceptors/DraftManagerInterceptor.cfc
@@ -1,6 +1,7 @@
 component extends="coldbox.system.Interceptor" {
 
-	property name="draftManagerService" inject="delayedInjector:DraftManagerService";
+	property name="draftManagerService"   inject="delayedInjector:DraftManagerService";
+	property name="adminDataViewsService" inject="delayedInjector:AdminDataViewsService";
 
 	public void function configure() {}
 
@@ -67,6 +68,32 @@ component extends="coldbox.system.Interceptor" {
 				};
 
 				ArrayAppend( propertyNames, "draftmanager_security_user_modified" );
+			}
+		}
+	}
+
+	public void function preRenderRecordForViewRecord( event, interceptData ) {
+		if ( !isFeatureEnabled( "draftManager" ) ) {
+			return;
+		}
+
+		var objectName         = interceptData.objectName ?: "";
+		var showDraftViewGroup = false;
+
+		if ( draftManagerService.checkManagerEnabled( objectName=objectName ) ) {
+			var draft = draftManagerService.getDraftForObject( objectName=objectName, recordId=( interceptData.recordId ?: "" ) );
+
+			showDraftViewGroup = !IsEmpty( draft );
+		}
+
+		if ( showDraftViewGroup ) {
+			interceptData.viewGroups = StructCopy( adminDataViewsService.listViewGroupsForObject( objectName=objectName ) );
+		} else {
+			for ( var i=1; i<=ArrayLen( interceptData.viewGroups.right ); i++ ) {
+				if ( interceptData.viewGroups.right[ i ].id == "draftManager" ) {
+					ArrayDeleteAt( interceptData.viewGroups.right, i );
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce pre/post render hooks for admin viewRecord and use DraftManager interceptor to conditionally remove the `draftManager` view group when no draft is present.
> 
> - **Interception Points**:
>   - Add `preRenderRecordForViewRecord` and `postRenderRecordForViewRecord` to `system/config/Config.cfc`.
> - **Admin View Rendering** (`system/handlers/admin/DataHelpers.cfc`):
>   - `viewRecord`: copies `viewGroups` and announces new pre/post render interception points.
> - **DraftManager Interceptor** (`system/interceptors/DraftManagerInterceptor.cfc`):
>   - Injects `AdminDataViewsService` and implements `preRenderRecordForViewRecord` to fetch view groups and remove the `draftManager` group from the right column when no draft exists for the record (feature-gated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 823f3fa24532341bc1a60484830692406c23d399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->