### PR TITLE
PRESIDECMS-3236 export redirect to url

### DIFF
--- a/system/handlers/renderers/content/Link.cfc
+++ b/system/handlers/renderers/content/Link.cfc
@@ -15,13 +15,6 @@ component {
 	}
 
 	private string function dataExport( event, rc, prc, args={} ) {
-		var link = getPresideObject( "link" ).selectData( id=args.data ?: "" );
-
-		if ( !link.recordCount ) {
-			return "Link not found";
-		}
-
-		return linksService.getLinkUrl( link.id );
+		return getLinkUrl( args.data ?: "" );
 	}
-
 }

--- a/system/handlers/renderers/content/Link.cfc
+++ b/system/handlers/renderers/content/Link.cfc
@@ -2,6 +2,7 @@
  * @feature cms
  */
 component {
+	property name="linksService" inject="LinksService";
 
 	public string function default( event, rc, prc, args={} ){
 		var linkId = args.data ?: "";
@@ -11,6 +12,16 @@ component {
 		}
 
 		return "";
+	}
+
+	private string function dataExport( event, rc, prc, args={} ) {
+		var link = getPresideObject( "link" ).selectData( id=args.data ?: "" );
+
+		if ( !link.recordCount ) {
+			return "Link not found";
+		}
+
+		return linksService.getLinkUrl( link.id );
 	}
 
 }

--- a/system/handlers/renderers/content/Link.cfc
+++ b/system/handlers/renderers/content/Link.cfc
@@ -2,8 +2,6 @@
  * @feature cms
  */
 component {
-	property name="linksService" inject="LinksService";
-
 	public string function default( event, rc, prc, args={} ){
 		var linkId = args.data ?: "";
 

--- a/system/i18n/preside-objects/url_redirect_rule.properties
+++ b/system/i18n/preside-objects/url_redirect_rule.properties
@@ -22,4 +22,4 @@ field.redirect_type.help=Whether the redirect is a permanent or temporary redire
 field.keep_query_string.title=Preserve URL parameters
 field.keep_query_string.help=If true, any URL parameters found at the incoming URL will be added to the target URL.
 
-field.rendered_redirect_link.title=Redirect to link
+field.redirect_to_url.title=Redirect to URL

--- a/system/i18n/preside-objects/url_redirect_rule.properties
+++ b/system/i18n/preside-objects/url_redirect_rule.properties
@@ -21,3 +21,5 @@ field.redirect_type.help=Whether the redirect is a permanent or temporary redire
 
 field.keep_query_string.title=Preserve URL parameters
 field.keep_query_string.help=If true, any URL parameters found at the incoming URL will be added to the target URL.
+
+field.rendered_redirect_link.title=Redirect to link

--- a/system/preside-objects/url_redirect_rule.cfc
+++ b/system/preside-objects/url_redirect_rule.cfc
@@ -2,7 +2,7 @@
  * The URL Redirect rule object is used to store individual URL redirect rules. These rules
  * can use regex, etc. and are used to setup dynamic and editorial redirects.
  *
- * @dataExportFields   id,label,source_url_pattern,redirect_type,exact_match_only,keep_query_string,redirect_to_link,datecreated,datemodified
+ * @dataExportFields   id,label,source_url_pattern,redirect_type,exact_match_only,keep_query_string,redirect_to_link,redirect_to_url,datecreated,datemodified
  * @datamanagerEnabled true
  * @feature            urlRedirects
  */
@@ -15,5 +15,5 @@ component extends="preside.system.base.SystemPresideObject" displayName="URL Red
 	property name="keep_query_string"  type="boolean" dbtype="boolean"               required=false default=false;
 
 	property name="redirect_to_link" relationship="many-to-one" relatedto="link" required=true;
-	property name="rendered_redirect_link" type="string" dbtype="text" formula="${prefix}redirect_to_link" adminRenderer="none" dataExportRenderer="Link" searchSearchable=false autofilter=false;
+	property name="redirect_to_url" type="string" formula="${prefix}redirect_to_link" adminRenderer="none" dataExportRenderer="Link" autofilter=false;
 }

--- a/system/preside-objects/url_redirect_rule.cfc
+++ b/system/preside-objects/url_redirect_rule.cfc
@@ -15,4 +15,5 @@ component extends="preside.system.base.SystemPresideObject" displayName="URL Red
 	property name="keep_query_string"  type="boolean" dbtype="boolean"               required=false default=false;
 
 	property name="redirect_to_link" relationship="many-to-one" relatedto="link" required=true;
+	property name="rendered_redirect_link" type="string" dbtype="text" formula="${prefix}redirect_to_link" adminRenderer="none" dataExportRenderer="Link" searchSearchable=false autofilter=false;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to data export rendering and metadata/i18n, with no impact on redirect matching or runtime request handling.
> 
> **Overview**
> Adds support for exporting the resolved target URL for redirect rules.
> 
> This introduces a `dataExport()` renderer in `renderers/content/Link.cfc` to output `getLinkUrl()` for a link, and updates `url_redirect_rule` to include a computed `redirect_to_url` export field (hidden in admin) plus a matching i18n label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe39de29bc1bb6a2c8c0abd049e0d463371a56a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->