### PR TITLE
Feature presidecms 2926 500 error when user uploads large file and hit validation error

### DIFF
--- a/system/helpers/structUtils.cfm
+++ b/system/helpers/structUtils.cfm
@@ -14,3 +14,55 @@
 		return result;
 	</cfscript>
 </cfsilent></cffunction>
+
+<cffunction name="cleanStruct" access="private" returntype="void" output="false">
+	<cfargument name="strct" type="struct" required="true" /><cfsilent>
+
+	<cfscript>
+		for( var key in arguments.strct ) {
+			if ( IsSimpleValue( arguments.strct[ key ] ) ) {
+				continue;
+			}
+			if ( IsStruct( arguments.strct[ key ] ) ) {
+				cleanStruct( arguments.strct[ key ] );
+				continue;
+			}
+
+			if ( IsArray( arguments.strct[ key ] ) ) {
+				var isByteArray = isinstanceof(arguments.strct[key], "byte[]");
+				if ( !isByteArray ) {
+					cleanArray( arguments.strct[ key ] );
+					continue;
+				}
+			}
+
+			StructDelete( arguments.strct, key );
+		}
+	</cfscript>
+</cfsilent></cffunction>
+
+<cffunction name="cleanArray" access="private" returntype="void" output="false">
+	<cfargument name="arr" type="array" required="true" /><cfsilent>
+	<cfscript>
+		for ( var i=ArrayLen( arguments.arr ); i>0; i-- ) {
+			var item = arguments.arr[ i ];
+			if ( IsSimpleValue( item ) ) {
+				continue;
+			}
+			if ( IsStruct( item ) ) {
+				cleanStruct( item );
+				continue;
+			}
+			if ( IsArray( item ) ) {
+				var isByteArray = isinstanceof(item, "byte[]");
+				if ( !isByteArray ) {
+					cleanArray( item );
+					continue;
+				}
+				ArrayDeleteAt( arguments.arr, i );
+			}
+
+			ArrayDelete( arguments.arr, i );
+		}
+	</cfscript>
+</cfsilent></cffunction>

--- a/system/helpers/structUtils.cfm
+++ b/system/helpers/structUtils.cfm
@@ -59,7 +59,6 @@
 					cleanArray( item );
 					continue;
 				}
-				ArrayDeleteAt( arguments.arr, i );
 			}
 
 			ArrayDeleteAt( arguments.arr, i );

--- a/system/helpers/structUtils.cfm
+++ b/system/helpers/structUtils.cfm
@@ -62,7 +62,7 @@
 				ArrayDeleteAt( arguments.arr, i );
 			}
 
-			ArrayDelete( arguments.arr, i );
+			ArrayDeleteAt( arguments.arr, i );
 		}
 	</cfscript>
 </cfsilent></cffunction>

--- a/system/services/cfmlscopes/SessionStorage.cfc
+++ b/system/services/cfmlscopes/SessionStorage.cfc
@@ -42,6 +42,15 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 			var expiry = expiry=_getUnixTimeStamp() + _getSessionTimeoutInSeconds();
 
 			StructDelete( storage, "sessionId" );
+
+			for ( var key in storage.cbox_flash_scope ?: {} ) {
+				if ( IsStruct( storage.cbox_flash_scope[ key ] ) ) {
+					if ( StructKeyExists( storage.cbox_flash_scope[ key ], "content" ) && IsStruct( storage.cbox_flash_scope[ key ].content ) ) {
+						StructDelete( storage.cbox_flash_scope[ key ].content, "binary" );
+					}
+				}
+			}
+
 			var value = SerializeJson( storage );
 
 			if ( Len( Trim( sessionId ) ) ) {

--- a/system/services/cfmlscopes/SessionStorage.cfc
+++ b/system/services/cfmlscopes/SessionStorage.cfc
@@ -43,7 +43,7 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 
 			StructDelete( storage, "sessionId" );
 
-			_cleanStruct( storage );
+			$helpers.cleanStruct( storage );
 
 
 			var value = SerializeJson( storage );
@@ -258,48 +258,4 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 		return IsBoolean( request._presideSessionUsed ?: "" ) && request._presideSessionUsed;
 	}
 
