### PR TITLE
PRESIDECMS-3238 site localisation coding standard updates

### DIFF
--- a/system/forms/preside-objects/site/admin.add.xml
+++ b/system/forms/preside-objects/site/admin.add.xml
@@ -16,7 +16,7 @@ This form is used for the "add site" form in the site manager
 	</tab>
 	<tab id="localisation" sortorder="20" title="preside-objects.site:localisation.tab.title">
 		<fieldset id="localisation" sortorder="10">
-			<field binding="site.locale" sortorder="10" control="siteLocalePicker" />
+			<field binding="site.locale"            sortorder="10" control="siteLocalePicker" />
 			<field binding="site.short_date_format" sortorder="20" control="siteDateFormatPicker" dateFormatType="short" />
 			<field binding="site.long_date_format"  sortorder="30" control="siteDateFormatPicker" dateFormatType="long" />
 			<field binding="site.time_format"       sortorder="40" control="enumRadioList" />

--- a/system/forms/preside-objects/site/admin.edit.xml
+++ b/system/forms/preside-objects/site/admin.edit.xml
@@ -16,7 +16,7 @@ This form is used for the "edit site" form in the site manager
 	</tab>
 	<tab id="localisation" sortorder="20" title="preside-objects.site:localisation.tab.title">
 		<fieldset id="localisation" sortorder="10">
-			<field binding="site.locale" sortorder="10" control="siteLocalePicker" />
+			<field binding="site.locale"            sortorder="10" control="siteLocalePicker" />
 			<field binding="site.short_date_format" sortorder="20" control="siteDateFormatPicker" dateFormatType="short" />
 			<field binding="site.long_date_format"  sortorder="30" control="siteDateFormatPicker" dateFormatType="long" />
 			<field binding="site.time_format"       sortorder="40" control="enumRadioList" />

