### PR TITLE
PRESIDECMS-3248 admin bootbox modal js error

### DIFF
--- a/system/assets/js/admin/presidecore/preside.bootbox.modal.js
+++ b/system/assets/js/admin/presidecore/preside.bootbox.modal.js
@@ -76,7 +76,7 @@
 				} else {
 					$.ajax( {
 						  method  : "GET"
-						, url     : $modalLink.attr( 'href' )
+						, url     : $modalLink.data( 'href' )
 						, cache   : false
 						, success : function( content ){ setupConfig( content ); }
 					} );
@@ -97,7 +97,13 @@
 	$( 'body' ).on( "click", '[data-toggle="bootbox-modal"]', function( e ){
 		e.preventDefault();
 
-		var $link = $( this );
+		var $link    = $( this )
+		  , linkHref = $link.attr( 'href' );
+
+		if ( linkHref !== 'javascript:void(0)' ) {
+			$link.data( 'href', linkHref );
+			$link.attr( 'href', 'javascript:void(0)' );
+		}
 
 		if ( !$link.data( "presideBootboxModal" ) ) {
 			$link.presideBootboxModal( {} ).click();

--- a/system/assets/js/admin/presidecore/preside.bootbox.modal.js
+++ b/system/assets/js/admin/presidecore/preside.bootbox.modal.js
@@ -71,7 +71,7 @@
 					callback( config );
 				};
 
-				var linkHref = $modalLink.data( 'href' )
+				var linkHref = $modalLink.data( 'href' ) || $modalLink.attr( 'href' )
 				  , hash     = ( linkHref && linkHref.indexOf( '#' ) !== -1 ) ? linkHref.slice( linkHref.indexOf( '#' ) ) : '';
 
 				if ( hash.length ) {

--- a/system/assets/js/admin/presidecore/preside.bootbox.modal.js
+++ b/system/assets/js/admin/presidecore/preside.bootbox.modal.js
@@ -71,12 +71,15 @@
 					callback( config );
 				};
 
-				if ( $modalLink.get(0).hash.length ) {
-					setupConfig( $( $modalLink.get(0).hash ).html() );
+				var linkHref = $modalLink.data( 'href' )
+				  , hash     = ( linkHref && linkHref.indexOf( '#' ) !== -1 ) ? linkHref.slice( linkHref.indexOf( '#' ) ) : '';
+
+				if ( hash.length ) {
+					setupConfig( $( hash ).html() );
 				} else {
 					$.ajax( {
 						  method  : "GET"
-						, url     : $modalLink.data( 'href' )
+						, url     : linkHref
 						, cache   : false
 						, success : function( content ){ setupConfig( content ); }
 					} );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized to admin modal link handling; main risk is regressions if callers rely on the original `href` remaining on the anchor element.
> 
> **Overview**
> Fixes bootbox modal initialization to **stop relying on the anchor’s live `href`/`.hash`**, instead caching the original URL in `data-href` and using it to resolve `#fragment` inline content or perform the modal content AJAX request.
> 
> The click delegate now rewrites modal trigger links to `javascript:void(0)` after caching the original `href`, preventing subsequent JS errors from mutated/empty `href` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cb9dc7efc4a04f704fa30534675022eeced456e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->