### PR TITLE
PRESIDECMS-3228 unable to identify the blocking foreign object when the object does not have an i18n file

### DIFF
--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -2184,7 +2184,13 @@ component displayName="Preside Object Service" {
 					recordCount = selectData( objectName=foreignObjName, selectFields=["count(*) as record_count"], filter=filter, useCache=false ).record_count;
 
 					if ( Val( recordCount ) ) {
-						ArrayAppend( blocking, { objectName=foreignObjName, recordcount=recordcount, fk=join.fk } );
+						ArrayAppend( blocking, {
+							  objectName  = foreignObjName
+							, recordcount = recordcount
+							, fk          = join.fk
+							, i18nBase    = getResourceBundleUriRoot( objectName=foreignObjName )
+							, isPageType  = isPageType( objectName=foreignObjName )
+						} );
 					}
 				}
 			}

--- a/system/views/admin/datamanager/cascadeDeletePrompt.cfm
+++ b/system/views/admin/datamanager/cascadeDeletePrompt.cfm
@@ -26,7 +26,7 @@
 						<li>
 							<i class="fa fa-database"></i>
 
-							#translateResource( "preside-objects.#blocker.objectName#:title" )#, #translateResource( uri="cms:datamanager.x.related.records", data=[blocker.recordcount] )#
+							#translateResource( uri="preside-objects.#blocker.objectName#:title", defaultValue=blocker.objectName )#, #translateResource( uri="cms:datamanager.x.related.records", data=[blocker.recordcount] )#
 						</li>
 					</cfloop>
 				</ul>

--- a/system/views/admin/datamanager/cascadeDeletePrompt.cfm
+++ b/system/views/admin/datamanager/cascadeDeletePrompt.cfm
@@ -26,7 +26,8 @@
 						<li>
 							<i class="fa fa-database"></i>
 
-							#translateResource( uri="preside-objects.#blocker.objectName#:title", defaultValue=blocker.objectName )#, #translateResource( uri="cms:datamanager.x.related.records", data=[blocker.recordcount] )#
+							#translateResource( uri="#blocker.i18nBase ?: "preside-objects.#blocker.objectName#:"##isTrue( blocker.isPageType ?: "" ) ? "name" : "title"#", defaultValue=blocker.objectName )#,
+							#translateResource( uri="cms:datamanager.x.related.records", data=[blocker.recordcount] )#
 						</li>
 					</cfloop>
 				</ul>

--- a/tests/unit/api/presideObjects/PresideObjectServiceTest.cfc
+++ b/tests/unit/api/presideObjects/PresideObjectServiceTest.cfc
@@ -1675,7 +1675,7 @@
 			var poService = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentsWithAutoJoinableRelationships/" ] );
 			var q = new query();
 			var result = "";
-			var expected = [ { objectName="object_d", recordcount=2, fk="object_e" } ]
+			var expected = [ { objectName="object_d", recordcount=2, fk="object_e", i18nBase="preside-objects.object_d:", isPageType=false } ]
 
 			poService.dbSync();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: limited to delete-blocker metadata and admin prompt rendering, with a small chance of incorrect label resolution/fallback strings in the UI.
> 
> **Overview**
> Fixes the cascade delete blocker display so the admin UI can identify the blocking foreign object even when it has no i18n bundle.
> 
> `listForeignObjectsBlockingDelete()` now returns extra metadata (`i18nBase`, `isPageType`) for each blocking object, and `cascadeDeletePrompt.cfm` uses that to translate the correct `title`/`name` with a safe default fallback. Unit expectations were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cb49bb37ce7d5d47dabdc3af27984174b032c6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->