### PR TITLE
PRESIDECMS-3227 admin filter segmentations for dynamic tag rendering

### DIFF
--- a/system/assets/css/admin/specific/datamanager/segmentationTags/segmentationTags.less
+++ b/system/assets/css/admin/specific/datamanager/segmentationTags/segmentationTags.less
@@ -1,3 +1,5 @@
+@import url( 'globals.less' );
+
 .presidecms {
 	.segmentation-tags {
 		display    : flex;
@@ -10,7 +12,9 @@
 			overflow      : hidden;
 			text-overflow : ellipsis;
 			padding       : .25em .75em;
+			border        : 1px solid;
 			border-radius : 3em;
+			color         : @blue;
 		}
 	}
 }

--- a/system/assets/css/admin/specific/datamanager/segmentationTags/segmentationTags.less
+++ b/system/assets/css/admin/specific/datamanager/segmentationTags/segmentationTags.less
@@ -1,0 +1,16 @@
+.presidecms {
+	.segmentation-tags {
+		display    : flex;
+		flex-wrap  : wrap;
+		gap        : .5em;
+		margin-top : 12px;
+
+		.segmentation-tag {
+			white-space   : nowrap;
+			overflow      : hidden;
+			text-overflow : ellipsis;
+			padding       : .25em .75em;
+			border-radius : 3em;
+		}
+	}
+}

--- a/system/assets/js/admin/specific/rulesEngine/toggleTagSection/toggleTagSection.js
+++ b/system/assets/js/admin/specific/rulesEngine/toggleTagSection/toggleTagSection.js
@@ -1,0 +1,22 @@
+( function( $ ){
+
+	var $tagToggleInput = $( "[name=segmentation_tag_enabled]" )
+	  , $form           = $tagToggleInput.length ? $tagToggleInput.closest( "form" ) : [];
+
+	if ( $form.length ) {
+		var $tagToggleConfigFieldset = $form.find( "#fieldset-tag_config" )
+		  , toggleConfigFieldSet;
+
+		toggleConfigFieldSet = function(){
+			if ( $tagToggleInput.is( ":checked" ) ) {
+				$tagToggleConfigFieldset.show( "fast" );
+			} else {
+				$tagToggleConfigFieldset.hide( "fast" );
+			}
+		};
+
+		$form.on( "click change", "[name=segmentation_tag_enabled]", toggleConfigFieldSet );
+		toggleConfigFieldSet();
+	}
+
+} )( presideJQuery );

--- a/system/forms/preside-objects/rules_engine_condition/admin.add.segmentation.filter.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.add.segmentation.filter.xml
@@ -30,8 +30,8 @@ This form is used for creating a segmentation filter
 			<field binding="rules_engine_condition.segmentation_tag_enabled" sortorder="10" />
 		</fieldset>
 		<fieldset id="tag_config" sortorder="20">
-			<field binding="rules_engine_condition.segmentation_tag_label"   sortorder="20" />
-			<field binding="rules_engine_condition.segmentation_tag_colour"  sortorder="30" />
+			<field binding="rules_engine_condition.segmentation_tag_label" sortorder="10" />
+			<field binding="rules_engine_condition.segmentation_tag_icon"  sortorder="20" />
 		</fieldset>
 	</tab>
 </form>

--- a/system/forms/preside-objects/rules_engine_condition/admin.add.segmentation.filter.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.add.segmentation.filter.xml
@@ -25,4 +25,13 @@ This form is used for creating a segmentation filter
 			<field binding="rules_engine_condition.locked_reason" control="textarea" />
 		</fieldset>
 	</tab>
+	<tab id="tag" sortorder="30">
+		<fieldset id="tag" sortorder="10">
+			<field binding="rules_engine_condition.segmentation_tag_enabled" sortorder="10" />
+		</fieldset>
+		<fieldset id="tag_config" sortorder="20">
+			<field binding="rules_engine_condition.segmentation_tag_label"   sortorder="20" />
+			<field binding="rules_engine_condition.segmentation_tag_colour"  sortorder="30" />
+		</fieldset>
+	</tab>
 </form>

--- a/system/forms/preside-objects/rules_engine_condition/admin.clone.filter.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.clone.filter.xml
@@ -15,4 +15,13 @@ This form is used for cloning a rules engine condition
 			</field>
 		</fieldset>
 	</tab>
