### PR TITLE
PRESIDECMS-3233 URL input styling on one to many manager modal

### DIFF
--- a/system/assets/css/admin/core/preside_ace_overrides.less
+++ b/system/assets/css/admin/core/preside_ace_overrides.less
@@ -24,6 +24,11 @@
 	.row {
 		margin-right : 0;
 		margin-left  : 0;
+
+		&.row-url-input {
+			margin-left: -15px;
+			margin-right: -15px;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, scoped CSS-only change affecting layout/styling for a specific row class in modals.
> 
> **Overview**
> Adjusts admin modal layout CSS to better align URL input rows in the one-to-many manager modal.
> 
> Adds a `.row-url-input` override under `.main-container.modal-dialog-layout-container .row` to apply negative left/right margins, undoing the default zeroed row margins for that specific row type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7de04a5ddf4157034ea9189e5c8d3451fa36ac9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->