### PR TITLE
Feature presidecms 3249 second date field when using between doesnt pass the value

### DIFF
--- a/system/assets/js/admin/specific/timePeriodPicker/timePeriodPicker.js
+++ b/system/assets/js/admin/specific/timePeriodPicker/timePeriodPicker.js
@@ -38,8 +38,8 @@
 				$typeControl.on( "change", updateTimePeriodValue );
 				$measureControl.on( "change", updateTimePeriodValue );
 				$unitControl.on( "change", updateTimePeriodValue );
-				$date1Control.on( "dp.change", updateTimePeriodValue );
-				$date2Control.on( "dp.change", updateTimePeriodValue );
+				$date1Control.on( "change dp.change", updateTimePeriodValue );
+				$date2Control.on( "change dp.change", updateTimePeriodValue );
 			};
 
 			showAndHideFieldsBasedOnPeriodType = function(){


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, isolated frontend event-binding change with minimal blast radius. Risk is limited to time period picker updates potentially firing more often than before.
> 
> **Overview**
> Ensures the admin `timePeriodPicker` updates its hidden JSON value when either date input changes by binding `updateTimePeriodValue` to both `change` and `dp.change` events for `date1` and `date2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ec994bdd398ef26bca7d3f453e0728d9f27f022. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->