### PR TITLE
Presidecms 3289 open count bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"gitflow.disableOnRepo": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"gitflow.disableOnRepo": true
-}

--- a/system/services/email/EmailLoggingService.cfc
+++ b/system/services/email/EmailLoggingService.cfc
@@ -351,7 +351,7 @@ component {
 		,          string  ipAddress = cgi.remote_addr
 		,          date    eventDate = Now()
  	) {
-		var data = { opened = true, opened_count=1 };
+		var data = { opened = true, open_count=1 };
 
 		if ( !arguments.softMark ) {
 			data.opened_date = _getNow();

--- a/tests/unit/api/email/EmailLoggingServiceTest.cfc
+++ b/tests/unit/api/email/EmailLoggingServiceTest.cfc
@@ -332,7 +332,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				expect( mockLogDao.$callLog().updateData[ 1 ] ).toBe( {
 					  filter       = "id = :id and ( opened is null or opened = :opened )"
 					, filterParams = { id=logId, opened=false }
-					, data         = { opened=true, opened_date=nowish, opened_count=1 }
+					, data         = { opened=true, opened_date=nowish, open_count=1 }
 				} );
 				expect( service.$callLog().markAsDelivered.len() ).toBe( 1 );
 				expect( service.$callLog().markAsDelivered[1] ).toBe( [ logId, true ] );
@@ -356,7 +356,7 @@ component extends="resources.HelperObjects.PresideBddTestCase" {
 				expect( mockLogDao.$callLog().updateData[ 1 ] ).toBe( {
 					  filter       = "id = :id and ( opened is null or opened = :opened )"
 					, filterParams = { id=logId, opened=false }
-					, data         = { opened=true, opened_count=1 }
+					, data         = { opened=true, open_count=1 }
 				} );
 				expect( service.$callLog().markAsDelivered.len() ).toBe( 1 );
 				expect( service.$callLog().markAsDelivered[1] ).toBe( [ logId, true ] );


### PR DESCRIPTION
for the first opening of an email, the open_count field wasn't set correctly, because the field name was opened_count.

To correct the statistics afterwards, here's some sql:

```
-- One-off backfill: repair psys_email_template_send_log.open_count
--
-- Background: markAsOpened() used opened_count instead of open_count on the first
-- open, so many rows have opened = 1 but open_count = 0 (or open_count too low).
--
-- Run against the Preside datasource (MySQL). Table prefix psys_ is the default
-- for system objects; adjust if your environment uses a different prefix.
--
-- Suggested workflow:
--   1. Run the preview SELECT below and review counts.
--   2. Take a DB backup.
--   3. Run steps 1 and 2 in a transaction (COMMIT when satisfied).

-- ---------------------------------------------------------------------------
-- Preview: rows that will be affected
-- ---------------------------------------------------------------------------
SELECT
    COUNT(*) AS rows_opened_but_zero_count
FROM psys_email_template_send_log
WHERE opened = 1
  AND COALESCE(open_count, 0) = 0;

SELECT
    l.id,
    l.recipient,
    l.opened,
    l.open_count AS current_open_count,
    COALESCE(sub.activity_open_count, 0) AS activity_open_count
FROM psys_email_template_send_log AS l
LEFT JOIN (
    SELECT message, COUNT(1) AS activity_open_count
    FROM psys_email_template_send_log_activity
    WHERE activity_type = 'open'
    GROUP BY message
) AS sub ON sub.message = l.id
WHERE l.opened = 1
  AND COALESCE(l.open_count, 0) = 0
LIMIT 50;

-- ---------------------------------------------------------------------------
-- Backfill (run inside a transaction)
-- ---------------------------------------------------------------------------
-- START TRANSACTION;

-- Step 1: set open_count from recorded "open" activities (source of truth)
UPDATE psys_email_template_send_log AS l
INNER JOIN (
    SELECT COUNT(1) AS n, message
    FROM psys_email_template_send_log_activity
    WHERE activity_type = 'open'
    GROUP BY message
) AS sub ON sub.message = l.id
SET l.open_count = sub.n
WHERE COALESCE(l.open_count, 0) <> sub.n;

-- Step 2: opened = 1 but still no count (e.g. no activity row was stored)
UPDATE psys_email_template_send_log
SET open_count = 1
WHERE opened = 1
  AND COALESCE(open_count, 0) = 0;

-- COMMIT;
-- ROLLBACK;

-- ---------------------------------------------------------------------------
-- Verify
-- ---------------------------------------------------------------------------
SELECT COUNT(*) AS remaining_opened_but_zero_count
FROM psys_email_template_send_log
WHERE opened = 1
  AND COALESCE(open_count, 0) = 0;
```