### PR TITLE
PRESIDECMS-3266 data manager no records shows showing 1 to 0 of 0 rec…

### DIFF
--- a/system/assets/js/admin/specific/datamanager/object/listingTable.js
+++ b/system/assets/js/admin/specific/datamanager/object/listingTable.js
@@ -288,7 +288,9 @@
 					fnInfoCallback: function( oSettings, iStart, iEnd, iMax, iTotal, sPre ) {
 						var info = "";
 
-						if ( iTotal == UNKNOWN_TOTAL ) {
+						if ( iTotal === 0 ) {
+							info = i18n.translateResource( "cms:datatables.infoEmpty", { data : [objectTitle], defaultValue : "" } );
+						} else if ( iTotal == UNKNOWN_TOTAL ) {
 							info = i18n.translateResource( "cms:datatables.infoCountUnknown", { data : [objectTitle], defaultValue : "" } );
 						} else {
 							info = i18n.translateResource( "cms:datatables.info", { data : [objectTitle], defaultValue : "" } );


### PR DESCRIPTION
…ords

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to DataTables info rendering when there are no results; no data, auth, or server-side logic is modified.
> 
> **Overview**
> Fixes the Data Manager listing table’s `fnInfoCallback` so that when `iTotal === 0` it uses the `cms:datatables.infoEmpty` message, avoiding the misleading “showing 1 to 0 of 0 records” display.
> 
> The existing “unknown total” case (`iTotal == UNKNOWN_TOTAL`) and normal count handling remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3530f26ed78a736f34e73f4525543a8e114477b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->