### PR TITLE
PRESSYNCED-3033 exclude select data view properties from export field list

### DIFF
--- a/system/handlers/formcontrols/DataExportFieldPicker.cfc
+++ b/system/handlers/formcontrols/DataExportFieldPicker.cfc
@@ -22,7 +22,13 @@ component {
 		args.sortable     = true;
 
 		for( var prop in propertyNames ) {
-			if ( !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" ) && !IsTrue( props[ prop ].excludeDataExport ?: "" ) ) {
+			var propRelationship = props[ prop ].relationship ?: "";
+
+			if ( propRelationship == "select-data-view" ) {
+				continue;
+			}
+
+			if ( !propRelationship.reFindNoCase( "to\-many$" ) && !IsTrue( props[ prop ].excludeDataExport ?: "" ) ) {
 				args.values.append( prop );
 			}
 		}

--- a/system/services/dataExport/DataExportService.cfc
+++ b/system/services/dataExport/DataExportService.cfc
@@ -424,6 +424,7 @@ component {
 				switch( prop.relationship ?: "" ) {
 					case "one-to-many":
 					case "many-to-many":
+					case "select-data-view":
 						continue;
 					break;
 					case "many-to-one":
@@ -518,6 +519,12 @@ component {
 				continue;
 			}
 
+			var propRelationship = props[ prop ].relationship ?: "";
+
+			if ( propRelationship == "select-data-view" ) {
+				continue;
+			}
+
 			var shouldInclude = !ArrayFindNoCase( defaultExcludeFields, prop ) && !$helpers.isTrue( props[ prop ].excludeDataExport ?: "" );
 			if ( ArrayLen( defaultIncludeFields ) ) {
 				shouldInclude = shouldInclude && ArrayFindNoCase( shouldInclude, prop );
@@ -527,7 +534,7 @@ component {
 				shouldInclude = !$helpers.isTrue( props[ prop ].excludeNestedDataExport ?: "" );
 			}
 
-			if ( shouldInclude && !( props[ prop ].relationship ?: "" ).reFindNoCase( "to\-many$" ) ) {
+			if ( shouldInclude && !propRelationship.reFindNoCase( "to\-many$" ) ) {
 				var hasPermission     = true;
 				var requiredRoleCheck = StructKeyExists( props[ prop ], "limitToAdminRoles" )
 				                     && ( args.context ?: "" ) == "admin"
@@ -541,7 +548,7 @@ component {
 				}
 
 				if ( hasPermission ) {
-					var shouldExpand = arguments.expandNestedRelationField && ( ( props[ prop ].relationship ?: "" ) == "many-to-one" );
+					var shouldExpand = arguments.expandNestedRelationField && ( propRelationship == "many-to-one" );
 					var expandFields = [];
 
 					if ( shouldExpand ) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the logic that determines which object properties are selectable/auto-included for data export, which could alter exported columns for objects using `select-data-view` relationships.
> 
> **Overview**
> **Excludes `select-data-view` properties from data export field selection.** The export field picker (`DataExportFieldPicker.cfc`) now skips properties whose `relationship` is `select-data-view` so they no longer appear in the selectable field list.
> 
> **Aligns backend default/allowed export field generation with the UI.** `DataExportService.cfc` now also treats `select-data-view` like other non-exportable relationships when building default export fields and the allowed export property list, while refactoring relationship checks to reuse a local `propRelationship` variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f9fc956315e26bec5abc7ff0141097d1d0223f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->