+	<tab id="tag" sortorder="20">
+		<fieldset id="tag" sortorder="10">
+			<field binding="rules_engine_condition.segmentation_tag_enabled" sortorder="10" />
+		</fieldset>
+		<fieldset id="tag_config" sortorder="20">
+			<field binding="rules_engine_condition.segmentation_tag_label"   sortorder="20" />
+			<field binding="rules_engine_condition.segmentation_tag_colour"  sortorder="30" />
+		</fieldset>
+	</tab>
 </form>

--- a/system/forms/preside-objects/rules_engine_condition/admin.clone.filter.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.clone.filter.xml
@@ -20,8 +20,8 @@ This form is used for cloning a rules engine condition
 			<field binding="rules_engine_condition.segmentation_tag_enabled" sortorder="10" />
 		</fieldset>
 		<fieldset id="tag_config" sortorder="20">
-			<field binding="rules_engine_condition.segmentation_tag_label"   sortorder="20" />
-			<field binding="rules_engine_condition.segmentation_tag_colour"  sortorder="30" />
+			<field binding="rules_engine_condition.segmentation_tag_label" sortorder="10" />
+			<field binding="rules_engine_condition.segmentation_tag_icon"  sortorder="20" />
 		</fieldset>
 	</tab>
 </form>

--- a/system/forms/preside-objects/rules_engine_condition/admin.edit.segmentation.filter.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.edit.segmentation.filter.xml
@@ -29,8 +29,8 @@ This form is used for editing segmentation filters
 			<field binding="rules_engine_condition.segmentation_tag_enabled" sortorder="10" />
 		</fieldset>
 		<fieldset id="tag_config" sortorder="20">
-			<field binding="rules_engine_condition.segmentation_tag_label"   sortorder="20" />
-			<field binding="rules_engine_condition.segmentation_tag_colour"  sortorder="30" />
+			<field binding="rules_engine_condition.segmentation_tag_label" sortorder="10" />
+			<field binding="rules_engine_condition.segmentation_tag_icon"  sortorder="20" />
 		</fieldset>
 	</tab>
 </form>

--- a/system/forms/preside-objects/rules_engine_condition/admin.edit.segmentation.filter.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.edit.segmentation.filter.xml
@@ -24,4 +24,13 @@ This form is used for editing segmentation filters
 			<field binding="rules_engine_condition.locked_reason" control="textarea" />
 		</fieldset>
 	</tab>
+	<tab id="tag" sortorder="30">
+		<fieldset id="tag" sortorder="10">
+			<field binding="rules_engine_condition.segmentation_tag_enabled" sortorder="10" />
+		</fieldset>
+		<fieldset id="tag_config" sortorder="20">
+			<field binding="rules_engine_condition.segmentation_tag_label"   sortorder="20" />
+			<field binding="rules_engine_condition.segmentation_tag_colour"  sortorder="30" />
+		</fieldset>
+	</tab>
 </form>

--- a/system/forms/preside-objects/rules_engine_condition/admin.tag.disabled.xml
+++ b/system/forms/preside-objects/rules_engine_condition/admin.tag.disabled.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<tab id="tag" deleted="true" />
+</form>

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -1602,6 +1602,21 @@ component extends="preside.system.base.AdminHandler" {
 		);
 	}
 
