### PR TITLE
PRESIDECMS-3239 website user auto login remember me cookie conflict

### DIFF
--- a/system/services/websiteUsers/WebsiteLoginService.cfc
+++ b/system/services/websiteUsers/WebsiteLoginService.cfc
@@ -680,6 +680,15 @@ component displayName="Website login service" {
 		}
 
 		if ( _getCookieService().exists( _getRememberMeCookieKey() ) ) {
+			var allowRememberMe = _getSystemConfigurationService().getSetting( "website_users", "allow_remember_me", true );
+
+			if ( $helpers.isFalse( allowRememberMe ) ) {
+				_deleteRememberMeCookie();
+
+				request._presideWebsiteAutoLoginResult = false;
+				return false;
+			}
+
 			var cookieValue = _readRememberMeCookie();
 			var user        = _getUserRecordFromCookie( cookieValue, securityAlertCallback );
 

--- a/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
+++ b/tests/unit/api/websiteUsers/WebsiteLoginServiceTest.cfc
@@ -499,6 +499,7 @@ component output="false" extends="tests.resources.HelperObjects.PresideTestCase"
 		mockResetDao.$( "deleteData", 1 );
 		mockRequestContext.$( "isBackgroundThread", false );
 		service.$property( propertyName="$helpers", mock=mockHelpers );
+		mockSysConfigService.$( "getSetting" ).$args( "website_users", "allow_remember_me", true ).$results( true );
 		mockHelpers.$( method="isTrue", callBack=function( val ){
 			return IsBoolean( arguments.val ) && arguments.val;
 		} );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to the website user autologin flow; risk is limited to potentially disabling existing remember-me sessions when the config is turned off.
> 
> **Overview**
> Website user auto-login via the remember-me cookie now checks the `website_users.allow_remember_me` system setting before attempting cookie-based authentication.
> 
> When the setting is disabled, the service proactively deletes the remember-me cookie and short-circuits auto-login to `false`, preventing cookie/session conflicts. Unit tests were updated to mock the new `getSetting()` call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f895b3b3b03a69373e316f74980aa7c94bd5b8d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->