### PR TITLE
PRESIDECMS-3282 fix logic around setting config form tenancy

### DIFF
--- a/system/services/configuration/SystemConfigurationService.cfc
+++ b/system/services/configuration/SystemConfigurationService.cfc
@@ -401,6 +401,8 @@ component displayName="System configuration service" {
 		var categories     = _getConfigCategories();
 		var formName       = _getConventionsBaseCategoryForm( arguments.id );
 		var formAttributes = _getFormsService().getForm( formName );
+		var tenant         = _normalizeTenant( formAttributes.tenancy ?: "" );
+		var noTenancy      = Len( tenant ) == 0 || $helpers.isTrue( formAttributes.notenancy ?: "" );
 
 		categories[ arguments.id ] = new ConfigCategory(
 			  id               = arguments.id
@@ -408,9 +410,9 @@ component displayName="System configuration service" {
 			, description      = _getConventionsBaseCategoryDescription( arguments.id )
 			, icon             = _getConventionsBaseCategoryIcon( arguments.id )
 			, form             = formName
-			, siteForm         = _getConventionsBaseSiteCategoryForm( arguments.id, formAttributes.tenancy ?: "" )
-			, tenancy          = formAttributes.tenancy ?: "site"
-			, noTenancy        = $helpers.isTrue( formAttributes.notenancy ?: "" )
+			, siteForm         = noTenancy ? "" : _getConventionsBaseSiteCategoryForm( arguments.id )
+			, tenancy          = tenant
+			, noTenancy        = noTenancy
 		);
 	}
 
@@ -426,11 +428,7 @@ component displayName="System configuration service" {
 	private string function _getConventionsBaseCategoryForm( required string id ) {
 		return "system-config.#arguments.id#";
 	}
-	private string function _getConventionsBaseSiteCategoryForm( required string id, required string tenant ) {
-		if ( !Len( arguments.tenant ) || ( arguments.tenant == "site" && !$isFeatureEnabled( "sites" ) ) ) {
-			return "";
-		}
-
+	private string function _getConventionsBaseSiteCategoryForm( required string id ) {
 		var fullFormName = _getConventionsBaseCategoryForm( arguments.id );
 
 		return _getFormsService().createForm( basedOn=fullFormName, generator=function( definition ){
@@ -465,6 +463,14 @@ component displayName="System configuration service" {
 		}
 
 		return filter;
+	}
+
+	private string function _normalizeTenant( required string tenant ) {
+		if ( !Len( Trim( arguments.tenant ) ) && $isFeatureEnabled( "sites" ) ) {
+			return "site";
+		}
+
+		return Trim( arguments.tenant );
 	}
 
 // GETTERS AND SETTERS


### PR DESCRIPTION
* Simplify and deduplicate
* Always generate category form if we have a tenant
* Only default to "site" tenancy if sites feature is enabled
* Always set noTenancy when we have an empty tenant