+	private string function _objectSegmentationTags( event, rc, prc, args={} ) {
+		args.recordId   = args.recordId   ?: ( prc.recordId   ?: "" );
+		args.objectName = args.objectName ?: ( prc.objectName ?: "" );
+
+		if ( !rulesEngineFilterService.objectSupportsSegmentationTag( objectName=args.objectName ) && !Len( args.recordId ) ) {
+			return "";
+		}
+
+		args.segmentationTags = rulesEngineFilterService.getObjectRecordSegmentationTags( objectName=args.objectName, recordId=args.recordId );
+
+		event.include( "/css/admin/specific/datamanager/segmentationTags/" );
+
+		return renderView( view="admin/datamanager/_objectSegmentationTags", args=args );
+	}
+
 	public void function addSegmentationFilter( event, rc, prc ) {
 		var objectName = prc.objectName ?: "";
 		var useSegmentationFilters = rulesEngineFilterService.objectSupportsSegmentationFilters( objectName );
@@ -1619,6 +1634,12 @@ component extends="preside.system.base.AdminHandler" {
 		prc.formName     = "preside-objects.rules_engine_condition.admin.add.segmentation.filter";
 		prc.submitAction = event.buildAdminLink( linkto="datamanager.addSegmentationFilterAction" );
 		prc.cancelAction = event.buildAdminLink( linkto="datamanager.manageFilters", queryString="object=#objectName#&tab=segmentation")
+
+		if ( rulesEngineFilterService.objectSupportsSegmentationTag( objectName=objectName ) ) {
+			event.include( "/js/admin/specific/rulesEngine/toggleTagSection/" );
+		} else {
+			prc.formName = formsService.getMergedFormName( prc.formName, "preside-objects.rules_engine_condition.admin.tag.disabled" );
+		}
 
 		event.addAdminBreadCrumb(
 			  title = translateResource( uri="cms:datamanager.managefilters.breadcrumb.title" )

--- a/system/handlers/admin/datamanager/rules_engine_condition.cfc
+++ b/system/handlers/admin/datamanager/rules_engine_condition.cfc
@@ -575,6 +575,12 @@ component extends="preside.system.base.AdminHandler" {
 
 			if ( isTrue( prc.record.is_segmentation_filter ?: "" ) ) {
 				formName = "preside-objects.rules_engine_condition.admin.edit.segmentation.filter";
+
+				if ( rulesEngineFilterService.objectSupportsSegmentationTag( objectName=rc.filter_object ) ) {
+					event.include( "/js/admin/specific/rulesEngine/toggleTagSection/" );
+				} else {
+					formName = formsService.getMergedFormName( formName, "preside-objects.rules_engine_condition.admin.tag.disabled" );
+				}
 			} else {
 				formName = "preside-objects.rules_engine_condition.admin.edit.filter";
 			}

--- a/system/handlers/renderers/content/RulesEngineSegmentationTag.cfc
+++ b/system/handlers/renderers/content/RulesEngineSegmentationTag.cfc
@@ -1,0 +1,38 @@
+/**
+ * @feature rulesEngine
+ */
+component {
+
+	private string function adminView( event, rc, prc, args={} ){
+		var recordId = Trim( args.data ?: ( args.record.id ?: "" ) );
+
+		if ( Len( recordId ) ) {
+			var recordDetail = getPresideObject( "rules_engine_condition" ).selectData(
+				  id           = recordId
+				, returntype   = "singleRecordStruct"
+				, selectFields = [
+					  "id"
+					, "segmentation_tag_enabled AS tag_enabled"
+					, "segmentation_tag_icon AS tag_icon"
+					, "COALESCE( segmentation_tag_label, condition_name ) AS tag_label"
+				]
+			);
+
+			if ( isTrue( recordDetail.tag_enabled ?: "" ) ) {
+				var renderedTag = recordDetail.tag_label;
+				if ( Len( recordDetail.tag_icon ?: "" ) ) {
+					renderedTag = '<i class="fa fa-fw fa-#recordDetail.tag_icon#"></i>&nbsp;' & renderedTag;
+				}
+
+				return '<span class="badge badge-primary segmentation-tag">#renderedTag#</span>'
+			} else {
+				return '<span class="text-muted">#translateResource( uri="cms:not.applicable" )#</span>'
+			}
+		}
+		return "";
+	}
+
+	private string function adminDatatable( event, rc, prc, args={} ){
+		return adminView( argumentCollection=arguments );
+	}
+}

--- a/system/helpers/presideProxies.cfm
+++ b/system/helpers/presideProxies.cfm
@@ -353,6 +353,20 @@
 		</cfscript>
 	</cfsilent></cffunction>
 
+	<cffunction name="objectSegmentationTags" access="public" returntype="any" output="false">
+		<cfargument name="objectName" type="string" required="true" />
+		<cfargument name="recordId"   type="string" required="true" /><cfsilent>
+
+		<cfscript>
+			return getSingleton( "dataManagerCustomizationService" ).runCustomization(
+				  objectName     = arguments.objectName
+				, args           = arguments
+				, action         = "renderSegmentationTags"
+				, defaultHandler = "admin.DataManager._objectSegmentationTags"
+			);
+		</cfscript>
+	</cfsilent></cffunction>
+
 <!--- healthchecks --->
 	<cffunction name="isUp" access="public" returntype="any" output="false">
 		<cfargument name="serviceId" type="string" required="true" /><cfsilent>

--- a/system/i18n/preside-objects/rules_engine_condition.properties
+++ b/system/i18n/preside-objects/rules_engine_condition.properties
@@ -12,6 +12,8 @@ tab.filterdefault.title=Filter definition
 tab.filterdefault.iconClass=fa-pencil blue
 tab.sharing.title=Favourites and sharing
 tab.sharing.iconClass=fa-heart red
+tab.tag.title=Segment tag
+tab.tag.iconClass=fa-tag green
 
 fieldset.superquickbasic.title=Labelling
 fieldset.sharing.title=Sharing options
@@ -64,6 +66,11 @@ field.segmentation_last_time_taken.title=Time taken (ms)
 field.segmentation_last_time_taken.listing.title=Time taken
 field.clone_children.title=Clone child filters?
 field.clone_children.help=If checked, we will clone all children of the current filter into the new filter.
+
+field.segmentation_tag_enabled.title=Tag enabled?
+field.segmentation_tag_label.title=Tag label
+field.segmentation_tag_label.placeholder=(leave empty for use filter name)
+field.segmentation_tag_colour.title=Tag colour
 
 renderer.error.no.expressions=There was a problem displaying the expressions for this condition/filter.
 condition.is.locked=This record has been locked for editing

--- a/system/i18n/preside-objects/rules_engine_condition.properties
+++ b/system/i18n/preside-objects/rules_engine_condition.properties
@@ -70,7 +70,9 @@ field.clone_children.help=If checked, we will clone all children of the current 
 field.segmentation_tag_enabled.title=Tag enabled?
 field.segmentation_tag_label.title=Tag label
 field.segmentation_tag_label.placeholder=(leave empty to use filter name)
-field.segmentation_tag_colour.title=Tag colour
+field.segmentation_tag_icon.title=Tag icon
+field.segmentation_tag_preview.title=Segmentation tag
+field.segmentation_tag_preview.listing.title=Tag
 
 renderer.error.no.expressions=There was a problem displaying the expressions for this condition/filter.
 condition.is.locked=This record has been locked for editing

--- a/system/i18n/preside-objects/rules_engine_condition.properties
+++ b/system/i18n/preside-objects/rules_engine_condition.properties
@@ -69,7 +69,7 @@ field.clone_children.help=If checked, we will clone all children of the current 
 
 field.segmentation_tag_enabled.title=Tag enabled?
 field.segmentation_tag_label.title=Tag label
-field.segmentation_tag_label.placeholder=(leave empty for use filter name)
+field.segmentation_tag_label.placeholder=(leave empty to use filter name)
 field.segmentation_tag_colour.title=Tag colour
 
 renderer.error.no.expressions=There was a problem displaying the expressions for this condition/filter.

--- a/system/preside-objects/rulesEngine/rules_engine_condition.cfc
+++ b/system/preside-objects/rulesEngine/rules_engine_condition.cfc
@@ -40,7 +40,8 @@ component extends="preside.system.base.SystemPresideObject" displayName="Rules e
 
 	property name="segmentation_tag_enabled" type="boolean" dbtype="boolean" default=false;
 	property name="segmentation_tag_label"   type="string"  dbtype="varchar" maxlength=200 control="textInput";
-	property name="segmentation_tag_colour"  type="string"  dbtype="varchar" maxlength=10  control="simpleColourPicker" palette="material" renderer="colourSwatch";
+	property name="segmentation_tag_icon"    type="string"  dbtype="varchar" maxlength=50  control="iconPicker" includeEmptyOption="true";
+	property name="segmentation_tag_preview" type="string"  formula="${prefix}id" renderer="rulesEngineSegmentationTag";
 
 	// helper formula fields for displays
 	property name="kind" type="string" formula="case when ${prefix}filter_object is null then 'condition' else 'filter' end" autofilter="false" renderer="enumlabel" enum="rulesEngineConditionType" control="none";

--- a/system/preside-objects/rulesEngine/rules_engine_condition.cfc
+++ b/system/preside-objects/rulesEngine/rules_engine_condition.cfc
@@ -38,6 +38,10 @@ component extends="preside.system.base.SystemPresideObject" displayName="Rules e
 	property name="segmentation_last_count"       type="numeric" dbtype="int" required=false default=0 batcheditable=false ignoreChangesForVersioning=true;
 	property name="segmentation_last_time_taken"  type="numeric" dbtype="int" required=false default=0 batcheditable=false ignoreChangesForVersioning=true renderer="taskTimeTaken";
 
+	property name="segmentation_tag_enabled" type="boolean" dbtype="boolean" default=false;
+	property name="segmentation_tag_label"   type="string"  dbtype="varchar" maxlength=200 control="textInput";
+	property name="segmentation_tag_colour"  type="string"  dbtype="varchar" maxlength=10  control="simpleColourPicker" palette="material" renderer="colourSwatch";
+
 	// helper formula fields for displays
 	property name="kind" type="string" formula="case when ${prefix}filter_object is null then 'condition' else 'filter' end" autofilter="false" renderer="enumlabel" enum="rulesEngineConditionType" control="none";
 	property name="applies_to" type="string" formula="coalesce( ${prefix}filter_object, ${prefix}context )" renderer="rulesEngineAppliesTo"  autofilter="false" control="none";

--- a/system/services/rulesEngine/RulesEngineFilterService.cfc
+++ b/system/services/rulesEngine/RulesEngineFilterService.cfc
@@ -365,7 +365,7 @@ component displayName="Rules Engine Filter Service" {
 			}
 			, selectFields = [
 				  "filter.id"
-				, "filter.segmentation_tag_colour AS tag_colour"
+				, "filter.segmentation_tag_icon AS tag_icon"
 				, "COALESCE( filter.segmentation_tag_label, filter.condition_name ) AS tag_label"
 			]
 		);

--- a/system/services/rulesEngine/RulesEngineFilterService.cfc
+++ b/system/services/rulesEngine/RulesEngineFilterService.cfc
@@ -340,6 +340,37 @@ component displayName="Rules Engine Filter Service" {
 		return Len( idField ) && (!IsBoolean( useSegmentation ) || useSegmentation );
 	}
 
+	public boolean function objectSupportsSegmentationTag( required string objectName ) {
+		if ( !objectSupportsSegmentationFilters( objectName=arguments.objectName ) ) {
+			return false;
+		}
+
+		var useSegmentationTag = $getPresideObjectService().getObjectAttribute(
+			  objectName    = arguments.objectName
+			, attributeName = "datamanagerUseSegmentationTag"
+		);
+
+		return IsBoolean( useSegmentationTag ) && useSegmentationTag;
+	}
+
+	public query function getObjectRecordSegmentationTags(
+		  required string objectName
+		, required string recordId
+	) {
+		return $getPresideObject( "rules_engine_filter_data" ).selectData(
+			  filter       = {
+				  "rules_engine_filter_data.object_name" = arguments.objectName
+				, "rules_engine_filter_data.record_id"   = arguments.recordId
+				, "filter.segmentation_tag_enabled"      = true
+			}
+			, selectFields = [
+				  "filter.id"
+				, "filter.segmentation_tag_colour AS tag_colour"
+				, "COALESCE( filter.segmentation_tag_label, filter.condition_name ) AS tag_label"
+			]
+		);
+	}
+
 	public query function getSegmentationFilter( required string filterId ) {
 		return $getPresideObject( "rules_engine_condition" ).selectData(
 			  filter       = "id = :id and is_segmentation_filter = :is_segmentation_filter and filter_object is not null"

--- a/system/views/admin/datamanager/_objectSegmentationTags.cfm
+++ b/system/views/admin/datamanager/_objectSegmentationTags.cfm
@@ -9,7 +9,7 @@
 			<cfloop query="#segmentationTags#">
 				<cfif Len( segmentationTags.tag_label ?: "" )>
 					<span class="segmentation-tag"
-						<cfif Len( segmentationTags.tag_colour ?: "" ) AND ( segmentationTags.tag_colour != "##ffffff" )>
+						<cfif Len( segmentationTags.tag_colour ?: "" ) and ( segmentationTags.tag_colour neq "##ffffff" )>
 							style="background-color: #segmentationTags.tag_colour#; color: white;"
 						</cfif>
 					>

--- a/system/views/admin/datamanager/_objectSegmentationTags.cfm
+++ b/system/views/admin/datamanager/_objectSegmentationTags.cfm
@@ -8,11 +8,10 @@
 		<div class="segmentation-tags">
 			<cfloop query="#segmentationTags#">
 				<cfif Len( segmentationTags.tag_label ?: "" )>
-					<span class="segmentation-tag"
-						<cfif Len( segmentationTags.tag_colour ?: "" ) and ( segmentationTags.tag_colour neq "##ffffff" )>
-							style="background-color: #segmentationTags.tag_colour#; color: white;"
+					<span class="segmentation-tag">
+						<cfif Len( segmentationTags.tag_icon ?: "" )>
+							<i class="fa fa-fw fa-#segmentationTags.tag_icon#"></i>
 						</cfif>
-					>
 						#segmentationTags.tag_label#
 					</span>
 				</cfif>

--- a/system/views/admin/datamanager/_objectSegmentationTags.cfm
+++ b/system/views/admin/datamanager/_objectSegmentationTags.cfm
@@ -1,0 +1,22 @@
+<!---@feature admin--->
+<cfscript>
+	segmentationTags = args.segmentationTags ?: QueryNew( "" );
+</cfscript>
+
+<cfoutput>
+	<cfif segmentationTags.recordcount>
+		<div class="segmentation-tags">
+			<cfloop query="#segmentationTags#">
+				<cfif Len( segmentationTags.tag_label ?: "" )>
+					<span class="segmentation-tag"
+						<cfif Len( segmentationTags.tag_colour ?: "" ) AND ( segmentationTags.tag_colour != "##ffffff" )>
+							style="background-color: #segmentationTags.tag_colour#; color: white;"
+						</cfif>
+					>
+						#segmentationTags.tag_label#
+					</span>
+				</cfif>
+			</cfloop>
+		</div>
+	</cfif>
+</cfoutput>

--- a/system/views/admin/datamanager/manageSegmentationFilters.cfm
+++ b/system/views/admin/datamanager/manageSegmentationFilters.cfm
@@ -13,7 +13,7 @@
 		#objectDataTable( objectName="rules_engine_condition", args={
 			  usesTreeView = true
 			, treeOnly     = true
-			, gridFields   = [ "condition_name", "segmentation_last_count", "segmentation_last_calculation", "segmentation_last_time_taken" ]
+			, gridFields   = [ "condition_name", "segmentation_tag_preview", "segmentation_last_count", "segmentation_last_calculation", "segmentation_last_time_taken" ]
 		} )#
 	<cfelse>
 		<p class="alert alert-warning">

--- a/system/views/formcontrols/iconPicker/index.cfm
+++ b/system/views/formcontrols/iconPicker/index.cfm
@@ -7,6 +7,7 @@
 	defaultValue = args.defaultValue ?: "";
 	savedValue   = args.savedValue   ?: "";
 
+	includeEmptyOption = IsTrue( args.includeEmptyOption ?: "" );
 	resultTemplate     = selectedTemplate = '<i class="fa {{classes}}"></i> {{text}}';
 	resultTemplateId   = "result_template_"   & CreateUUID();
 	selectedTemplateId = "selected_template_" & CreateUUID();
@@ -47,6 +48,9 @@
 			data-display-limit="#ArrayLen( icons )#"
 			#htmlAttributes#
 	>
+		<cfif includeEmptyOption>
+			<option value=""></option>
+		</cfif>
 		<cfloop item="icon" array="#icons#">
 			<cfset selected=ListFind( value, icon ) />
 			<option


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces optional segmentation tags for rules engine segmentation filters and displays them across the admin UI.
> 
> - Adds `segmentation_tag_enabled`, `segmentation_tag_label`, `segmentation_tag_icon`, and `segmentation_tag_preview` fields to `rules_engine_condition` (with icon picker and preview renderer)
> - New UI: tag config tab in add/edit/clone forms; JS (`toggleTagSection.js`) to show/hide config; CSS for tag badges; i18n strings for labels
> - Renders tags: new renderer `RulesEngineSegmentationTag` and datatable column `segmentation_tag_preview`; viewlet `_objectSegmentationTags.cfm` for record pages
> - Services: `objectSupportsSegmentationTag()` (gated by `datamanagerUseSegmentationTag`) and `getObjectRecordSegmentationTags()`; DataManager integrates viewlet and conditionally merges a disabled tag form when unsupported; helper proxy method `objectSegmentationTags()`
> - Enhances `iconPicker` control to allow an empty option
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2945e198cba80d1d37c3c861e1704fb8394b40e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->