### PR TITLE
PRESIDECMS-3240 space styling issue on rendering the hidden tab in admin drop down

### DIFF
--- a/system/assets/css/admin/specific/datamanager/viewTabs/viewtabs.less
+++ b/system/assets/css/admin/specific/datamanager/viewTabs/viewtabs.less
@@ -13,6 +13,18 @@
 				color: inherit;
 				background-color: inherit;
 			}
+
+			.view-record-detail-dropdown {
+				> li {
+					a {
+						display: block;
+
+						> i {
+							margin-right: 0;
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/system/views/admin/datamanager/_tabs.cfm
+++ b/system/views/admin/datamanager/_tabs.cfm
@@ -44,7 +44,7 @@
 					<a class="dropdown-toggle" data-toggle="dropdown" href="##" role="button" aria-haspopup="true" aria-expanded="false">
 						&hellip; <span class="caret"></span>
 					</a>
-					<ul class="dropdown-menu pull-right">
+					<ul class="dropdown-menu view-record-detail-dropdown pull-right">
 						<cfloop from="#( maxTabs + 1 )#" to="#ArrayLen( tabs )#" index="i">
 							<cfset tab = tabs[ i ] />
 							<li<cfif tab.id eq activeTab> class="active"</cfif>>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only styling tweak scoped to the datamanager tabs overflow dropdown; low risk aside from minor UI regressions in that menu.
> 
> **Overview**
> Fixes the styling of hidden/overflow Data Manager tabs shown in the admin tabs dropdown.
> 
> The dropdown menu in `system/views/admin/datamanager/_tabs.cfm` now includes a dedicated `view-record-detail-dropdown` class, and `viewtabs.less` adds targeted rules to make dropdown items block-level and remove extra icon spacing to prevent unwanted gaps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9158393d62c1aa5b9609d4ab5d0e68e77eb4acad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->