### PR TITLE
PRESIDECMS-3244 - Allowed plus sign for query string field on link picker

### DIFF
--- a/system/services/validation/CoreValidators.cfc
+++ b/system/services/validation/CoreValidators.cfc
@@ -364,9 +364,9 @@ component validationProvider=true {
 	}
 
 	public boolean function queryString( required string fieldName, any value="" ) validatorMessage="cms:validation.queryString.default" {
-		return IsEmpty( arguments.value ) || ReFindNoCase( "^([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-,]*)?)*)?$", arguments.value );
+		return IsEmpty( arguments.value ) || ReFindNoCase( "^([\w-]+(=[\w-+,]*)?(&[\w-]+(=[\w-+,]*)?)*)?$", arguments.value );
 	}
 	public string function queryString_js() validatorMessage="validationExtras:validation.simpleUrl.default" {
-		return "function( value, el, params ){ return !value.length || value.match( /^([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-,]*)?)*)?$/i ) !== null }";
+		return "function( value, el, params ){ return !value.length || value.match( /^([\w-]+(=[\w-+,]*)?(&[\w-]+(=[\w-+,]*)?)*)?$/i ) !== null }";
 	}
 }


### PR DESCRIPTION
…ield on link picker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk regex tweak to input validation; main risk is slightly broadening accepted query string characters, potentially allowing previously-invalid inputs through.
> 
> **Overview**
> Updates the `queryString` validator in `CoreValidators.cfc` (server and `*_js` client version) to accept `+` characters in query-string parameter values, aligning link picker validation with common URL-encoding usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d3842232016cab269ad74f1cc5dcf4bf724b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->