### PR TITLE
PRESIDECMS-3241 admin validation error placement for radio checkbox

### DIFF
--- a/system/assets/js/admin/presidecore/preside.validation.defaults.js
+++ b/system/assets/js/admin/presidecore/preside.validation.defaults.js
@@ -32,7 +32,7 @@
 
 		errorPlacement: function (error, element) {
 			if(element.is(':checkbox') || element.is(':radio')) {
-				var controls = element.closest('div[class*="col-"]');
+				var controls = element.closest('.form-group > div');
 				if(controls.find(':checkbox,:radio').length > 1) controls.append(error);
 				else error.insertAfter(element.nextAll('.lbl:eq(0)').eq(0));
 			}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized DOM selector change that only affects where validation errors render for checkbox/radio inputs in the admin UI.
> 
> **Overview**
> Updates admin form validation `errorPlacement` for checkbox/radio inputs to locate the containing controls via `.form-group > div` instead of a Bootstrap `col-*` selector, improving error message placement for varied layouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9062de48155ebaee2f13d30f2b61156e50cdf4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->