### PR TITLE
Feature presidecms 3232 create helper functions for admin dateformat

### DIFF
--- a/system/helpers/dateUtils.cfm
+++ b/system/helpers/dateUtils.cfm
@@ -95,3 +95,22 @@
 	<cfset var tfService = getSingleton( "timeFormatService" ) />
 	<cfreturn tfService.roundHours( argumentCollection=arguments ) />
 </cfsilent></cffunction>
+
+<cffunction name="getAdminDateFormatMask" access="public" returntype="string" output="false"><cfsilent>
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getAdminDateFormatMask( argumentCollection=arguments ) />
+</cfsilent></cffunction>
+
+<cffunction name="getFormattedAdminDate" access="public" returntype="string" output="false">
+	<cfargument name="date" type="date" required="true" /><cfsilent>
+
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getFormattedAdminDate( argumentCollection=arguments ) />
+</cfsilent></cffunction>
+
+<cffunction name="getFormattedAdminDateTime" access="public" returntype="string" output="false">
+	<cfargument name="dateTime" type="date" required="true" /><cfsilent>
+
+	<cfset var dfService = getSingleton( "dateFormatService" ) />
+	<cfreturn dfService.getFormattedAdminDateTime( argumentCollection=arguments ) />
+</cfsilent></cffunction>

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -291,6 +291,53 @@ component {
 
         return ordinal;
     }
+
+    public string function getAdminDateFormatMask() {
+        var event            = $getRequestContext();
+        var adminUserDetails = event.getAdminUserDetails();
+        var dateFormatMask   = $translateResource( uri="cms:dateFormat");
+        
+        if ( IsStruct(adminUserDetails) ) {
+			if ( Len( adminUserDetails.user_admin_date_format ?: "" ) ) {
+				dateFormatMask = adminUserDetails.user_admin_date_format;
+			}
+		}
+
+        return dateFormatMask;
+    }
+
+    public string function getAdminTimeFormatMask() {
+        var event            = $getRequestContext();
+        var adminUserDetails = event.getAdminUserDetails();
+        var timeFormatMask   = $translateResource( uri="cms:timeFormat");
+        
+        if ( IsStruct(adminUserDetails) ) {
+
+			if( Len( adminUserDetails.user_time_format ?: "" ) ) {
+				if ( adminUserDetails.user_time_format == "24h" ) {
+					timeFormatMask = "HH:mm:ss";
+				} else {
+					timeFormatMask = "hh:mm:ss tt";
+				}
+			}
+		}
+
+        return timeFormatMask;
+    }
+
+    public string function getFormattedAdminDate( required date date ) {
+        var dateFormatMask = getAdminDateFormatMask();
+        
+        return LSdateFormat( LSparseDateTime( arguments.date ), dateFormatMask );
+    }
+    
+    public string function getFormattedAdminDateTime( required date dateTime ) {
+        var dateFormatMask    = getAdminDateFormatMask();
+		var timeFormatMask    = getAdminTimeFormatMask();
+		var formattedDateTime = LSparseDateTime( arguments.dateTime );
+
+        return LSdateFormat( LSparseDateTime( arguments.dateTime ), dateFormatMask ) & " " & LStimeFormat( arguments.dateTime, timeFormatMask );
+    }
     
 //PRIVATE FUNCTIONS
     private string function _getLongDateFormat() {

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -312,7 +312,6 @@ component {
         var timeFormatMask   = $translateResource( uri="cms:timeFormat");
         
         if ( IsStruct(adminUserDetails) ) {
-
 			if( Len( adminUserDetails.user_time_format ?: "" ) ) {
 				if ( adminUserDetails.user_time_format == "24h" ) {
 					timeFormatMask = "HH:mm:ss";
@@ -328,14 +327,14 @@ component {
     public string function getFormattedAdminDate( required date date ) {
         var dateFormatMask = getAdminDateFormatMask();
         
-        return LSdateFormat( LSparseDateTime( arguments.date ), dateFormatMask );
+        return LSdateFormat( arguments.date, dateFormatMask );
     }
     
     public string function getFormattedAdminDateTime( required date dateTime ) {
         var dateFormatMask    = getAdminDateFormatMask();
 		var timeFormatMask    = getAdminTimeFormatMask();
 
-        return LSdateFormat( LSparseDateTime( arguments.dateTime ), dateFormatMask ) & " " & LStimeFormat( arguments.dateTime, timeFormatMask );
+        return LSdateFormat( arguments.dateTime, dateFormatMask ) & " " & LStimeFormat( arguments.dateTime, timeFormatMask );
     }
     
 //PRIVATE FUNCTIONS

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -334,7 +334,6 @@ component {
     public string function getFormattedAdminDateTime( required date dateTime ) {
         var dateFormatMask    = getAdminDateFormatMask();
 		var timeFormatMask    = getAdminTimeFormatMask();
-		var formattedDateTime = LSparseDateTime( arguments.dateTime );
 
         return LSdateFormat( LSparseDateTime( arguments.dateTime ), dateFormatMask ) & " " & LStimeFormat( arguments.dateTime, timeFormatMask );
     }


### PR DESCRIPTION
Adds new helper functions for formatting dates in admin user's chosen format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formatting helpers only; risk is limited to potential display/format regressions in admin date/time output if user preferences or masks are misconfigured.
> 
> **Overview**
> Adds admin-user-specific date/time formatting in `DateFormatService`, deriving masks from the admin user profile (with translated defaults) and exposing `getFormattedAdminDate()` / `getFormattedAdminDateTime()`.
> 
> Exposes new helper functions in `dateUtils.cfm` (`getAdminDateFormatMask`, `getFormattedAdminDate`, `getFormattedAdminDateTime`) to make those admin-format values easily consumable across the app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d61ba8bd279ee5077dd57f3db49e22bb5bad5be0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->