-	private void function _cleanStruct( required struct strct ) {
-		for( var key in arguments.strct ) {
-			if ( IsSimpleValue( arguments.strct[ key ] ) ) {
-				continue;
-			}
-			if ( IsStruct( arguments.strct[ key ] ) ) {
-				_cleanStruct( arguments.strct[ key ] );
-				continue;
-			}
-
-			if ( IsArray( arguments.strct[ key ] ) ) {
-				var isByteArray = isinstanceof(arguments.strct[key], "byte[]");
-				if ( !isByteArray ) {
-					_cleanArray( arguments.strct[ key ] );
-					continue;
-				}
-			}
-
-			StructDelete( arguments.strct, key );
-		}
-	}
-
-	private void function _cleanArray( required array arr ) {
-		for ( var i=ArrayLen( arguments.arr ); i>0; i-- ) {
-			var item = arguments.arr[ i ];
-			if ( IsSimpleValue( item ) ) {
-				continue;
-			}
-			if ( IsStruct( item ) ) {
-				_cleanStruct( item );
-				continue;
-			}
-			if ( IsArray( item ) ) {
-				var isByteArray = isinstanceof(item, "byte[]");
-				if ( !isByteArray ) {
-					_cleanArray( item );
-					continue;
-				}
-				ArrayDeleteAt( arguments.arr, i );
-			}
-
-			ArrayDelete( arguments.arr, i );
-		}
-	}
 }

--- a/system/services/cfmlscopes/SessionStorage.cfc
+++ b/system/services/cfmlscopes/SessionStorage.cfc
@@ -43,13 +43,8 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 
 			StructDelete( storage, "sessionId" );
 
-			for ( var key in storage.cbox_flash_scope ?: {} ) {
-				if ( IsStruct( storage.cbox_flash_scope[ key ] ) ) {
-					if ( StructKeyExists( storage.cbox_flash_scope[ key ], "content" ) && IsStruct( storage.cbox_flash_scope[ key ].content ) ) {
-						StructDelete( storage.cbox_flash_scope[ key ].content, "binary" );
-					}
-				}
-			}
+			_cleanStruct( storage );
+
 
 			var value = SerializeJson( storage );
 
@@ -263,5 +258,48 @@ component extends="preside.system.modules.cbstorages.models.SessionStorage" outp
 		return IsBoolean( request._presideSessionUsed ?: "" ) && request._presideSessionUsed;
 	}
 
+	private void function _cleanStruct( required struct strct ) {
+		for( var key in arguments.strct ) {
+			if ( IsSimpleValue( arguments.strct[ key ] ) ) {
+				continue;
+			}
+			if ( IsStruct( arguments.strct[ key ] ) ) {
+				_cleanStruct( arguments.strct[ key ] );
+				continue;
+			}
 
+			if ( IsArray( arguments.strct[ key ] ) ) {
+				var isByteArray = isinstanceof(arguments.strct[key], "byte[]");
+				if ( !isByteArray ) {
+					_cleanArray( arguments.strct[ key ] );
+					continue;
+				}
+			}
+
+			StructDelete( arguments.strct, key );
+		}
+	}
+
+	private void function _cleanArray( required array arr ) {
+		for ( var i=ArrayLen( arguments.arr ); i>0; i-- ) {
+			var item = arguments.arr[ i ];
+			if ( IsSimpleValue( item ) ) {
+				continue;
+			}
+			if ( IsStruct( item ) ) {
+				_cleanStruct( item );
+				continue;
+			}
+			if ( IsArray( item ) ) {
+				var isByteArray = isinstanceof(item, "byte[]");
+				if ( !isByteArray ) {
+					_cleanArray( item );
+					continue;
+				}
+				ArrayDeleteAt( arguments.arr, i );
+			}
+
+			ArrayDelete( arguments.arr, i );
+		}
+	}
 }

--- a/tests/unit/api/helpers/StructUtilsTest.cfc
+++ b/tests/unit/api/helpers/StructUtilsTest.cfc
@@ -1,0 +1,28 @@
+component extends="testbox.system.BaseSpec" {
+
+
+	function run(){
+		describe( "cleanStruct() helper function", function(){
+			it( "should return a cleaned struct with byte arrays removed", function(){
+				include "/preside/system/helpers/structUtils.cfm";
+
+				var inputStruct = {
+					  booleanTest = false
+					, stringTest  = "Test"
+					, arrayTest   = [ "one", "two", "three", ToBinary( ToBase64("I am a string.") ) ]
+					, structTest  = { one="one", two="two", three="three" , byteArray=ToBinary( ToBase64("I am a string.") ) }
+				};
+
+				var expectedStruct = {
+					  booleanTest = false
+					, stringTest  = "Test"
+					, arrayTest   = [ "one", "two", "three" ]
+					, structTest  = { one="one", two="two", three="three" }
+				};
+				cleanStruct( inputStruct );
+				expect(  inputStruct ).toBe( expectedStruct );
+			} );
+		} );
+
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens session persistence by ensuring only serializable data is stored.
> 
> - Adds `cleanStruct` and `cleanArray` in `system/helpers/structUtils.cfm` to recursively remove byte arrays and non-serializable values from structs/arrays
> - Updates `SessionStorage.persist()` to invoke `$helpers.cleanStruct(storage)` before `SerializeJson`
> - Adds `StructUtilsTest.cfc` unit test validating byte arrays are removed from nested structs/arrays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f35e299c93312ec73172655b402f9125e37502ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->