### PR TITLE
PRESSYNCED-3040 allow draft manager to manage multiple new record drafts

### DIFF
--- a/system/services/draftManager/DraftManagerService.cfc
+++ b/system/services/draftManager/DraftManagerService.cfc
@@ -124,7 +124,7 @@ component {
 				}
 			);
 
-			if ( $helpers.isEmptyString( draft.id ?: "" ) ) {
+			if ( !$helpers.isEmptyString( draft.id ?: "" ) ) {
 				$getPresideObject( "draftmanager_draft" ).updateData(
 					  id   = draft.id
 					, data = {

--- a/system/services/draftManager/DraftManagerService.cfc
+++ b/system/services/draftManager/DraftManagerService.cfc
@@ -112,41 +112,43 @@ component {
 		,          string recordId = ""
 		,          struct data     = {}
 	) {
-		var draft = $getPresideObject( "draftmanager_draft" ).selectData(
-			  selectFields = [ "id" ]
-			, filter       = "_object_name = :_object_name and _record_id = :_record_id and _status != 'publish'"
-			, filterParams = {
-				  _object_name = { type="cf_sql_varchar", value=arguments.objectName }
-				, _record_id   = { type="cf_sql_varchar", value=arguments.recordId   }
-			  }
-		);
-
 		var label = _getDraftLabel( objectName=arguments.objectName, data=arguments.data );
 
-		if ( $helpers.isEmptyString( draft.id ?: "" ) ) {
-			return $getPresideObject( "draftmanager_draft" ).insertData(
-				data = {
-					  label                   = label
-					, _object_name            = arguments.objectName
-					, _record_id              = arguments.recordId
-					, _workflow_id            = getWorkflowId( objectName=arguments.objectName )
-					, _data                   = SerializeJSON( arguments.data )
-					, _security_user_created  = $getAdminLoggedInUserId()
-					, _security_user_modified = $getAdminLoggedInUserId()
+		if ( Len( arguments.recordId ) ) {
+			var draft = $getPresideObject( "draftmanager_draft" ).selectData(
+				  selectFields = [ "id" ]
+				, filter       = "_object_name = :_object_name and _record_id = :_record_id and _status != 'publish'"
+				, filterParams = {
+					  _object_name = { type="cf_sql_varchar", value=arguments.objectName }
+					, _record_id   = { type="cf_sql_varchar", value=arguments.recordId   }
 				}
 			);
-		} else {
-			$getPresideObject( "draftmanager_draft" ).updateData(
-				  id   = draft.id
-				, data = {
-					  label                   = label
-					, _data                   = SerializeJSON( arguments.data )
-					, _security_user_modified = $getAdminLoggedInUserId()
-				  }
-			);
 
-			return draft.id;
+			if ( $helpers.isEmptyString( draft.id ?: "" ) ) {
+				$getPresideObject( "draftmanager_draft" ).updateData(
+					  id   = draft.id
+					, data = {
+						  label                   = label
+						, _data                   = SerializeJSON( arguments.data )
+						, _security_user_modified = $getAdminLoggedInUserId()
+					}
+				);
+
+				return draft.id;
+			}
 		}
+
+		return $getPresideObject( "draftmanager_draft" ).insertData(
+			data = {
+				  label                   = label
+				, _object_name            = arguments.objectName
+				, _record_id              = arguments.recordId
+				, _workflow_id            = getWorkflowId( objectName=arguments.objectName )
+				, _data                   = SerializeJSON( arguments.data )
+				, _security_user_created  = $getAdminLoggedInUserId()
+				, _security_user_modified = $getAdminLoggedInUserId()
+			}
+		);
 	}
 
 	public boolean function updateDraftStatusForObject(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes draft persistence logic and could alter whether drafts are inserted vs updated, impacting draft duplication or overwrites for existing records.
> 
> **Overview**
> Adjusts `DraftManagerService.saveDraftDataForObject()` so draft saves only attempt to find/update an existing draft when a `recordId` is present; when creating a new record (empty `recordId`), each save now inserts a new `draftmanager_draft` row instead of reusing a single draft.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492b08f53e08dd455856383b2d8789877460df74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->