### PR TITLE
PRESIDECMS-3226 show filtered results from filter rules engine filter buiilder

### DIFF
--- a/system/assets/js/admin/specific/datamanager/object/listingTable.js
+++ b/system/assets/js/admin/specific/datamanager/object/listingTable.js
@@ -53,8 +53,9 @@
 			  , enabledContextHotkeys, refreshFavourites
 			  , lastAjaxResult
 			  , $tableFilter, filterSettings, allowUseFilter=false, allowManageFilter=false, manageFiltersLink=""
-			  , filtersPopulated=false
-			  , hasPreFilters=false;
+			  , filtersPopulated = false
+			  , hasPreFilters    = false
+			  , hasFilterVal     = $filterDiv.find( "[name=filter]" ).val().length > 0;
 
 			if ( allowFilter ) {
 				$tableFilter = $( `#${tableId}-filter` );
@@ -241,6 +242,12 @@
 					},
 					fnFiltersPopulatedCallback: function() {
 						return allowFilter ? filtersPopulated : true;
+					},
+					fnStateLoadParams: function( oSettings, oData ) {
+						if ( hasFilterVal && allowFilter && typeof oData.oFilter !== "undefined" ) {
+							oData.oFilter = undefined;
+						}
+						return oData;
 					},
 					fnCookieCallback: function( sName, oData, sExpires, sPath ) {
 						if ( allowFilter ) {
@@ -491,6 +498,11 @@
 				// toggles between filter mode + basic search mode
 				if ( allowUseFilter ) {
 					$filterLink.on( "click", toggleAdvancedFilter );
+
+					if ( hasFilterVal ) {
+						$filterDiv.removeClass( "hide" );
+						$filterLink.find( "i.fa" ).removeClass( "fa-caret-right" ).addClass( "fa-caret-down" );
+					}
 				}
 
 				// filter change listener

--- a/system/assets/js/admin/specific/datamanager/object/listingTable.js
+++ b/system/assets/js/admin/specific/datamanager/object/listingTable.js
@@ -55,7 +55,7 @@
 			  , $tableFilter, filterSettings, allowUseFilter=false, allowManageFilter=false, manageFiltersLink=""
 			  , filtersPopulated = false
 			  , hasPreFilters    = false
-			  , hasFilterVal     = $filterDiv.find( "[name=filter]" ).val().length > 0;
+			  , hasFilterVal     = $filterDiv.find( "[name=filter]" ).length > 0 && $filterDiv.find( "[name=filter]" ).val().length > 0;
 
 			if ( allowFilter ) {
 				$tableFilter = $( `#${tableId}-filter` );

--- a/system/assets/js/admin/specific/rulesEngineConditionBuilder/conditionBuilder.js
+++ b/system/assets/js/admin/specific/rulesEngineConditionBuilder/conditionBuilder.js
@@ -4,6 +4,7 @@
 	  , defaultRenderFieldEndpoint    = cfrequest.rulesEngineRenderFieldEndpoint   || ""
 	  , defaultEditFieldEndpoint      = cfrequest.rulesEngineEditFieldEndpoint     || ""
 	  , defaultFilterCountEndpoint    = cfrequest.rulesEngineFilterCountEndpoint   || ""
+	  , defaultFilterPreviewEndpoint  = cfrequest.rulesEngineFilterPreviewEndpoint || ""
 	  , defaultContextData            = cfrequest.rulesEngineContextData           || {}
 	  , defaultPreSavedFilters        = cfrequest.rulesEnginePreSavedFilters       || ""
 	  , defaultPreRulesEngineFilters  = cfrequest.rulesEnginePreRulesEngineFilters || ""
@@ -16,10 +17,12 @@
 			, $ruleList
 			, isFilter
 			, $filterCount
+			, $filterPreview
 			, objectName
 			, renderFieldEndpoint
 			, editFieldEndpoint
 			, filterCountEndpoint
+			, filterPreviewEndpoint
 			, contextData
 			, preSavedFilters
 			, preRulesEngineFilters
@@ -35,14 +38,16 @@
 			this.renderFieldEndpoint   = renderFieldEndpoint;
 			this.editFieldEndpoint     = editFieldEndpoint;
 			this.filterCountEndpoint   = filterCountEndpoint;
+			this.filterPreviewEndpoint = filterPreviewEndpoint;
 			this.contextData           = contextData;
 			this.preSavedFilters       = preSavedFilters;
 			this.preRulesEngineFilters = preRulesEngineFilters;
 			this.context               = context;
 
 			if ( this.isFilter ) {
-				this.$filterCount = $filterCount;
-				this.objectName   = objectName;
+				this.$filterCount   = $filterCount;
+				this.$filterPreview = $filterPreview;
+				this.objectName     = objectName;
 			}
 
 			this.setupBehaviors();
@@ -95,6 +100,7 @@
 			var lis, $selectedLi, transformExpressionsToHtmlLis, i, rulesEngineCondition=this;
 
 			this.updateFilterCount();
+			this.updateFilterPreviewUrl();
 
 			transformExpressionsToHtmlLis = function( expressions, depth, index ) {
 				var lis             = []
@@ -183,6 +189,27 @@
 				  this.filterCountEndpoint
 				, postData
 				, function( data ){ conditionBuilder.$filterCount.html( data ).removeClass( "loading" ); }
+			);
+		};
+
+		RulesEngineCondition.prototype.updateFilterPreviewUrl = function() {
+			if ( !this.isFilter || !this.$filterPreview.length ) { return; }
+
+			var conditionBuilder = this
+			  , postData         = this.contextData;
+
+			postData.condition  = this.serialize();
+			postData.objectName = this.objectName;
+
+			conditionBuilder.$filterPreview.attr( "href", "" ).addClass( "disabled" );
+			$.post(
+				  this.filterPreviewEndpoint
+				, postData
+				, function( data ){
+					if ( data.length > 0 ) {
+						conditionBuilder.$filterPreview.attr( "href", data ).removeClass( "disabled" );
+					}
+				}
 			);
 		};
 
@@ -667,6 +694,7 @@
 			  , $conditionPanel   = $builderContainer.find( ".rules-engine-condition-builder-condition-pane" )
 			  , $ruleList         = $builderContainer.find( ".rules-engine-condition-builder-rule-list" )
 			  , $filterCount      = $builderContainer.find( ".rules-engine-condition-builder-filter-count-count" )
+			  , $filterPreview    = $builderContainer.find( ".rules-engine-condition-builder-filter-preview" )
 			  , tabIndex          = $formControl.attr( "tabindex" )
 			  , savedCondition    = $formControl.val()
 			  , isFilter          = $formControl.data( "isFilter" ) || false
@@ -686,6 +714,7 @@
 			  , renderFieldEndpoint
 			  , editFieldEndpoint
 			  , filterCountEndpoint
+			  , filterPreviewEndpoint
 			  , contextData
 			  , preSavedFilters
 			  , preRulesEngineFilters
@@ -739,6 +768,7 @@
 							renderFieldEndpoint   = fieldConfig.rulesEngineRenderFieldEndpoint   || defaultRenderFieldEndpoint;
 							editFieldEndpoint     = fieldConfig.rulesEngineEditFieldEndpoint     || defaultEditFieldEndpoint;
 							filterCountEndpoint   = fieldConfig.rulesEngineFilterCountEndpoint   || defaultFilterCountEndpoint;
+							filterPreviewEndpoint = fieldConfig.rulesEngineFilterPreviewEndpoint || defaultFilterPreviewEndpoint;
 							contextData           = fieldConfig.rulesEngineContextData           || defaultContextData;
 							preSavedFilters       = fieldConfig.rulesEnginePreSavedFilters       || defaultPreSavedFilters;
 							preRulesEngineFilters = fieldConfig.rulesEnginePreRulesEngineFilters || defaultPreRulesEngineFilters;
@@ -760,10 +790,12 @@
 								, $ruleList
 								, isFilter
 								, $filterCount
+								, $filterPreview
 								, objectName
 								, renderFieldEndpoint
 								, editFieldEndpoint
 								, filterCountEndpoint
+								, filterPreviewEndpoint
 								, contextData
 								, preSavedFilters
 								, preRulesEngineFilters

--- a/system/handlers/admin/RulesEngine.cfc
+++ b/system/handlers/admin/RulesEngine.cfc
@@ -162,6 +162,18 @@ component extends="preside.system.base.AdminHandler" {
 		event.renderData( data=NumberFormat( count ), type="text" );
 	}
 
+	public void function getFilterPreviewUrl( event, rc, prc ) {
+		var expressions = rc.condition ?: "";
+		var objectName  = rc.objectName ?: "";
+		var previewUrl  = "";
+
+		if ( Len( objectName ) && Len( expressions ) ) {
+			previewUrl = event.buildAdminLink( objectName=objectName, queryString="filter=#UrlEncode( ToBase64( expressions ) )#" );
+		}
+
+		event.renderData( data=previewUrl, type="text" );
+	}
+
 	public void function quickAddConditionForm( event, rc, prc ) {
 		prc.modalClasses = "modal-dialog-less-padding";
 		prc.contextData  = {};

--- a/system/handlers/formcontrols/RulesEngineFilterBuilder.cfc
+++ b/system/handlers/formcontrols/RulesEngineFilterBuilder.cfc
@@ -2,7 +2,8 @@
  * @feature presideForms and rulesEngine
  */
 component {
-	property name="expressionService" inject="rulesEngineExpressionService";
+	property name="expressionService"    inject="rulesEngineExpressionService";
+	property name="customizationService" inject="dataManagerCustomizationService";
 
 	private string function index( event, rc, prc, args={} ) {
 		args.object      = args.object      ?: ( rc.filter_object ?: "" );
@@ -30,6 +31,23 @@ component {
 				, rulesEnginePreRulesEngineFilters = args.preRulesEngineFilters ?: ""
 			}
 		};
+
+		var hasReadPermission = customizationService.runCustomization(
+			  objectName     = args.object
+			, action         = "checkPermission"
+			, defaultHandler = "admin.datamanager._checkPermissionDefault"
+			, args           = {
+				  key             = "read"
+				, object          = args.object
+				, throwOnError    = false
+				, checkOperations = true
+			}
+		);
+
+		args.showPreview = isTrue( args.showPreview ?: args.isFilter ) && hasReadPermission;
+		if ( args.showPreview ) {
+			expressionData.rulesEngineFilterPreviewEndpoint = event.buildAdminLink( linkTo="rulesengine.getFilterPreviewUrl" );
+		}
 
 		event.include( "/js/admin/specific/rulesEngineConditionBuilder/"  )
 			 .include( "/css/admin/specific/rulesEngineConditionBuilder/" )

--- a/system/handlers/formcontrols/RulesEngineFilterBuilder.cfc
+++ b/system/handlers/formcontrols/RulesEngineFilterBuilder.cfc
@@ -46,7 +46,7 @@ component {
 
 		args.showPreview = isTrue( args.showPreview ?: args.isFilter ) && hasReadPermission;
 		if ( args.showPreview ) {
-			expressionData.rulesEngineFilterPreviewEndpoint = event.buildAdminLink( linkTo="rulesengine.getFilterPreviewUrl" );
+			expressionData[ "filter-builder-#fieldId#" ].rulesEngineFilterPreviewEndpoint = event.buildAdminLink( linkTo="rulesengine.getFilterPreviewUrl" );
 		}
 
 		event.include( "/js/admin/specific/rulesEngineConditionBuilder/"  )

--- a/system/i18n/cms.properties
+++ b/system/i18n/cms.properties
@@ -1639,6 +1639,7 @@ rulesEngine.time.period.type.futureplus.configured=at least {1} {2} from now
 rulesEngine.time.period.type.futureequal.configured=exactly {1} {2} in the future
 
 rulesEngine.filter.builder.record.count.message=Matching records: {1}
+rulesEngine.filter.builder.record.preview.label=Preview
 
 rulesEngine.condition.builder.condition.pane.title=Edit condition
 rulesEngine.condition.builder.expressions.pane.title=Expression library (drag and drop to add)

--- a/system/views/admin/datamanager/_objectDataTable.cfm
+++ b/system/views/admin/datamanager/_objectDataTable.cfm
@@ -126,6 +126,7 @@
 							, layout      = ""
 							, compact     = true
 							, showCount   = false
+							, showPreview = false
 						)#
 
 						<cfif allowManageFilter>

--- a/system/views/formcontrols/rulesEngineConditionBuilder/index.cfm
+++ b/system/views/formcontrols/rulesEngineConditionBuilder/index.cfm
@@ -17,7 +17,11 @@
 	if ( !IsSimpleValue( value ) ) {
 		value = "";
 	} else {
-		value = ToString( ToBinary( UrlDecode( value ) ) );
+		try {
+			value = ToString( ToBinary( UrlDecode( value ) ) );
+		} catch ( any e ) {
+			// fallback when it's not valid base64
+		}
 	}
 
 	value = EncodeForHtmlAttribute( value );

--- a/system/views/formcontrols/rulesEngineConditionBuilder/index.cfm
+++ b/system/views/formcontrols/rulesEngineConditionBuilder/index.cfm
@@ -9,12 +9,15 @@
 	maxLength    = Val( args.maxLength ?: 0 );
 	isFilter     = IsTrue( args.isFilter ?: "" ) ? "true" : "false"; // deliberate stringifying of booleans here
 	showCount    = IsTrue( args.showCount ?: isFilter );
+	showPreview  = IsTrue( args.showPreview ?: "" );
 	object       = args.object ?: "";
 	compact      = IsTrue( args.compact ?: "" );
 
 	value = event.getValue( name=inputName, defaultValue=defaultValue );
 	if ( !IsSimpleValue( value ) ) {
 		value = "";
+	} else {
+		value = ToString( ToBinary( UrlDecode( value ) ) );
 	}
 
 	value = EncodeForHtmlAttribute( value );
@@ -56,10 +59,21 @@
 					</div>
 				</div>
 			</div>
-			<cfif showCount>
+			<cfif showCount || showPreview>
 				<div class="row">
 					<div class="col-md-12">
-						<p class="grey rules-engine-condition-builder-filter-count">#translateResource( uri="cms:rulesEngine.filter.builder.record.count.message", data=[ '<span class="rules-engine-condition-builder-filter-count-count">0</span>'] )#</p>
+						<p class="grey rules-engine-condition-builder-filter-count">
+							<cfif showCount>
+								#translateResource( uri="cms:rulesEngine.filter.builder.record.count.message", data=[ '<span class="rules-engine-condition-builder-filter-count-count">0</span>'] )#
+							</cfif>
+
+							<cfif showPreview>
+								<a class="btn btn-link btn-link-info rules-engine-condition-builder-filter-preview" href="##" target="_blank">
+									<i class="fa fa-fw fa-external-link-alt"></i>
+									#translateResource( uri="cms:rulesEngine.filter.builder.record.preview.label" )#
+								</a>
+							</cfif>
+						</p>
 					</div>
 				</div>
 			</cfif>

--- a/system/views/formcontrols/rulesEngineConditionBuilder/index.cfm
+++ b/system/views/formcontrols/rulesEngineConditionBuilder/index.cfm
@@ -18,7 +18,7 @@
 		value = "";
 	} else {
 		try {
-			value = ToString( ToBinary( UrlDecode( value ) ) );
+			value = IsJSON( value ) ? value : ToString( ToBinary( UrlDecode( value ) ) );
 		} catch ( any e ) {
 			// fallback when it's not valid base64
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a lightweight preview of filtered results and refines filter state behavior.
> 
> - Adds `rulesEngineFilterPreviewEndpoint` and UI link in the filter builder; JS posts current condition to get a preview URL, enabling the link when available
> - New backend handler `RulesEngine.getFilterPreviewUrl` returns an admin URL (base64/URL-encoded filter) for previewing results; view decodes incoming base64 filter if needed
> - Shows the filter panel expanded when a filter value is present and suppresses restoring saved filter state via DataTables when an explicit filter is provided
> - Permissions: preview link shown only when read permission is granted
> - i18n: adds `rulesEngine.filter.builder.record.preview.label`; datamanager object table explicitly disables preview in that context
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcc8167e01128804d0eda12de1ee46e64ba413ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->