### PR TITLE
PRESIDECMS-3246 extend customisation ability for admin listing with categories

### DIFF
--- a/system/views/admin/datamanager/_listingWithCategories.cfm
+++ b/system/views/admin/datamanager/_listingWithCategories.cfm
@@ -3,6 +3,8 @@
 	categoryField     = args.listingCategoryField ?: "";
 	listingCategories = args.allListingCategories ?: [];
 	listingView       = args.currentListingView   ?: "";
+	allRecordsLink    = args.allRecordsLink       ?: event.buildAdminLink( objectName=objectName );
+	categoryLinkBase  = args.categoryLinkBase     ?: event.buildAdminLink( objectName=objectName, queryString="activeCategoryId={activeCategoryId}" );
 	activeCategoryId  = Trim( rc.activeCategoryId ?: "" );
 </cfscript>
 
@@ -11,7 +13,7 @@
 		<div class="tabbable tabs-left">
 			<ul class="nav nav-tabs">
 				<li<cfif !Len( activeCategoryId )> class="active"</cfif>>
-					<a href="#event.buildAdminLink( objectName=objectName )#">
+					<a href="#allRecordsLink#">
 						#translateResource(
 							  uri          = "preside-objects.#objectName#:datamanager.records.category.all.label"
 							, defaultValue = translateResource( uri="cms:datamanager.records.category.all.label" )
@@ -20,7 +22,7 @@
 				</li>
 				<cfloop array="#listingCategories#" item="listingCategory">
 					<li<cfif activeCategoryId eq listingCategory.id> class="active"</cfif>>
-						<a href="#event.buildAdminLink( objectName=objectName, queryString="activeCategoryId=#listingCategory.id#" )#">
+						<a href="#ReplaceNoCase( categoryLinkBase, "{activeCategoryId}", listingCategory.id )#">
 							#listingCategory.label#
 						</a>
 					</li>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk view-layer change that only affects how category navigation URLs are constructed in the admin datamanager listing.
> 
> **Overview**
> Updates `system/views/admin/datamanager/_listingWithCategories.cfm` to allow customization of the category tab navigation links by accepting `args.allRecordsLink` and `args.categoryLinkBase` overrides. The view now uses these computed/overridable URLs (with `{activeCategoryId}` substitution) instead of always calling `event.buildAdminLink()` inline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f568d22e343f9ef2127cc53a6553ba04773ccbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->