### PR TITLE
PRESIDECMS-3215: Fix webflow step sync site-tenancy caching bug and add migration for orphaned steps

### DIFF
--- a/system/handlers/dbmigrations/WebflowStepOrphanedRecordsFix.cfc
+++ b/system/handlers/dbmigrations/WebflowStepOrphanedRecordsFix.cfc
@@ -1,5 +1,6 @@
 /**
  * @feature webflow
+ * @feature sites
  */
 component {
 

--- a/system/handlers/dbmigrations/WebflowStepOrphanedRecordsFix.cfc
+++ b/system/handlers/dbmigrations/WebflowStepOrphanedRecordsFix.cfc
@@ -1,0 +1,47 @@
+/**
+ * @feature webflow
+ */
+component {
+
+	property name="sqlRunner" inject="SqlRunner";
+
+	private void function run() {
+		var dsn = getPresideObject( "webflow_configuration" ).getDsn();
+
+		// Step 1: Update orphaned steps to point to correct configuration
+		// These are steps where the step's site doesn't match the configuration's site
+		sqlRunner.runSql(
+			  dsn = dsn
+			, sql = "
+				UPDATE webflow_configuration_step wcs
+				INNER JOIN webflow_configuration wc_current ON wc_current.id = wcs.webflow
+				INNER JOIN webflow_configuration wc_correct ON wc_correct.webflow_id = wc_current.webflow_id
+					AND wc_correct.site = wcs.site
+					AND wc_correct.is_singleton = 1
+					AND wc_correct.instance_ref IS NULL
+				SET wcs.webflow = wc_correct.id
+				WHERE wc_current.site != wcs.site
+				  AND wc_current.is_singleton = 1
+				  AND wc_current.instance_ref IS NULL
+			"
+		);
+
+		// Step 2: Delete duplicate steps (keep ones pointing to correct config)
+		// This handles cases where both old orphaned and new correct steps exist
+		sqlRunner.runSql(
+			  dsn = dsn
+			, sql = "
+				DELETE wcs_old FROM webflow_configuration_step wcs_old
+				INNER JOIN webflow_configuration_step wcs_new ON wcs_new.step_id = wcs_old.step_id
+					AND wcs_new.site = wcs_old.site
+					AND wcs_new.id != wcs_old.id
+				INNER JOIN webflow_configuration wc_old ON wc_old.id = wcs_old.webflow
+				INNER JOIN webflow_configuration wc_new ON wc_new.id = wcs_new.webflow
+				WHERE wc_old.webflow_id = wc_new.webflow_id
+				  AND wc_old.site != wcs_old.site
+				  AND wc_new.site = wcs_new.site
+			"
+		);
+	}
+
+}

--- a/system/handlers/dbmigrations/WebflowStepOrphanedRecordsFix.cfc
+++ b/system/handlers/dbmigrations/WebflowStepOrphanedRecordsFix.cfc
@@ -8,7 +8,25 @@ component {
 	private void function run() {
 		var dsn = getPresideObject( "webflow_configuration" ).getDsn();
 
-		// Step 1: Update orphaned steps to point to correct configuration
+		// Step 1: Delete duplicate steps (keep ones pointing to correct config)
+		// This handles cases where both old orphaned and new correct steps exist
+		// Must run BEFORE updating orphaned steps to avoid unique constraint violations
+		sqlRunner.runSql(
+			  dsn = dsn
+			, sql = "
+				DELETE wcs_old FROM webflow_configuration_step wcs_old
+				INNER JOIN webflow_configuration_step wcs_new ON wcs_new.step_id = wcs_old.step_id
+					AND wcs_new.site = wcs_old.site
+					AND wcs_new.id != wcs_old.id
+				INNER JOIN webflow_configuration wc_old ON wc_old.id = wcs_old.webflow
+				INNER JOIN webflow_configuration wc_new ON wc_new.id = wcs_new.webflow
+				WHERE wc_old.webflow_id = wc_new.webflow_id
+				  AND wc_old.site != wcs_old.site
+				  AND wc_new.site = wcs_new.site
+			"
+		);
+
+		// Step 2: Update orphaned steps to point to correct configuration
 		// These are steps where the step's site doesn't match the configuration's site
 		sqlRunner.runSql(
 			  dsn = dsn
@@ -23,23 +41,6 @@ component {
 				WHERE wc_current.site != wcs.site
 				  AND wc_current.is_singleton = 1
 				  AND wc_current.instance_ref IS NULL
-			"
-		);
-
-		// Step 2: Delete duplicate steps (keep ones pointing to correct config)
-		// This handles cases where both old orphaned and new correct steps exist
-		sqlRunner.runSql(
-			  dsn = dsn
-			, sql = "
-				DELETE wcs_old FROM webflow_configuration_step wcs_old
-				INNER JOIN webflow_configuration_step wcs_new ON wcs_new.step_id = wcs_old.step_id
-					AND wcs_new.site = wcs_old.site
-					AND wcs_new.id != wcs_old.id
-				INNER JOIN webflow_configuration wc_old ON wc_old.id = wcs_old.webflow
-				INNER JOIN webflow_configuration wc_new ON wc_new.id = wcs_new.webflow
-				WHERE wc_old.webflow_id = wc_new.webflow_id
-				  AND wc_old.site != wcs_old.site
-				  AND wc_new.site = wcs_new.site
 			"
 		);
 	}

--- a/system/services/webflow/WebflowConfigurationService.cfc
+++ b/system/services/webflow/WebflowConfigurationService.cfc
@@ -779,22 +779,35 @@ component {
 	}
 
 	private struct function _getExistingSingletonFlowForStartupCheck( required string webflowId ) {
-		var currentSiteId = $getRequestContext().getSiteId();
+		var sitesEnabled = $isFeatureEnabled( "sites" );
 
 		if ( !StructKeyExists( request, "_webflowSingletonsStartupCache" ) ) {
 			request._webflowSingletonsStartupCache = {};
 		}
 
-		if ( !StructKeyExists( request._webflowSingletonsStartupCache, currentSiteId ) ) {
-			request._webflowSingletonsStartupCache[ currentSiteId ] = {};
+		if ( sitesEnabled ) {
+			var currentSiteId = $getRequestContext().getSiteId();
 
-			var rawflows = $getPresideObject( "webflow_configuration" ).selectData( filter="instance_ref is null" );
-			for( var f in rawFlows ) {
-				request._webflowSingletonsStartupCache[ currentSiteId ][ f.webflow_id ] = f;
+			if ( !StructKeyExists( request._webflowSingletonsStartupCache, currentSiteId ) ) {
+				request._webflowSingletonsStartupCache[ currentSiteId ] = {};
+				_populateSingletonFlowCache( request._webflowSingletonsStartupCache[ currentSiteId ] );
 			}
+
+			return request._webflowSingletonsStartupCache[ currentSiteId ][ arguments.webflowId ] ?: {};
 		}
 
-		return request._webflowSingletonsStartupCache[ currentSiteId ][ arguments.webflowId ] ?: {};
+		if ( !StructKeyExists( request._webflowSingletonsStartupCache, arguments.webflowId ) ) {
+			_populateSingletonFlowCache( request._webflowSingletonsStartupCache );
+		}
+
+		return request._webflowSingletonsStartupCache[ arguments.webflowId ] ?: {};
+	}
+
+	private void function _populateSingletonFlowCache( required struct cache ) {
+		var rawflows = $getPresideObject( "webflow_configuration" ).selectData( filter="instance_ref is null" );
+		for( var f in rawFlows ) {
+			arguments.cache[ f.webflow_id ] = f;
+		}
 	}
 
 	private struct function _getExistingNonSingletonFlowForStartupCheck( required string webflowId, required string instanceRef, string siteId="" ) {

--- a/system/services/webflow/WebflowConfigurationService.cfc
+++ b/system/services/webflow/WebflowConfigurationService.cfc
@@ -796,7 +796,7 @@ component {
 			return request._webflowSingletonsStartupCache[ currentSiteId ][ arguments.webflowId ] ?: {};
 		}
 
-		if ( !StructKeyExists( request._webflowSingletonsStartupCache, arguments.webflowId ) ) {
+		if ( StructIsEmpty( request._webflowSingletonsStartupCache ) ) {
 			_populateSingletonFlowCache( request._webflowSingletonsStartupCache );
 		}
 

--- a/system/services/webflow/WebflowConfigurationService.cfc
+++ b/system/services/webflow/WebflowConfigurationService.cfc
@@ -779,16 +779,22 @@ component {
 	}
 
 	private struct function _getExistingSingletonFlowForStartupCheck( required string webflowId ) {
+		var currentSiteId = $getRequestContext().getSiteId();
+
 		if ( !StructKeyExists( request, "_webflowSingletonsStartupCache" ) ) {
 			request._webflowSingletonsStartupCache = {};
+		}
+
+		if ( !StructKeyExists( request._webflowSingletonsStartupCache, currentSiteId ) ) {
+			request._webflowSingletonsStartupCache[ currentSiteId ] = {};
 
 			var rawflows = $getPresideObject( "webflow_configuration" ).selectData( filter="instance_ref is null" );
 			for( var f in rawFlows ) {
-				request._webflowSingletonsStartupCache[ f.webflow_id ] = f;
+				request._webflowSingletonsStartupCache[ currentSiteId ][ f.webflow_id ] = f;
 			}
 		}
 
-		return request._webflowSingletonsStartupCache[ arguments.webflowId ] ?: {};
+		return request._webflowSingletonsStartupCache[ currentSiteId ][ arguments.webflowId ] ?: {};
 	}
 
 	private struct function _getExistingNonSingletonFlowForStartupCheck( required string webflowId, required string instanceRef, string siteId="" ) {

--- a/system/services/webflow/WebflowConfigurationService.cfc
+++ b/system/services/webflow/WebflowConfigurationService.cfc
@@ -779,13 +779,13 @@ component {
 	}
 
 	private struct function _getExistingSingletonFlowForStartupCheck( required string webflowId ) {
-		var sitesEnabled = $isFeatureEnabled( "sites" );
+		var isSiteTenanted = _webflowConfigSiteTenanted();
 
 		if ( !StructKeyExists( request, "_webflowSingletonsStartupCache" ) ) {
 			request._webflowSingletonsStartupCache = {};
 		}
 
-		if ( sitesEnabled ) {
+		if ( isSiteTenanted ) {
 			var currentSiteId = $getRequestContext().getSiteId();
 
 			if ( !StructKeyExists( request._webflowSingletonsStartupCache, currentSiteId ) ) {


### PR DESCRIPTION
- Fix _getExistingSingletonFlowForStartupCheck() to use site-aware caching
  Prevents subsequent sites from using first site's cached webflow config data
- Add WebflowStepOrphanedRecordsFix migration to fix orphaned step foreign keys
  Updates steps pointing to wrong site's config and removes duplicates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes site-tenanted caching for singleton webflow configs and adds a DB migration to repair step FK issues.
> 
> - Adjusts `_getExistingSingletonFlowForStartupCheck()` to cache per-site when site tenancy is enabled; introduces `_populateSingletonFlowCache()` helper to populate cache
> - New migration `WebflowStepOrphanedRecordsFix.cfc`:
>   - Deletes duplicate `webflow_configuration_step` rows when both orphaned and correct-site steps exist
>   - Updates orphaned steps to reference the correct singleton `webflow_configuration` for their site
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61cd14165d00b50a341c8a11a350b646baefc322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->