### PR TITLE
fix: DataTables in iframe modals shows 0 rows on initial load

### DIFF
--- a/system/assets/js/admin/presidecore/preside.iframe.modal.js
+++ b/system/assets/js/admin/presidecore/preside.iframe.modal.js
@@ -103,12 +103,20 @@
 				} );
 			}
 
-			if ( typeof callbacks.onShow === "function" ) {
-				modal.on( "shown.bs.modal", function(){
-					modal.off( "shown.bs.modal" );
-					callbacks.onShow( modal, getIframe() );
-				} );
-			}
+			modal.on( "shown.bs.modal", function(){
+				modal.off( "shown.bs.modal" );
+				var iframeWin = getIframe();
+
+				if ( iframeWin && iframeWin.presideJQuery ) {
+					iframeWin.presideJQuery( "table.object-listing-table" ).each( function(){
+						try { iframeWin.presideJQuery( this ).dataTable().fnDraw(); } catch(e) {}
+					} );
+				}
+
+				if ( typeof callbacks.onShow === "function" ) {
+					callbacks.onShow( modal, iframeWin );
+				}
+			} );
 
 			modal.modal( "show" );
 		};


### PR DESCRIPTION
## Problem

When a `PresideIframeModal` is opened (e.g. when managing a one-to-many 
relationship via `manageOneToManyRecords`), any DataTables grid inside the 
iframe renders 0 rows on initial load despite a successful AJAX response.

The root cause: Preside wraps the iframe in `<div style="display:none;">` 
during setup. DataTables initialises and fires its first AJAX request while 
the container is still hidden. Since column dimensions are zero at that 
point, the returned rows are not rendered.

The issue manifests in modern Chromium-based browsers and is observable 
whenever a one-to-many listing is opened as an iframe modal in the Preside 
admin.

**Workaround (before this fix):** typing any character into the search field 
and deleting it triggers a redraw and the rows appear.

## Fix

Bind `fnDraw()` to the `shown.bs.modal` Bootstrap event so that all 
`object-listing-table` DataTables inside the iframe redraw once the modal 
animation has completed and the container has proper dimensions.

The existing `onShow` callback behaviour is preserved.

## Affected versions

This issue affects older Preside CMS versions as well and the fix should 
be backported accordingly.