### PR TITLE
PRESIDECMS-3236 unable to export url redirects redirect links

### DIFF
--- a/system/handlers/renderers/content/Link.cfc
+++ b/system/handlers/renderers/content/Link.cfc
@@ -2,7 +2,6 @@
  * @feature cms
  */
 component {
-
 	public string function default( event, rc, prc, args={} ){
 		var linkId = args.data ?: "";
 
@@ -13,4 +12,7 @@ component {
 		return "";
 	}
 
+	private string function dataExport( event, rc, prc, args={} ) {
+		return getLinkUrl( args.data ?: "" );
+	}
 }

--- a/system/i18n/preside-objects/url_redirect_rule.properties
+++ b/system/i18n/preside-objects/url_redirect_rule.properties
@@ -26,3 +26,5 @@ field.redirect_type.301.warning=301 redirects are permanent changes that get cac
 
 field.keep_query_string.title=Preserve URL parameters
 field.keep_query_string.help=If true, any URL parameters found at the incoming URL will be added to the target URL.
+
+field.redirect_to_url.title=Redirect to URL

--- a/system/preside-objects/url_redirect_rule.cfc
+++ b/system/preside-objects/url_redirect_rule.cfc
@@ -2,7 +2,7 @@
  * The URL Redirect rule object is used to store individual URL redirect rules. These rules
  * can use regex, etc. and are used to setup dynamic and editorial redirects.
  *
- * @dataExportFields      id,label,source_url_pattern,redirect_type,exact_match_only,keep_query_string,redirect_to_link,datecreated,datemodified
+ * @dataExportFields      id,label,source_url_pattern,redirect_type,exact_match_only,keep_query_string,redirect_to_link,redirect_to_url,datecreated,datemodified
  * @datamanagerEnabled    true
  * @datamanagerGridFields label,source_url_pattern,redirect_to_link,redirect_type,exact_match_only,datecreated,datemodified
  * @feature               urlRedirects
@@ -16,4 +16,5 @@ component extends="preside.system.base.SystemPresideObject" displayName="URL Red
 	property name="keep_query_string"  type="boolean" dbtype="boolean"               required=false default=false;
 
 	property name="redirect_to_link" relationship="many-to-one" relatedto="link" required=true;
+	property name="redirect_to_url" type="string" formula="${prefix}redirect_to_link" adminRenderer="none" dataExportRenderer="Link" autofilter=false;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive change limited to data export behavior and a computed field; no changes to redirect matching/execution logic.
> 
> **Overview**
> Fixes URL redirect rule data exports so the redirect destination can be exported as an actual URL (not just a link reference).
> 
> This adds a `Link.dataExport()` renderer that returns `getLinkUrl()`, and introduces a computed `redirect_to_url` field on `url_redirect_rule` (included in `@dataExportFields`) that uses that renderer while staying hidden from the admin UI; accompanying i18n copy is updated to include `Redirect to URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aea156c0c58b4e96e343fa6e5c01c208f8ab5eaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->