### PR TITLE
PRESIDECMS-3237 faster queries for segmented filter population

### DIFF
--- a/system/services/rulesEngine/RulesEngineFilterService.cfc
+++ b/system/services/rulesEngine/RulesEngineFilterService.cfc
@@ -605,6 +605,7 @@ component displayName="Rules Engine Filter Service" {
 		var objectName      = arguments.filter.filter_object;
 		var filterId        = arguments.filter.id;
 		var idField         = $getPresideObjectService().getIdField( objectName );
+		var idFieldType     = _getFieldDbType( objectName, idField );
 		var fullIdField     = "#objectName#.#idField#";
 		var bypassTenants   = [];
 		var preparedFilters = [ prepareFilter(
@@ -660,7 +661,7 @@ component displayName="Rules Engine Filter Service" {
 				);
 
 				filter       = "#fullIdField# > :lastRecordId";
-				filterParams = { lastRecordId = { type="cf_sql_varchar", value=ArrayLast( recordIds ) } };
+				filterParams = { lastRecordId = { type=idFieldType, value=ArrayLast( recordIds ) } };
 			}
 		} while( ArrayLen( recordIds ) == pageSize );
 
@@ -731,6 +732,18 @@ component displayName="Rules Engine Filter Service" {
 		);
 
 		return DateAdd( unit, filter.segmentation_frequency_measure, Now() );
+	}
+
+	private function _getFieldDbType( required string objectName, required string fieldName ) {
+		var poService = $getPresideObjectService();
+		var dbAdapter = poService.getDbAdapterForObject( arguments.objectName );
+		var dbType    = poService.getObjectPropertyAttribute(
+			  objectName    = arguments.objectName
+			, propertyName  = arguments.fieldName
+			, attributeName = "dbType"
+			, defaultValue  = "varchar"
+		);
+		return dbAdapter.sqlDataTypeToCfSqlDatatype( dbType );
 	}
 
 // GETTERS AND SETTERS

--- a/system/services/rulesEngine/RulesEngineFilterService.cfc
+++ b/system/services/rulesEngine/RulesEngineFilterService.cfc
@@ -605,6 +605,7 @@ component displayName="Rules Engine Filter Service" {
 		var objectName      = arguments.filter.filter_object;
 		var filterId        = arguments.filter.id;
 		var idField         = $getPresideObjectService().getIdField( objectName );
+		var fullIdField     = "#objectName#.#idField#";
 		var bypassTenants   = [];
 		var preparedFilters = [ prepareFilter(
 			  objectName         = objectName
@@ -624,16 +625,46 @@ component displayName="Rules Engine Filter Service" {
 			bypassTenants = ListToArray( objectTenant );
 		}
 
-		return $getPresideObjectService().insertDataFromSelect(
-			  objectName     = "rules_engine_filter_holding_data"
-			, fieldList      = [ "filter", "object_name", "record_id", "holding_id" ]
-			, selectDataArgs = {
-				  objectName    = objectName
-				, selectFields  = [ "'#filterId#'", "'#objectName#'", "#objectName#.#idField#", "'#arguments.holdingId#'" ]
+		var object      = $getPresideObject( objectName );
+		var poService   = $getPresideObjectService();
+		var recordIds   = [];
+		var filter      = "";
+		var filterParams = {};
+		var pageSize     = 100;
+		var totalRecords = 0;
+
+		do {
+			recordIds = object.selectData(
+				  selectFields  = [ "#fullIdField# as id" ]
+				, filter        = filter
+				, filterParams  = filterParams
 				, extraFilters  = preparedFilters
 				, bypassTenants = bypassTenants
+				, orderBy       = fullIdField
+				, maxRows       = pageSize
+				, useCache      = false
+				, returnType    = "arrayOfValues"
+				, columnKey     = "id"
+			);
+
+			if ( ArrayLen( recordIds ) ) {
+				totalRecords += poService.insertDataFromSelect(
+					  objectName     = "rules_engine_filter_holding_data"
+					, fieldList      = [ "filter", "object_name", "record_id", "holding_id" ]
+					, selectDataArgs = {
+						  objectName    = objectName
+						, selectFields  = [ "'#filterId#'", "'#objectName#'", "#fullIdField#", "'#arguments.holdingId#'" ]
+						, extraFilters  = [ { filter = { "#fullIdField#" = recordIds } } ]
+						, bypassTenants = bypassTenants
+					}
+				);
+
+				filter       = "#fullIdField# > :lastRecordId";
+				filterParams = { lastRecordId = { type="cf_sql_varchar", value=ArrayLast( recordIds ) } };
 			}
-		);
+		} while( ArrayLen( recordIds ) == pageSize );
+
+		return totalRecords;
 	}
 
 	private void function _clearHoldingTable( required string holdingId ) {


### PR DESCRIPTION
 Because this can be unjustly slow in MariaDB/MYSQL:

 ```sql
insert into ... from select ... where ... complexFilter
```

 We have to do a simpler insert from select with no complex filters and
 achieve this by batch selecting just record IDs from the query and then
 running each of those in turn in a simple `where id in (:batch)` insert
 statement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the data-population path for segmentation filters and introduces paging based on ordered IDs; risk is mainly around correctness/performance with non-standard ID types or unexpected ordering/cursor behavior on different DBs.
> 
> **Overview**
> Improves segmentation filter recalculation performance by replacing a single complex `insert ... select` into `rules_engine_filter_holding_data` with a paged approach: select matching record IDs in batches (ordered by ID) and then insert via simple `WHERE id IN (:batch)` selects.
> 
> Adds `_getFieldDbType()` to derive the correct `cf_sql_*` type for the object’s ID field and uses it to parameterize the paging cursor (`lastRecordId`) when iterating through batches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d6d08f92d59bc7104ecc2b132eb78268983288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->