### PR TITLE
PRESSYNCED-3009 Fix email preview showing wrong site template branding

### DIFF
--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -1618,8 +1618,8 @@ component {
 		, template
 		, viewOnline
 	) {
-		var siteId   = $getRequestContext().getSiteId() ?: "";
-		var cacheKey = siteId & ( $helpers.isTrue( arguments.useDefaultContent ?: "" ) ? "default" : "saved" ) & "rawhtml" & arguments.template;
+		var siteId    = $getRequestContext().getSiteId() ?: "";
+		var cacheKey  = siteId & ( $helpers.isTrue( arguments.useDefaultContent ?: "" ) ? "default" : "saved" ) & "rawhtml" & arguments.template;
 		var fromCache = _getTemplateCache().get( cacheKey );
 
 		if ( !IsNull( local.fromCache ) ) {

--- a/system/services/email/EmailTemplateService.cfc
+++ b/system/services/email/EmailTemplateService.cfc
@@ -1618,7 +1618,8 @@ component {
 		, template
 		, viewOnline
 	) {
-		var cacheKey = ( $helpers.isTrue( arguments.useDefaultContent ?: "" ) ? "default" : "saved" ) & "rawhtml" & arguments.template;
+		var siteId   = $getRequestContext().getSiteId() ?: "";
+		var cacheKey = siteId & ( $helpers.isTrue( arguments.useDefaultContent ?: "" ) ? "default" : "saved" ) & "rawhtml" & arguments.template;
 		var fromCache = _getTemplateCache().get( cacheKey );
 
 		if ( !IsNull( local.fromCache ) ) {


### PR DESCRIPTION
Include siteId in email template cache key to ensure templates are cached per site and prevent cross-site template contamination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures email previews/rendered HTML use the correct site-specific branding by separating cache entries per site.
> 
> - Updates `EmailTemplateService.cfc` `_prepareHtml` to prefix cache key with `$getRequestContext().getSiteId()`
> - Cache key now: `siteId + (default|saved) + rawhtml + template`, preventing cross-site template contamination
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b7c473ce45fd9e3a09c5d064029303309630c73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->