### PR TITLE
PRESIDECMS-3243 many to one admin view

### DIFF
--- a/system/handlers/renderers/content/ManyToOne.cfc
+++ b/system/handlers/renderers/content/ManyToOne.cfc
@@ -20,8 +20,10 @@ component {
 			, defaultValue  = propertyName
 		);
 
-		args.recordLink = event.buildAdminLink( objectName=fkObjectName, recordId=fkId );
-		args.recordLabel = renderLabel( fkObjectName, fkId );
+		if( Len( fkObjectName ) && presideObjectService.dataExists( objectName=fkObjectName, id=fkId ) ){
+			args.recordLink = event.buildAdminLink( objectName=fkObjectName, recordId=fkId );
+			args.recordLabel = renderLabel( fkObjectName, fkId );
+		}
 
 		return renderView( view="/renderers/content/manyToOne/adminView", args=args );
 


### PR DESCRIPTION
Since the admin datamanager is getting the data from versioned table, some of the deleted record via cascade delete / set null from relationship table is not reflected properly in the version table, hence a quick check if object exists before generating the link would help to hide link with not found / deleted record.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a guard to avoid rendering admin links/labels when the related record no longer exists, which should only change display behavior for stale FK values.
> 
> **Overview**
> Prevents the Many-to-One admin renderer (`ManyToOne.cfc`) from generating a related-record link/label when the target record is missing.
> 
> `adminView` now checks `presideObjectService.dataExists()` (and that the related object name is non-empty) before calling `event.buildAdminLink()` and `renderLabel()`, avoiding broken links for deleted/cascaded relationships.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2e6f589cf1d3604f97776081c7551b048b91d79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->