### PR TITLE
PRESIDECMS-3224 silently drop and ignore statusText when setting response code

### DIFF
--- a/system/coldboxModifications/RequestContext.cfc
+++ b/system/coldboxModifications/RequestContext.cfc
@@ -534,7 +534,7 @@ component serializable=false accessors=true extends="coldbox.system.web.context.
 
 		// status code? We do not add to response headers as this is a separate marker identifier to the response
 		if( structKeyExists( arguments, "statusCode" ) ){
-			getPageContext().getResponse().setStatus( javaCast( "int", arguments.statusCode ), javaCast( "string", arguments.statusText ) );
+			getPageContext().getResponse().setStatus( javaCast( "int", arguments.statusCode ) );
 		}
 		// Name Exists
 		else if( structKeyExists( arguments, "name" ) ){


### PR DESCRIPTION
This is because it has been deprecated for over a decade and fully dropped in jakarta jee