### PR TITLE
PRESIDECMS-3219 unknown columns error when exporting email send logs

### DIFF
--- a/system/handlers/dataExportTemplates/EmailTemplate.cfc
+++ b/system/handlers/dataExportTemplates/EmailTemplate.cfc
@@ -4,6 +4,7 @@
 component extends="preside.system.handlers.dataExportTemplates.Default" {
 
 	public array function getSelectFields( event, rc, prc, objectName, templateConfig, suppliedFields ) {
+		var fieldPrefix    = "";
 		var requiredFields = [
 			  "send_count_from_stats"
 			, "unique_opens_count"
@@ -14,9 +15,13 @@ component extends="preside.system.handlers.dataExportTemplates.Default" {
 			, "unsubscribe_rate_percentage"
 		];
 
+		if ( arguments.objectName == "email_template_send_log" ) {
+			fieldPrefix = "email_template.";
+		}
+
 		for ( var field in requiredFields ) {
 			if ( !ArrayFindNoCase( arguments.suppliedFields, field ) ) {
-				ArrayAppend( arguments.suppliedFields, field );
+				ArrayAppend( arguments.suppliedFields, "#fieldPrefix##field#" );
 			}
 		}
 

--- a/system/preside-objects/email/email_template.cfc
+++ b/system/preside-objects/email/email_template.cfc
@@ -75,9 +75,9 @@ component extends="preside.system.base.SystemPresideObject" displayname="Email t
 	property name="unique_unsubscribes_count" type="numeric" formula="agg:sum{ stats.unsubscribe_count }"  autofilter=false;
 
 	// Percentage fields for export (calculated by EmailTemplate export template)
-	property name="open_rate_percentage"        type="numeric" formula="0" autofilter=false;
-	property name="click_rate_percentage"       type="numeric" formula="0" autofilter=false;
-	property name="unsubscribe_rate_percentage" type="numeric" formula="0" autofilter=false;
+	property name="open_rate_percentage"        type="numeric" formula="min( 0 )" autofilter=false;
+	property name="click_rate_percentage"       type="numeric" formula="min( 0 )" autofilter=false;
+	property name="unsubscribe_rate_percentage" type="numeric" formula="min( 0 )" autofilter=false;
 
 	property name="_version_is_draft"   excludeDataExport=true;
 	property name="_version_has_drafts" excludeDataExport=true;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Resolves export errors when exporting send logs by ensuring correct field scoping and safe default formulas.
> 
> - Update `EmailTemplate.cfc` export template to prefix required fields with `email_template.` when `objectName` is `email_template_send_log`
> - Change percentage fields in `email_template.cfc` (`open_rate_percentage`, `click_rate_percentage`, `unsubscribe_rate_percentage`) to use `formula="min( 0 )"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16fb29f6a37aba01cf99c97405e57deab448e684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->