### PR TITLE
PRESIDECMS-3218 Error on empty file input in form builder

### DIFF
--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -95,7 +95,7 @@ component {
 					case "fileUpload":
 						ruleValues = fileTypesService.expandTypeList( types=ListToArray( ruleValue ) );
 
-						if ( IsStruct( formFieldValue )  ) {
+						if ( IsStruct( formFieldValue ) ) {
 							var tempFileInfo = formFieldValue.tempFileInfo ?: {};
 
 							if ( !IsEmpty( tempFileInfo ) ) {

--- a/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
+++ b/system/handlers/rules/expressions/FormbuilderFormPageAnswerMatches.cfc
@@ -95,11 +95,15 @@ component {
 					case "fileUpload":
 						ruleValues = fileTypesService.expandTypeList( types=ListToArray( ruleValue ) );
 
-						if ( IsStruct( formFieldValue ) ) {
+						if ( IsStruct( formFieldValue )  ) {
 							var tempFileInfo = formFieldValue.tempFileInfo ?: {};
 
-							if ( ( tempFileInfo.serverFileExt ?: "" ) == ( tempFileInfo.clientFileExt ?: "" ) ) {
-								formFieldValues = [ tempFileInfo.serverFileExt ];
+							if ( !IsEmpty( tempFileInfo ) ) {
+								var serverFileExt = tempFileInfo.serverFileExt  ?: "";
+
+								if ( !isEmptyString( serverFileExt ) ) {
+									formFieldValues = [ serverFileExt ];
+								}
 							}
 						}
 						break;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Safely handles `fileUpload` answers by using `serverFileExt` only when present, preventing errors on empty uploads.
> 
> - **Rules engine (form builder)**:
>   - In `FormbuilderFormPageAnswerMatches.cfc`, relax `fileUpload` handling to only use `tempFileInfo.serverFileExt` when present; avoids reliance on `clientFileExt` and prevents errors on empty inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 526414743ac3a7da6db85e28c0641a651111616a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->