--- a/system/handlers/formcontrols/SiteDateFormatPicker.cfc
+++ b/system/handlers/formcontrols/SiteDateFormatPicker.cfc
@@ -3,31 +3,31 @@
  */
 component {
 
-	property name="i18n"              inject="i18n";
-
 	public string function index( event, rc, prc, args={} ) output=false {
 		var settings       = getSetting( "datetime.formats" );
-		var dateFormatType = args.dateFormatType ?: ""		
-		var items          = settings[dateFormatType] ?: [];
-		args.labels        = [ "" ];
-		args.values        = [ "" ];
-		
-		if ( !ArrayLen(items) ) {
+		var dateFormatType = args.dateFormatType ?: "";
+		var items          = settings[ dateFormatType ] ?: [];
+
+		if ( !ArrayLen( items ) ) {
 			return "";
 		}
 
-		for( var item in items ) {
-			ArrayAppend(args.values, item);
+		args.labels = [ "" ];
+		args.values = [ "" ];
 
-			var label = translateResource(uri="preside-objects.site:option.#item#.label", defaultValue="");
-			if( Len(label) ) {
-				ArrayAppend(args.labels, label);
+		for( var item in items ) {
+			ArrayAppend( args.values, item );
+
+			var label = translateResource( uri="preside-objects.site:option.#item#.label", defaultValue="" );
+			if( Len( label ) ) {
+				ArrayAppend( args.labels, label );
 			} else {
-				label = item & " (" & DateFormat("2025-09-20", item) & ")";
-				ArrayAppend(args.labels, label);
+				label = item & " (" & DateFormat( "2025-09-20", item ) & ")";
+
+				ArrayAppend( args.labels, label );
 			}
 		}
-		
+
 		return renderView( view="formcontrols/select/index", args=args );
 	}
 }

--- a/system/handlers/formcontrols/SiteLocalePicker.cfc
+++ b/system/handlers/formcontrols/SiteLocalePicker.cfc
@@ -5,10 +5,12 @@ component {
 
 	property name="i18n"                  inject="i18n";
 	property name="frontendLanguages"     inject="coldbox:setting:frontendLanguages";
+	property name="defaultLocaleSettings" inject="coldbox:setting:datetime.regionDefaults";
 	property name="resourceBundleService" inject="resourceBundleService";
 
-	public string function index( event, rc, prc, args={} ) output=false {
-		args.extraClasses = "site-locale-picker";
+	public string function index( event, rc, prc, args={} ) {
+		args.extraClasses = args.extraClasses ?: "";
+		args.extraClasses = ListAppend( args.extraClasses, "site-locale-picker", " " );
 		args.adminLocales = false;
 		args.locales      = frontendLanguages;
 		args.defaultValue = args.defaultValue ?: i18n.getDefaultLocale();
@@ -17,19 +19,24 @@ component {
 			return "";
 		}
 
-		var isoCountriesJson = resourceBundleService.getBundleAsJson(
-			bundle   = "enum.isoCountries"
-		);
-
-		var defaultLocaleSettings = getSetting( "datetime.regionDefaults" );
+		var isoCountriesJson = resourceBundleService.getBundleAsJson( bundle="enum.isoCountries" );
 
 		event.includeData( {
-			  isoCountries = deserializeJson(isoCountriesJson)
+			  isoCountries          = DeserializeJson( isoCountriesJson )
 			, defaultLocaleSettings = defaultLocaleSettings
 		} );
 
 		event.include( "/js/admin/specific/siteLocalePicker/" );
 
 		return renderViewlet( event="formcontrols.localePicker.index", args=args );
+	}
+
+	public string function admin( event, rc, prc, args={} ) {
+		args.extraClasses = args.extraClasses ?: "";
+		if ( !ReFindNoCase( "form-control", args.extraClasses ) ) {
+			args.extraClasses = ListAppend( args.extraClasses, "form-control", " " );
+		}
+
+		return index( argumentCollection=arguments );
 	}
 }

--- a/system/helpers/dateUtils.cfm
+++ b/system/helpers/dateUtils.cfm
@@ -65,7 +65,7 @@
 	<cfreturn getSingleton( "dateFormatService" ).getDateDayOrdinal( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
-<cffunction name="getSiteLocaleSettings" access="public" returntype="query" output="false"><cfsilent>
+<cffunction name="getSiteLocaleSettings" access="public" returntype="struct" output="false"><cfsilent>
 	<cfreturn getSingleton( "dateFormatService" ).getSiteLocaleSettings() />
 </cfsilent></cffunction>
 

--- a/system/helpers/dateUtils.cfm
+++ b/system/helpers/dateUtils.cfm
@@ -6,92 +6,79 @@
 </cfsilent></cffunction>
 
 <cffunction name="getShortDateFormatMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getShortDateFormatMask() />
+	<cfreturn getSingleton( "dateFormatService" ).getShortDateFormatMask() />
 </cfsilent></cffunction>
 
 <cffunction name="getShortDate" access="public" returntype="string" output="false">
 	<cfargument name="date" type="date" required="true" /><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getShortDate( argumentCollection=arguments ) />
+	<cfreturn getSingleton( "dateFormatService" ).getShortDate( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDateFormatMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDateFormatMask() />
+	<cfreturn getSingleton( "dateFormatService" ).getLongDateFormatMask() />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDateFormatDayMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDateFormatDayMask() />
+	<cfreturn getSingleton( "dateFormatService" ).getLongDateFormatDayMask() />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDateFormatMonthMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDateFormatMonthMask() />
+	<cfreturn getSingleton( "dateFormatService" ).getLongDateFormatMonthMask() />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDateFormatYearMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDateFormatYearMask() />
+	<cfreturn getSingleton( "dateFormatService" ).getLongDateFormatYearMask() />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDateFormatDayMonthMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDateFormatDayMonthMask() />
+	<cfreturn getSingleton( "dateFormatService" ).getLongDateFormatDayMonthMask() />
 </cfsilent></cffunction>
 
 <cffunction name="getLongDate" access="public" returntype="string" output="false">
-	<cfargument name="date" type="date" required="true" />
+	<cfargument name="date"           type="date"    required="true" />
 	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getLongDate( argumentCollection=arguments ) />
+
+	<cfreturn getSingleton( "dateFormatService" ).getLongDate( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getDateRange" access="public" returntype="string" output="false">
-	<cfargument name="date1" type="date" required="true" />
-	<cfargument name="date2" type="date" required="true" />
-	<cfargument name="showYear" type="boolean" required="false" default="false" />
+	<cfargument name="date1"          type="date"    required="true" />
+	<cfargument name="date2"          type="date"    required="true" />
+	<cfargument name="showYear"       type="boolean" required="false" default="false" />
 	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
 
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getDateRange( argumentCollection=arguments ) />
+	<cfreturn getSingleton( "dateFormatService" ).getDateRange( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getSplitDate" access="public" returntype="string" output="false">
-	<cfargument name="dates" type="array" required="true" />
-	<cfargument name="compact" type="boolean" required="false" default="false" />
+	<cfargument name="dates"            type="array"   required="true" />
+	<cfargument name="compact"          type="boolean" required="false" default="false" />
 	<cfargument name="compactThreshold" type="numeric" required="false" default="30" />
-	<cfargument name="includeOrdinal" type="boolean" required="false" default="false" /><cfsilent>
+	<cfargument name="includeOrdinal"   type="boolean" required="false" default="false" /><cfsilent>
 
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getSplitDate( argumentCollection=arguments ) />
+	<cfreturn getSingleton( "dateFormatService" ).getSplitDate( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getDateDayOrdinal" access="public" returntype="string" output="false">
 	<cfargument name="date" type="date" required="true" /><cfsilent>
 		
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getDateDayOrdinal( argumentCollection=arguments ) />
+	<cfreturn getSingleton( "dateFormatService" ).getDateDayOrdinal( argumentCollection=arguments ) />
 </cfsilent></cffunction>
 
 <cffunction name="getSiteLocaleSettings" access="public" returntype="query" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getSiteLocaleSettings() />
+	<cfreturn getSingleton( "dateFormatService" ).getSiteLocaleSettings() />
 </cfsilent></cffunction>
 
 <cffunction name="getDefaultSettingsForLocale" access="public" returntype="struct" output="false"><cfsilent>
-	<cfset var dfService = getSingleton( "dateFormatService" ) />
-	<cfreturn dfService.getDefaultSettingsForLocale() />
+	<cfreturn getSingleton( "dateFormatService" ).getDefaultSettingsForLocale() />
 </cfsilent></cffunction>
 
 <cffunction name="getTimeFormatMask" access="public" returntype="string" output="false"><cfsilent>
-	<cfset var tfService = getSingleton( "timeFormatService" ) />
-	<cfreturn tfService.getTimeFormatMask() />
+	<cfreturn getSingleton( "timeFormatService" ).getTimeFormatMask() />
 </cfsilent></cffunction>
 
 <cffunction name="roundHours" access="public" returntype="string" output="false">
 	<cfargument name="formattedTime" type="string" required="true" /><cfsilent>
-	<cfset var tfService = getSingleton( "timeFormatService" ) />
-	<cfreturn tfService.roundHours( argumentCollection=arguments ) />
+
+	<cfreturn getSingleton( "timeFormatService" ).roundHours( argumentCollection=arguments ) />
 </cfsilent></cffunction>

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -10,7 +10,7 @@ component {
 
 // SHORT DATE FORMAT FUNCTIONS
 	public string function getShortDateFormatMask() {
-		return LCase( getSiteLocaleSettings().short_date_format );
+		return LCase( getSiteLocaleSettings().short_date_format ?: "" );
 	}
 
 	public string function getShortDate( required date date ) {
@@ -277,8 +277,8 @@ component {
 	public struct function getDefaultSettingsForLocale() {
 		var localeSettings  = getSiteLocaleSettings();
 		var defaultSettings = $getColdbox().getSetting( "datetime.regionDefaults" );
-		var countryCode     = ListLast( localeSettings.locale, "_" );
-		var regionCode      = $translateResource( uri="enum.isoCountries:#countryCode#.region");
+		var countryCode     = Len( localeSettings.locale ?: "" ) ? ListLast( localeSettings.locale, "_" ) : "";
+		var regionCode      = $translateResource( uri="enum.isoCountries:#countryCode#.region", defaultValue="" );
 
 		if ( Len( countryCode ) && Len( regionCode ) && StructKeyExists( defaultSettings, regionCode ) ) {
 			return defaultSettings[ regionCode ];

--- a/system/services/l10n/DateFormatService.cfc
+++ b/system/services/l10n/DateFormatService.cfc
@@ -1,307 +1,313 @@
 /**
- * @singleton true
+ * @singleton      true
  * @presideService true
  */
 component {
 
-    function init() {
+	public any function init() {
 		return this;
 	}
 
-    
+// SHORT DATE FORMAT FUNCTIONS
+	public string function getShortDateFormatMask() {
+		return LCase( getSiteLocaleSettings().short_date_format );
+	}
 
-//SHORT DATE FORMAT FUNCTIONS
-    public string function getShortDateFormatMask() {
-        return LCase(getSiteLocaleSettings().short_date_format);
-    }
+	public string function getShortDate( required date date ) {
+		return LSDateFormat( arguments.date, getShortDateFormatMask() );
+	}
 
-    public string function getShortDate( required date date ) {
-        return LSdateFormat( arguments.date, getShortDateFormatMask() );
-    }
+// LONG DATE FORMAT FUNCTIONS
+	public string function getLongDateFormatMask() {
+		if ( _getLongDateFormat() == "DMY" ) {
+			return "d mmmm yyyy";
+		} else {
+			return "mmmm d, yyyy";
+		}
+	}
 
-//LONG DATE FORMAT FUNCTIONS
-    public string function getLongDateFormatMask() {
-        if ( _getLongDateFormat() == "DMY" ) {
-            return "d mmmm yyyy";
-        } else {
-            return "mmmm d, yyyy";
-        }
-    }
+	public string function getLongDateFormatDayMask() {
+		return "d";
+	}
 
-    public string function getLongDateFormatDayMask() {
-        return "d";
-    }
+	public string function getLongDateFormatMonthMask() {
+		return "mmmm";
+	}
 
-    public string function getLongDateFormatMonthMask() {
-        return "mmmm";
-    }
+	public string function getLongDateFormatYearMask() {
+		return "yyyy";
+	}
 
-    public string function getLongDateFormatYearMask() {
-        return "yyyy";
-    }
+	public string function getLongDateFormatDayMonthMask() {
+		if ( _getLongDateFormat() == "DMY" ) {
+			return "d mmmm";
+		} else {
+			return "mmmm d";
+		}
+	}
 
-    public string function getLongDateFormatDayMonthMask() {
-        if ( _getLongDateFormat() == "DMY" ) {
-            return "d mmmm";
-        } else {
-            return "mmmm d";
-        }
-    }
+	public string function getLongDate( required date date, boolean includeOrdinal=false ) {
+		var longFormat    = _getLongDateFormat();
+		var mask          = getLongDateFormatMask();
+		var formattedDate = LSDateFormat( arguments.date, mask );
 
-    public string function getLongDate( required date date, boolean includeOrdinal=false ) {
-        var longFormat    = _getLongDateFormat();
-        var mask          = getLongDateFormatMask();
-        var formattedDate = LSdateFormat( arguments.date, mask );
+		if ( arguments.includeOrdinal && longFormat == "DMY" ) {
+			var dateOrdinal = getDateDayOrdinal( arguments.date );
+			formattedDate   = ReReplace( formattedDate, "(\d{1,2})", "\1#dateOrdinal#" );
+		}
 
-        if ( arguments.includeOrdinal && longFormat == "DMY" ) {
-            var dateOrdinal = getDateDayOrdinal( arguments.date );
-            formattedDate   = ReReplace( formattedDate, "(\d{1,2})", "\1#dateOrdinal#" ); 
-        }
+		return formattedDate;
+	}
 
-        return formattedDate;
-    }
+// DATE RANGE FUNCTIONS
+	public string function getDateRange( required date date1, required date date2, boolean showYear=false, boolean includeOrdinal=false ) {
+		var longFormat = _getLongDateFormat();
+		var mask       = getLongDateFormatMask();
+		var maskNoYear = getLongDateFormatDayMonthMask();
+		var dayMask    = getLongDateFormatDayMask();
+		var yearMask   = getLongDateFormatYearMask();
 
-//DATE RANGE FUNCTIONS
-    public string function getDateRange( required date date1, required date date2, boolean showYear=false, boolean includeOrdinal=false ) {
-        var longFormat = _getLongDateFormat();
-        var mask       = getLongDateFormatMask();
-        var maskNoYear = getLongDateFormatDayMonthMask();
-        var dayMask    = getLongDateFormatDayMask();
-        var yearMask   = getLongDateFormatYearMask();
+		if ( arguments.includeOrdinal && longFormat == "MDY" ) {
+			arguments.includeOrdinal = false;
+		}
 
-        if ( arguments.includeOrdinal && longFormat == "MDY" ) {
-            arguments.includeOrdinal = false;
-        }
+		if ( Month( arguments.date1 ) == Month( arguments.date2 ) ) {
+			return getDateRangeWithSameMonth( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
+		} else {
+			if ( Year( arguments.date1 ) == Year( arguments.date2 ) ) {
+				return getDateRangeWithDifferentMonthAndSameYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
+			} else {
+				return getDateRangeWithDifferentMonthAndDifferentYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
+			}
+		}
 
-        if ( month( arguments.date1 ) == month( arguments.date2 ) ) {
-            return getDateRangeWithSameMonth( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
-        } else {
-            if ( year( arguments.date1 ) == year( arguments.date2 ) ) {
-                return getDateRangeWithDifferentMonthAndSameYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
-            } else {
-                return getDateRangeWithDifferentMonthAndDifferentYear( arguments.date1, arguments.date2, arguments.showYear, includeOrdinal );
-            }
-        }
-        
-    }
+	}
 
-    public string function getDateRangeWithSameMonth( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
-        var longFormat         = _getLongDateFormat();
-        var mask               = getLongDateFormatMask();
+	public string function getDateRangeWithSameMonth( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
+		var longFormat         = _getLongDateFormat();
+		var mask               = getLongDateFormatMask();
 		var maskNoYear         = getLongDateFormatDayMonthMask();
 		var dayMask            = getLongDateFormatDayMask();
 		var yearMask           = getLongDateFormatYearMask();
 
 		if ( longFormat == "DMY" ) {
-            var dateRange = LSDateFormat( arguments.date1, dayMask );
-            if ( arguments.includeOrdinal ) {
-                dateRange &= getDateDayOrdinal( arguments.date1 );
-            }
+			var dateRange = LSDateFormat( arguments.date1, dayMask );
+			if ( arguments.includeOrdinal ) {
+				dateRange &= getDateDayOrdinal( arguments.date1 );
+			}
 
-            var date2Part = "";
-            
-            if ( arguments.showYear ) {
-                date2Part = LSDateFormat( arguments.date2, mask );
-            } else {
-                date2Part = LSDateFormat( arguments.date2, maskNoYear );
-            }
+			var date2Part = "";
 
-            if ( arguments.includeOrdinal ) {
-                var date2Ordinal = getDateDayOrdinal( arguments.date2 );
-                date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
-            }
+			if ( arguments.showYear ) {
+				date2Part = LSDateFormat( arguments.date2, mask );
+			} else {
+				date2Part = LSDateFormat( arguments.date2, maskNoYear );
+			}
 
-            dateRange &= " - " & date2Part;
+			if ( arguments.includeOrdinal ) {
+				var date2Ordinal = getDateDayOrdinal( arguments.date2 );
+				date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
+			}
 
-            return dateRange;
+			dateRange &= " - " & date2Part;
+
+			return dateRange;
 		} else {
-            var dateRange = "#LSDateFormat( arguments.date1, maskNoYear )# - #LSDateFormat( arguments.date2, dayMask )#";
-            if ( arguments.showYear ) {
-                dateRange &= ", " & LSDateFormat( arguments.date1, yearMask );
-            }
-            return dateRange;
+			var dateRange = "#LSDateFormat( arguments.date1, maskNoYear )# - #LSDateFormat( arguments.date2, dayMask )#";
+			if ( arguments.showYear ) {
+				dateRange &= ", " & LSDateFormat( arguments.date1, yearMask );
+			}
+			return dateRange;
 		}
-    }
+	}
 
-    public string function getDateRangeWithDifferentMonthAndSameYear( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
-        var longFormat         = _getLongDateFormat();
-        var mask               = getLongDateFormatMask();
+	public string function getDateRangeWithDifferentMonthAndSameYear( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
+		var longFormat         = _getLongDateFormat();
+		var mask               = getLongDateFormatMask();
 		var maskNoYear         = getLongDateFormatDayMonthMask();
 		var dayMonthMask       = getLongDateFormatDayMonthMask();
 
-        if ( !arguments.showYear ) {
-            mask = maskNoYear;
-        }
+		if ( !arguments.showYear ) {
+			mask = maskNoYear;
+		}
 
-        if ( longFormat == "DMY" ) {
-            var date1Part = LSDateFormat( date1, dayMonthMask );
-            var date2Part = LSDateFormat( date2, mask );
+		if ( longFormat == "DMY" ) {
+			var date1Part = LSDateFormat( date1, dayMonthMask );
+			var date2Part = LSDateFormat( date2, mask );
 
-            if ( arguments.includeOrdinal ) {
-                var date1Ordinal = getDateDayOrdinal( arguments.date1 );
-                date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
+			if ( arguments.includeOrdinal ) {
+				var date1Ordinal = getDateDayOrdinal( arguments.date1 );
+				date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
 
-                var date2Ordinal = getDateDayOrdinal( arguments.date2 );
-                date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
-            }
-            
+				var date2Ordinal = getDateDayOrdinal( arguments.date2 );
+				date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
+			}
+
 			return "#date1Part# - #date2Part#";
 		} else {
 			return "#LSDateFormat( date1, maskNoYear )# - #LSDateFormat( date2, mask )#";
 		}
-    }
+	}
 
-    public string function getDateRangeWithDifferentMonthAndDifferentYear( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
-        var mask        = getLongDateFormatMask();
-        var maskNoYear  = getLongDateFormatDayMonthMask();
+	public string function getDateRangeWithDifferentMonthAndDifferentYear( required date date1, required date date2, showYear=false, boolean includeOrdinal=false ) {
+		var mask       = getLongDateFormatMask();
+		var maskNoYear = getLongDateFormatDayMonthMask();
 
-        if ( !arguments.showYear ) {
-            mask = maskNoYear;
-        }
+		if ( !arguments.showYear ) {
+			mask = maskNoYear;
+		}
 
-        var date1Part = LSDateFormat( date1, mask );
-        var date2Part = LSDateFormat( date2, mask );
+		var date1Part = LSDateFormat( date1, mask );
+		var date2Part = LSDateFormat( date2, mask );
 
-        if ( arguments.includeOrdinal ) {
-            var date1Ordinal = getDateDayOrdinal( arguments.date1 );
-            date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
+		if ( arguments.includeOrdinal ) {
+			var date1Ordinal = getDateDayOrdinal( arguments.date1 );
+			date1Part = ReReplace( date1Part, "(\d{1,2})", "\1#date1Ordinal#" );
 
-            var date2Ordinal = getDateDayOrdinal( arguments.date2 );
-            date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
-        }
+			var date2Ordinal = getDateDayOrdinal( arguments.date2 );
+			date2Part = ReReplace( date2Part, "(\d{1,2})", "\1#date2Ordinal#" );
+		}
 
-        return "#date1Part# - #date2Part#";
-    }
+		return "#date1Part# - #date2Part#";
+	}
 
-    public string function getSplitDate( required array dates, boolean compact=false, numeric compactThreshold=30, boolean includeOrdinal=false ) {
-        var dayMask   = getLongDateFormatDayMask();
-        var dmyOrder  = _getLongDateFormat();
-        var delimiter = ", ";
-        
-        //sort the dates by year
-		ArraySort(arguments.dates, function(a,b) {
-			return DateCompare(a,b, "y");
+	public string function getSplitDate( required array dates, boolean compact=false, numeric compactThreshold=30, boolean includeOrdinal=false ) {
+		var dayMask   = getLongDateFormatDayMask();
+		var dmyOrder  = _getLongDateFormat();
+		var delimiter = ", ";
+
+		// sort the dates by year
+		ArraySort( arguments.dates, function( a, b ) {
+			return DateCompare( a, b, "y" );
 		});
-		
-        //get the unique years from the dates
-        var years = [];
+
+		// get the unique years from the dates
+		var years = [];
 		for( var date in arguments.dates ) {
-			if ( !ArrayContains(years, year(date)) ) {
-				ArrayAppend(years, year(date));
+			if ( !ArrayContains(years, Year( date )) ) {
+				ArrayAppend( years, Year( date ) );
 			}
 		}
-        
-		var formattedDates = [];
-        //loop through the years
-		for(var year in years) {
-			var formattedYearDates = "";
-			var monthDates   = {};
-			var monthNumbers = [];
 
-            //get the dates for the current year
-			var yearDates = ArrayFilter(arguments.dates, function(date) {
-				return year(date) == year;
+		var formattedDates = [];
+		// loop through the years
+		for( var year in years ) {
+			var formattedYearDates = "";
+			var monthDates         = {};
+			var monthNumbers       = [];
+
+			// get the dates for the current year
+			var yearDates = ArrayFilter( arguments.dates, function( date ) {
+				return Year( date ) == year;
 			});
 
-			//loop through the dates for the current year
+			// loop through the dates for the current year
 			for( var date in yearDates ) {
-				var monthNumber = month(date);
-				if ( !ArrayContains(monthNumbers, monthNumber) ) {
-					ArrayAppend(monthNumbers, monthNumber);
+				var monthNumber = Month( date );
+				if ( !ArrayContains( monthNumbers, monthNumber ) ) {
+					ArrayAppend( monthNumbers, monthNumber );
 				}
 
-				if ( !StructKeyExists(monthDates, monthNumber) ) {
-					monthDates[monthNumber] = [];
+				if ( !StructKeyExists( monthDates, monthNumber ) ) {
+					monthDates[ monthNumber ] = [];
 				}
 
-                var monthDate = LSDateFormat(date, dayMask);
+				var monthDate = LSDateFormat( date, dayMask );
 
-                if ( arguments.includeOrdinal && dmyOrder == "DMY" ) {
-                    var dayOrdinal  = getDateDayOrdinal( date );
-                    monthDate &= dayOrdinal;
-                }
+				if ( arguments.includeOrdinal && dmyOrder == "DMY" ) {
+					var dayOrdinal  = getDateDayOrdinal( date );
+					monthDate &= dayOrdinal;
+				}
 
-                ArrayAppend(monthDates[monthNumber], monthDate);
+				ArrayAppend( monthDates[ monthNumber ], monthDate );
 			}
 
-			//sort the month numbers numerically ascending
-			ArraySort(monthNumbers, "numeric", "asc");
+			// sort the month numbers numerically ascending
+			ArraySort( monthNumbers, "numeric", "asc" );
 
-			//loop through the month numbers
-			for( var i=1; i<=ArrayLen(monthNumbers); i++ ) {
+			// loop through the month numbers
+			for( var i=1; i<=ArrayLen( monthNumbers ); i++ ) {
 				//get the month number
-				var monthNumber = monthNumbers[i];
-                
+				var monthNumber = monthNumbers[ i ];
+
 
 				if ( dmyOrder == "DMY" ) {
-					formattedYearDates &= ArrayToList(monthDates[monthNumber], delimiter) & " " & MonthAsString(monthNumber) & delimiter;
+					formattedYearDates &= ArrayToList( monthDates[ monthNumber ], delimiter ) & " " & MonthAsString( monthNumber ) & delimiter;
 				} else if ( dmyOrder == "MDY" || dmyOrder == "YMD" ) {
-					formattedYearDates &= MonthAsString(monthNumber) & " " & ArrayToList(monthDates[monthNumber], delimiter) & delimiter;
+					formattedYearDates &= MonthAsString( monthNumber ) & " " & ArrayToList( monthDates[ monthNumber ], delimiter ) & delimiter;
 				}
 			}
 
-            //strip the trailing delimiter
-			if ( Right(formattedYearDates, 2) == delimiter ) {
-				formattedYearDates = Left(formattedYearDates, Len(formattedYearDates) - Len(delimiter));
+			// strip the trailing delimiter
+			if ( Right( formattedYearDates, 2 ) == delimiter ) {
+				formattedYearDates = Left( formattedYearDates, Len( formattedYearDates ) - Len( delimiter ) );
 			}
 
-            //add the year
+			// add the year
 			if ( dmyOrder == "MDY" ) {
-                formattedYearDates &= ",";
+				formattedYearDates &= ",";
 			}
-            formattedYearDates &= " " & year;
+			formattedYearDates &= " " & year;
 
-			ArrayAppend(formattedDates, formattedYearDates);
+			ArrayAppend( formattedDates, formattedYearDates );
 		}
 
-        return ArrayToList(formattedDates, delimiter);
-    }
+		return ArrayToList( formattedDates, delimiter );
+	}
 
-    public query function getSiteLocaleSettings() {
-        var event                  = $getRequestContext();
-        var currentSite            = event.getSite();
-        var siteId                 = currentSite.id;
+	public struct function getSiteLocaleSettings() {
+		var siteId = $getRequestContext().getSiteId();
 
-        return $getPresideObject( "site" ).selectData(
-              filter = { id=siteId }
-        );
-    }
+		if ( Len( siteId ) ) {
+			return $getPresideObject( "site" ).selectData(
+				  id           = siteId
+				, returntype   = "singleRecordStruct"
+				, selectFields = [
+					  "id"
+					, "locale"
+					, "short_date_format"
+					, "long_date_format"
+					, "time_format"
+				]
+			);
+		}
+		return {};
+	}
 
-    public struct function getDefaultSettingsForLocale() {
-        var localeSettings  = getSiteLocaleSettings();
-        var defaultSettings = $getColdbox().getSetting( "datetime.regionDefaults" );
-        var countryCode     = ListLast(localeSettings.locale, "_");
-        var regionCode      = $translateResource( uri="enum.isoCountries:#countryCode#.region");
-        
-        if ( Len(countryCode) && Len(regionCode) && Structkeyexists(defaultSettings, regionCode) ) {
-            return defaultSettings[regionCode];
-        } else {
-            return defaultSettings["uk"];
-        }
-    }
+	public struct function getDefaultSettingsForLocale() {
+		var localeSettings  = getSiteLocaleSettings();
+		var defaultSettings = $getColdbox().getSetting( "datetime.regionDefaults" );
+		var countryCode     = ListLast( localeSettings.locale, "_" );
+		var regionCode      = $translateResource( uri="enum.isoCountries:#countryCode#.region");
 
-    public string function getDateDayOrdinal( required date date ) {
-        var ordinalTypeA = [ "st", "nd", "rd" ];
-        var ordinal      = "th"
-        var date         = DateFormat( arguments.date, "dd" );
+		if ( Len( countryCode ) && Len( regionCode ) && StructKeyExists( defaultSettings, regionCode ) ) {
+			return defaultSettings[ regionCode ];
+		} else {
+			return defaultSettings[ "uk" ];
+		}
+	}
 
-        if ( ( val( date[1] ) != 1 ) && ( date[2] > 0 && date[2] <= arrayLen( ordinalTypeA) ) ) {
-            ordinal = ordinalTypeA[date[2]];
-        }
+	public string function getDateDayOrdinal( required date date ) {
+		var ordinalTypeA = [ "st", "nd", "rd" ];
+		var ordinal      = "th"
+		var date         = DateFormat( arguments.date, "dd" );
 
-        return ordinal;
-    }
-    
-//PRIVATE FUNCTIONS
-    private string function _getLongDateFormat() {
-        var defaults = getDefaultSettingsForLocale();
+		if ( ( Val( date[1] ) != 1 ) && ( date[ 2 ] > 0 && date[ 2 ] <= ArrayLen( ordinalTypeA ) ) ) {
+			ordinal = ordinalTypeA[ date[ 2 ] ];
+		}
 
-        if ( Len(getSiteLocaleSettings().long_date_format)) {
-            return getSiteLocaleSettings().long_date_format;
-        } else {
-            return defaults.long_date_format;
-        }
-    }
+		return ordinal;
+	}
 
-    
+// PRIVATE FUNCTIONS
+	private string function _getLongDateFormat() {
+		var defaults = getDefaultSettingsForLocale();
+
+		if ( Len( getSiteLocaleSettings().long_date_format ?: "" ) ) {
+			return getSiteLocaleSettings().long_date_format;
+		} else {
+			return defaults.long_date_format;
+		}
+	}
+
 }

--- a/system/services/l10n/TimeFormatService.cfc
+++ b/system/services/l10n/TimeFormatService.cfc
@@ -11,7 +11,7 @@ component {
 	public string function getTimeFormatMask(){
 		var localeSettings  = $helpers.getSiteLocaleSettings();
 		var defaultSettings = $helpers.getDefaultSettingsForLocale();
-		var time_format     = Len( localeSettings.time_format ) ? localeSettings.time_format : defaultSettings.time_format;
+		var time_format     = Len( localeSettings.time_format ?: "" ) ? localeSettings.time_format : defaultSettings.time_format;
 
 		if ( time_format == "12h" ) {
 			return "h:mmtt";

--- a/system/services/l10n/TimeFormatService.cfc
+++ b/system/services/l10n/TimeFormatService.cfc
@@ -1,37 +1,37 @@
 /**
- * @singleton true
+ * @singleton      true
  * @presideService true
  */
 component {
 
-    function init() {
+	public any function init() {
 		return this;
 	}
 
-    public string function getTimeFormatMask(  ){
-        var localeSettings  = $helpers.getSiteLocaleSettings();
-        var defaultSettings = $helpers.getDefaultSettingsForLocale();
-        var time_format     = Len(localeSettings.time_format) ? localeSettings.time_format : defaultSettings.time_format;
-        
-        if( time_format == "12h" ) {
-            return "h:mmtt";
-        }else {
-            return "HH:mm";
-        }
-    }
+	public string function getTimeFormatMask(){
+		var localeSettings  = $helpers.getSiteLocaleSettings();
+		var defaultSettings = $helpers.getDefaultSettingsForLocale();
+		var time_format     = Len( localeSettings.time_format ) ? localeSettings.time_format : defaultSettings.time_format;
 
-    public string function roundHours( string formattedTime ){
-        var localeSettings = $helpers.getSiteLocaleSettings();
-        
-        if ( localeSettings.time_format == "12h" ) {
-            return Replace(arguments.formattedTime, ":00", "", "all");
-        }
+		if ( time_format == "12h" ) {
+			return "h:mmtt";
+		} else {
+			return "HH:mm";
+		}
+	}
 
-        return arguments.formattedTime;
-    }
+	public string function roundHours( string formattedTime ){
+		var localeSettings = $helpers.getSiteLocaleSettings();
 
-    public string function getFormattedTime( required date date ){
-        return LSTimeFormat(arguments.date, getTimeFormatMask());
-    }
+		if ( localeSettings.time_format == "12h" ) {
+			return Replace( arguments.formattedTime, ":00", "", "all" );
+		}
+
+		return arguments.formattedTime;
+	}
+
+	public string function getFormattedTime( required date date ){
+		return LSTimeFormat( arguments.date, getTimeFormatMask() );
+	}
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches locale/date/time formatting and site-locale settings retrieval, so subtle changes could affect formatting output or defaults across sites, though the changes are largely defensive and scoped.
> 
> **Overview**
> Updates site localisation UI controls and services to follow coding standards and improve robustness.
> 
> `SiteLocalePicker` now supports an `admin()` variant that ensures `form-control` styling and consistently appends the `site-locale-picker` class, while injecting `datetime.regionDefaults` directly and normalizing JSON deserialization for client-side locale data.
> 
> `DateFormatService`/`TimeFormatService` and `dateUtils` helpers are reformatted and tightened: locale settings are now fetched as a struct via `getSiteId()` with explicit `selectFields`, missing values are guarded with null-safe defaults, and helper return types are aligned accordingly; site add/edit form XML changes are cosmetic alignment only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5cccad69edf6e19f9dc65110d96f68c3294a49d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->