### PR TITLE
PRESIDECMS-3304 upsertData and other transaction improvements

### DIFF
--- a/system/services/assetManager/AssetQueueService.cfc
+++ b/system/services/assetManager/AssetQueueService.cfc
@@ -120,33 +120,31 @@ component implements="preside.system.services.assetManager.IAssetQueue" {
 	 * @autodoc true
 	 */
 	public struct function getNextQueuedAsset() {
-		transaction {
-			var takenByOtherProcess = false;
-			var queueDao            = $getPresideObject( "asset_generation_queue" );
-			var queuedAsset         = queueDao.selectData(
-				  selectFields = [ "id", "asset", "asset_version", "derivative_name", "retry_count", "context" ]
-				, filter       = "queue_status = :queue_status"
-				, filterParams = { queue_status="pending" }
-				, orderby      = "retry_count,datecreated"
-				, maxRows      = 1
+		var takenByOtherProcess = false;
+		var queueDao            = $getPresideObject( "asset_generation_queue" );
+		var queuedAsset         = queueDao.selectData(
+			  selectFields = [ "id", "asset", "asset_version", "derivative_name", "retry_count", "context" ]
+			, filter       = "queue_status = :queue_status"
+			, filterParams = { queue_status="pending" }
+			, orderby      = "retry_count,datecreated"
+			, maxRows      = 1
+		);
+
+		for( var q in queuedAsset ) {
+			var updated = queueDao.updateData(
+				  filter       = "id = :id and queue_status = :queue_status"
+				, filterParams = { id=q.id, queue_status="pending" }
+				, data         = { queue_status = "running" }
 			);
 
-			for( var q in queuedAsset ) {
-				var updated = queueDao.updateData(
-					  filter       = "id = :id and queue_status = :queue_status"
-					, filterParams = { id=q.id, queue_status="pending" }
-					, data         = { queue_status = "running" }
-				);
+			if ( updated ) {
+				q.context = IsJSON( q.context ?: "" ) ? DeserializeJSON( q.context ) : {};
 
-				if ( updated ) {
-					q.context = IsJSON( q.context ?: "" ) ? DeserializeJSON( q.context ) : {};
-
-					return q;
-				}
-
-				takenByOtherProcess = true;
-				break;
+				return q;
 			}
+
+			takenByOtherProcess = true;
+			break;
 		}
 
 		if ( takenByOtherProcess ) {

--- a/system/services/configuration/SystemConfigurationService.cfc
+++ b/system/services/configuration/SystemConfigurationService.cfc
@@ -191,19 +191,21 @@ component displayName="System configuration service" {
 	 * See [[editablesystemsettings]] for a full guide.
 	 *
 	 * @autodoc
-	 * @category.hint  Category name of the setting to save
-	 * @setting.hint   Name of the setting to save
-	 * @value.hint     Value to save
-	 * @siteId.hint    Deprecated (use tenantId): ID of site to which the setting applies (optional, if empty setting is treated as system wide default)
-	 * @tenantId.hint  ID of the tenant to which the setting applies (optional, if empty setting is treated as system wide default)
+	 * @category.hint       Category name of the setting to save
+	 * @setting.hint        Name of the setting to save
+	 * @value.hint          Value to save
+	 * @siteId.hint         Deprecated (use tenantId): ID of site to which the setting applies (optional, if empty setting is treated as system wide default)
+	 * @tenantId.hint       ID of the tenant to which the setting applies (optional, if empty setting is treated as system wide default)
+	 * @skipVersioning.hint Whether to skip versioning of the setting
 	 *
 	 */
 	public any function saveSetting(
-		  required string category
-		, required string setting
-		, required string value
-		,          string siteId = ""
-		,          string tenantId = arguments.siteId
+		  required string  category
+		, required string  setting
+		, required string  value
+		,          string  siteId         = ""
+		,          string  tenantId       = arguments.siteId
+		,          boolean skipVersioning = false
 	)  {
 		_reloadCheck();
 
@@ -230,6 +232,7 @@ component displayName="System configuration service" {
 			  data          = data
 			, matchColumns  = matchColumns
 			, updateColumns = [ "value" ]
+			, useVersioning = !arguments.skipVersioning
 		);
 
 		clearSettingsCache( arguments.category );

--- a/system/services/configuration/SystemConfigurationService.cfc
+++ b/system/services/configuration/SystemConfigurationService.cfc
@@ -207,50 +207,34 @@ component displayName="System configuration service" {
 	)  {
 		_reloadCheck();
 
-		var dao    = _getDao();
-		var result = "";
-		var tenancy = getConfigCategoryTenancy( arguments.category );
+		var dao          = _getDao();
+		var tenancy      = getConfigCategoryTenancy( arguments.category );
+		var matchColumns = [ "category", "setting", "site", "tenant_id" ];
+		var data         = {
+			  category  = arguments.category
+			, setting   = arguments.setting
+			, value     = arguments.value
+			, site      = ""
+			, tenant_id = ""
+		};
 
-		transaction {
-			var filter = "category = :category and setting = :setting";
-			var params = { category = arguments.category, setting = arguments.setting };
-			var data   = {
-				  category  = arguments.category
-				, setting   = arguments.setting
-				, value     = arguments.value
-				, site      = ""
-				, tenant_id = ""
-			};
-
-			if ( Len( tenancy ) && Len( Trim( arguments.tenantId ) ) ) {
-				if ( $isFeatureEnabled( "sites" ) && tenancy == "site" ) {
-					filter &= " and site = :site";
-					params.site = arguments.tenantId;
-
-					data.site = arguments.tenantId;
-				} else {
-					filter &= " and tenant_id = :tenant_id";
-					params.tenant_id = arguments.tenantId;
-					data.tenant_id = arguments.tenantId;
-				}
+		if ( Len( tenancy ) && Len( Trim( arguments.tenantId ) ) ) {
+			if ( $isFeatureEnabled( "sites" ) && tenancy == "site" ) {
+				data.site = arguments.tenantId;
 			} else {
-				filter &= " and #_getGlobalTenantFilter()#";
-			}
-
-			result = dao.updateData(
-				  data         = { value = arguments.value }
-				, filter       = filter
-				, filterParams = params
-			);
-
-			if ( !result ) {
-				result = dao.insertData( data );
+				data.tenant_id = arguments.tenantId;
 			}
 		}
 
+		var result = dao.upsertData(
+			  data          = data
+			, matchColumns  = matchColumns
+			, updateColumns = [ "value" ]
+		);
+
 		clearSettingsCache( arguments.category );
 
-		return result;
+		return result.id;
 	}
 
 	public any function deleteSetting(

--- a/system/services/database/adapters/BaseAdapter.cfc
+++ b/system/services/database/adapters/BaseAdapter.cfc
@@ -222,6 +222,19 @@ component {
 		return [ sql ];
 	}
 
+	public boolean function supportsUpsertSql() {
+		return false;
+	}
+
+	public array function getUpsertSql(
+		  required string tableName
+		, required array  insertColumns
+		, required array  updateColumns
+		, required array  conflictColumns
+	) {
+		return [ "getUpsertSql() not implemented. Must be implemented by extended adapters." ];
+	}
+
 	public string function getSelectSql(
 		  required string  tableName
 		, required array   selectColumns

--- a/system/services/database/adapters/MySqlAdapter.cfc
+++ b/system/services/database/adapters/MySqlAdapter.cfc
@@ -94,6 +94,37 @@ component extends="BaseAdapter" {
 		return "alter table #escapeEntity( arguments.tableName )# drop index #escapeEntity( arguments.indexName )#";
 	}
 
+	public boolean function supportsUpsertSql() {
+		return true;
+	}
+
+	public array function getUpsertSql(
+		  required string tableName
+		, required array  insertColumns
+		, required array  updateColumns
+		, required array  conflictColumns
+	) {
+		var insertSql = super.getInsertSql(
+			  tableName     = arguments.tableName
+			, insertColumns = arguments.insertColumns
+		);
+		var sql  = insertSql[ 1 ];
+		var delim = "";
+
+		if ( !ArrayLen( arguments.updateColumns ) ) {
+			return [ sql ];
+		}
+
+		sql &= " on duplicate key update";
+
+		for( var col in arguments.updateColumns ) {
+			sql &= delim & " " & escapeEntity( lcase( col ) ) & " = :set__" & col;
+			delim = ",";
+		}
+
+		return [ sql ];
+	}
+
 	public string function getUpdateSql(
 		  required string tableName
 		, required array  updateColumns

--- a/system/services/database/adapters/PostgreSqlAdapter.cfc
+++ b/system/services/database/adapters/PostgreSqlAdapter.cfc
@@ -20,6 +20,52 @@ component extends="BaseAdapter" {
 		return sql;
 	}
 
+	public boolean function supportsUpsertSql() {
+		return true;
+	}
+
+	public array function getUpsertSql(
+		  required string tableName
+		, required array  insertColumns
+		, required array  updateColumns
+		, required array  conflictColumns
+	) {
+		var insertSql = super.getInsertSql(
+			  tableName     = arguments.tableName
+			, insertColumns = arguments.insertColumns
+		);
+		var sql       = insertSql[ 1 ];
+		var delim     = "";
+		var conflict  = "";
+
+		if ( !ArrayLen( arguments.conflictColumns ) ) {
+			throw(
+				  type    = "PostgreSqlAdapter.Upsert.MissingConflictColumns"
+				, message = "PostgreSQL upsert requires one or more conflict columns that map to a unique index"
+			);
+		}
+
+		for( var col in arguments.conflictColumns ) {
+			conflict &= delim & escapeEntity( lcase( col ) );
+			delim = ", ";
+		}
+
+		sql &= " on conflict ( #conflict# ) do update set";
+		delim = "";
+
+		if ( !ArrayLen( arguments.updateColumns ) ) {
+			sql &= " " & escapeEntity( lcase( arguments.conflictColumns[ 1 ] ) ) & " = excluded." & escapeEntity( lcase( arguments.conflictColumns[ 1 ] ) );
+			return [ sql ];
+		}
+
+		for( var updateCol in arguments.updateColumns ) {
+			sql &= delim & " " & escapeEntity( lcase( updateCol ) ) & " = :set__" & updateCol;
+			delim = ",";
+		}
+
+		return [ sql ];
+	}
+
 	public string function getInsertReturnType(){
 		return 'recordset';
 	}

--- a/system/services/forms/FormsService.cfc
+++ b/system/services/forms/FormsService.cfc
@@ -1033,11 +1033,7 @@ component displayName="Forms service" {
 			forms[ formName ] = formDefinition;
 
 			if ( arguments.isDynamic ) {
-				$getSystemConfigurationService().saveSetting(
-					  category = "dynamicform"
-					, setting  = Hash( formName )
-					, value    = SerializeJson( formDefinition )
-				);
+				_saveDynamicFormIfUpdated( formName, formDefinition );
 			}
 
 			return true;
@@ -1661,6 +1657,24 @@ component displayName="Forms service" {
 		}
 
 		return false;
+	}
+
+	private void function _saveDynamicFormIfUpdated( required string formName, required struct formDefinition ) {
+		var settingName   = Hash( arguments.formName );
+		var serialized    = SerializeJson( arguments.formDefinition );
+		var configService = $getSystemConfigurationService();
+		var setting       = configService.getSetting( category="dynamicform", setting=settingName );
+
+		if ( IsSimpleValue( setting ) && setting == serialized ) {
+			return;
+		}
+
+		configService.saveSetting(
+			  category       = "dynamicform"
+			, setting        = settingName
+			, value          = serialized
+			, skipVersioning = true
+		);
 	}
 
 // GETTERS AND SETTERS

--- a/system/services/notifications/NotificationService.cfc
+++ b/system/services/notifications/NotificationService.cfc
@@ -443,26 +443,23 @@ component autodoc=true displayName="Notification Service" {
 			_getUserDao().updateData( id=arguments.userId, data={ subscribed_to_all_notifications=false } );
 		}
 
-		transaction {
+		var currentSubscriptions = getUserSubscriptions( arguments.userId );
 
-			var currentSubscriptions = getUserSubscriptions( arguments.userId );
-
-			for( var topic in currentSubscriptions ) {
-				if ( !arguments.topics.find( topic ) ) {
-					forDeletion.append( topic );
-				}
+		for( var topic in currentSubscriptions ) {
+			if ( !arguments.topics.find( topic ) ) {
+				forDeletion.append( topic );
 			}
-			if ( forDeletion.len() ) {
-				subscriptionDao.deleteData( filter={ security_user = arguments.userId, topic=forDeletion } );
-			}
+		}
+		if ( forDeletion.len() ) {
+			subscriptionDao.deleteData( filter={ security_user = arguments.userId, topic=forDeletion } );
+		}
 
-			for( var topic in arguments.topics ) {
-				if ( !currentSubscriptions.find( topic ) ) {
-					subscriptionDao.insertData({
-						  security_user = arguments.userId
-						, topic         = topic
-					});
-				}
+		for( var topic in arguments.topics ) {
+			if ( !currentSubscriptions.find( topic ) ) {
+				subscriptionDao.insertData({
+					  security_user = arguments.userId
+					, topic         = topic
+				});
 			}
 		}
 	}
@@ -479,22 +476,21 @@ component autodoc=true displayName="Notification Service" {
 		for( var userId in subscribers ){
 			if ( userHasAccessToTopic( userId, arguments.topic ) ) {
 				var filter = { admin_notification=arguments.notificationId, security_user=userId };
-				transaction {
-					if ( !_getConsumerDao().updateData( filter=filter, data={ read=false } ) ) {
-						interceptorArgs.subscription = subscribers[ userId ];
-						_announceInterception( "preCreateNotificationConsumer", interceptorArgs );
 
-						_getConsumerDao().insertData( data={
-							  admin_notification = arguments.notificationId
-							, security_user      = userId
-						} );
+				if ( !_getConsumerDao().updateData( filter=filter, data={ read=false } ) ) {
+					interceptorArgs.subscription = subscribers[ userId ];
+					_announceInterception( "preCreateNotificationConsumer", interceptorArgs );
 
-						if ( IsBoolean( subscribers[ userId ].get_email_notifications ?: "" ) && subscribers[ userId ].get_email_notifications ) {
-							sendSubsciberNotificationEmail( recipient=userId, topic=arguments.topic, notificationId=arguments.notificationId, data=arguments.data );
-						}
+					_getConsumerDao().insertData( data={
+						  admin_notification = arguments.notificationId
+						, security_user      = userId
+					} );
 
-						_announceInterception( "postCreateNotificationConsumer", interceptorArgs );
+					if ( IsBoolean( subscribers[ userId ].get_email_notifications ?: "" ) && subscribers[ userId ].get_email_notifications ) {
+						sendSubsciberNotificationEmail( recipient=userId, topic=arguments.topic, notificationId=arguments.notificationId, data=arguments.data );
 					}
+
+					_announceInterception( "postCreateNotificationConsumer", interceptorArgs );
 				}
 			}
 		}

--- a/system/services/presideObjects/PresideObjectDecorator.cfc
+++ b/system/services/presideObjects/PresideObjectDecorator.cfc
@@ -37,7 +37,7 @@ component singleton=true {
 
 // METHODS WITH WHICH TO DECORATE
 	public any function onMissingMethod( required string missingMethodName, required struct missingMethodArguments ) output=false {
-		var proxyMethods = "dataExists,fieldExists,selectData,selectManyToManyData,insertData,insertDataFromSelect,updateData,deleteData,getObjectProperties,getIdField,getLabelField,getDateCreatedField,getDateModifiedField,getFlagField";
+		var proxyMethods = "dataExists,fieldExists,selectData,selectManyToManyData,insertData,insertDataFromSelect,upsertData,updateData,deleteData,getObjectProperties,getIdField,getLabelField,getDateCreatedField,getDateModifiedField,getFlagField";
 		var i            = 1;
 
 		if ( ListFindNoCase( proxyMethods, missingMethodName ) ) {

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -776,6 +776,319 @@ component displayName="Preside Object Service" {
 	}
 
 	/**
+	 * Inserts a record or updates an existing record when a matching unique key already exists.
+	 * Uses a single atomic database upsert statement where the adapter supports it, avoiding
+	 * read-then-write races that can occur with separate update and insert calls.
+	 * \n
+	 * ${arguments}
+	 * \n
+	 * ## Examples
+	 * \n
+	 * ```luceescript
+	 * result = presideObjectService.upsertData(
+	 *       objectName   = "system_config"
+	 *     , data         = { category="myapp", setting="mysetting", value="myvalue", site="", tenant_id="" }
+	 *     , matchColumns = [ "category", "setting", "site", "tenant_id" ]
+	 * );
+	 * // result.id       = record id
+	 * // result.inserted = true when a new record was created, false when an existing record was updated
+	 * ```
+	 *
+	 * @objectName.hint                 Name of the object whose record you want to upsert
+	 * @data.hint                       Structure of data to insert or update. Keys should map to properties on the object. All match columns must be present.
+	 * @matchColumns.hint               Array of property names whose combined values identify an existing record via a unique index
+	 * @updateColumns.hint              Array of property names to update when a matching record already exists. Defaults to all data properties that are not match columns.
+	 * @insertManyToManyRecords.hint    Whether or not to insert multiple relationship records for properties that have a many-to-many relationship
+	 * @isDraft.hint                    Whether or not the record change is a draft change
+	 * @useVersioning.hint              Whether or not to use the versioning system with the upsert
+	 * @versionNumber.hint              If using versioning, specify a version number to save against
+	 * @clearCaches.hint                Whether or not to clear caches related to the object
+	 * @timeout.hint                    Timeout, in seconds, of the main upsert DB query
+	 * @useVersioning.docdefault        automatic
+	 * @clearCaches.docdefault          Defaults to whether query caching is enabled or not for this object
+	 */
+	public struct function upsertData(
+		  required string  objectName
+		, required struct  data
+		, required array   matchColumns
+		,          array   updateColumns             = []
+		,          boolean insertManyToManyRecords   = false
+		,          boolean isDraft                     = false
+		,          boolean useVersioning               = objectIsVersioned( arguments.objectName )
+		,          numeric versionNumber               = 0
+		,          boolean clearCaches                 = _objectUsesCaching( arguments.objectName )
+		,          numeric timeout                     = _getDefaultTimeout()
+	) autodoc=true {
+		var interceptorResult = _announceInterception( "preUpsertObjectData", arguments );
+
+		if ( IsBoolean( interceptorResult.abort ?: "" ) && interceptorResult.abort ) {
+			return interceptorResult.returnValue ?: { id="", inserted=false };
+		}
+
+		var args               = _cleanupPropertyAliases( argumentCollection=_deepishDuplicate( arguments ) );
+		var obj                = _getObject( args.objectName ).meta;
+		var adapter            = _getAdapter( obj.dsn );
+		var dateCreatedField   = getDateCreatedField( args.objectName );
+		var dateModifiedField  = getDateModifiedField( args.objectName );
+		var idField            = getIdField( args.objectName );
+		var key                = "";
+		var cleanedData        = _addDefaultValuesToDataSet( args.objectName, args.data );
+		var manyToManyData     = {};
+		var matchFilter        = {};
+		var rightNow           = DateFormat( Now(), "yyyy-mm-dd" ) & " " & TimeFormat( Now(), "HH:mm:ss" );
+		var requiresVersioning = args.useVersioning && objectIsVersioned( args.objectName );
+		var versionNumber      = 0;
+		var existedBefore      = false;
+		var oldData            = "";
+		var recordId           = "";
+		var inserted           = false;
+		var sql                = "";
+		var params             = "";
+		var result             = "";
+
+		if ( !ArrayLen( args.matchColumns ) ) {
+			throw(
+				  type    = "PresideObjects.upsertData.MissingMatchColumns"
+				, message = "upsertData() requires one or more match columns that map to a unique index on [#args.objectName#]"
+			);
+		}
+
+		for( key in args.matchColumns ) {
+			if ( !StructKeyExists( cleanedData, key ) ) {
+				throw(
+					  type    = "PresideObjects.upsertData.MissingMatchColumnValue"
+					, message = "upsertData() requires a value for match column [#key#] in the data argument"
+				);
+			}
+			matchFilter[ key ] = cleanedData[ key ];
+		}
+
+		cleanedData.append( _addGeneratedValues(
+			  operation  = "insert"
+			, objectName = args.objectName
+			, data       = cleanedData
+		) );
+
+		for( key in cleanedData ) {
+			if ( args.insertManyToManyRecords && getObjectPropertyAttribute( objectName, key, "relationship", "none" ).reFindNoCase( "(many|one)\-to\-many" ) ) {
+				manyToManyData[ key ] = cleanedData[ key ];
+			}
+			if ( !ListFindNoCase( obj.dbFieldList, key ) ) {
+				StructDelete( cleanedData, key );
+			}
+		}
+
+		existedBefore = dataExists(
+			  objectName = args.objectName
+			, filter     = matchFilter
+		);
+
+		if ( existedBefore ) {
+			if ( dateModifiedField.len() && StructKeyExists( obj.properties, dateModifiedField ) && !StructKeyExists( cleanedData, dateModifiedField ) ) {
+				cleanedData[ dateModifiedField ] = rightNow;
+			}
+			oldData = selectData(
+				  objectName       = args.objectName
+				, filter           = matchFilter
+				, allowDraftVersions = true
+				, fromVersionTable   = args.isDraft
+			);
+		} else {
+			if ( dateCreatedField.len() && StructKeyExists( obj.properties, dateCreatedField ) && !StructKeyExists( cleanedData, dateCreatedField ) ) {
+				cleanedData[ dateCreatedField ] = rightNow;
+			}
+			if ( dateModifiedField.len() && StructKeyExists( obj.properties, dateModifiedField ) && !StructKeyExists( cleanedData, dateModifiedField ) ) {
+				cleanedData[ dateModifiedField ] = rightNow;
+			}
+			if ( ListFindNoCase( obj.dbFieldList, idField ) && StructKeyExists( obj.properties, idField ) ) {
+				if ( !StructKeyExists( cleanedData, idField ) || !Len( Trim( cleanedData[ idField ] ) ) ) {
+					var newId = _generateNewIdWhenNecessary( generator=( obj.properties[ idField ].generator ?: "UUID" ) );
+					if ( Len( Trim( newId ) ) ) {
+						cleanedData[ idField ] = newId;
+					}
+				}
+			}
+		}
+
+		if ( objectUsesDrafts( args.objectName ) ) {
+			cleanedData._version_is_draft = cleanedData._version_has_drafts = args.isDraft;
+		}
+
+		if ( !ArrayLen( args.updateColumns ) ) {
+			args.updateColumns = [];
+			for( key in cleanedData ) {
+				if ( !ArrayFind( args.matchColumns, key ) ) {
+					args.updateColumns.append( key );
+				}
+			}
+		}
+
+		if ( !ArrayLen( args.updateColumns ) ) {
+			args.updateColumns = [ args.matchColumns[ 1 ] ];
+		}
+
+		if ( !adapter.supportsUpsertSql() ) {
+			return _upsertDataWithUpdateInsert( argumentCollection=args );
+		}
+
+		var preparedFilter = _prepareFilter(
+			  adapter            = adapter
+			, columnDefinitions  = obj.properties
+			, objectName         = args.objectName
+			, filter             = matchFilter
+		);
+		var changedData = {};
+
+		if ( requiresVersioning && existedBefore ) {
+			for( var record in oldData ) {
+				var changedFields = _getVersioningService().getChangedFields(
+					  objectName   = args.objectName
+					, recordId     = record[ idField ]
+					, newData      = cleanedData
+					, existingData = record
+				);
+
+				if ( ArrayLen( changedFields ) ) {
+					changedData[ record[ idField ] ] = {};
+					for( var field in changedFields ) {
+						changedData[ record[ idField ] ][ field ] = cleanedData[ field ] ?: "";
+					}
+				}
+			}
+		}
+
+		if ( requiresVersioning ) {
+			if ( existedBefore ) {
+				versionNumber = _getVersioningService().saveVersionForUpdate(
+					  objectName       = args.objectName
+					, data             = cleanedData
+					, manyToManyData   = manyToManyData
+					, existingRecords  = oldData
+					, changedData      = changedData
+					, filter           = preparedFilter.filter
+					, filterParams     = preparedFilter.filterParams
+					, versionNumber    = args.versionNumber ? args.versionNumber : getNextVersionNumber()
+					, isDraft          = args.isDraft
+				);
+			} else {
+				versionNumber = _getVersioningService().saveVersionForInsert(
+					  objectName     = args.objectName
+					, data           = cleanedData
+					, manyToManyData = manyToManyData
+					, versionNumber  = args.versionNumber ? args.versionNumber : getNextVersionNumber()
+					, isDraft        = args.isDraft
+				);
+			}
+		} else if ( objectIsVersioned( args.objectName ) && existedBefore ) {
+			_getVersioningService().updateLatestVersionWithNonVersionedChanges(
+				  objectName = args.objectName
+				, recordId   = oldData[ idField ][ 1 ]
+				, data       = cleanedData
+			);
+		}
+
+		sql = adapter.getUpsertSql(
+			  tableName       = obj.tableName
+			, insertColumns   = StructKeyArray( cleanedData )
+			, updateColumns   = args.updateColumns
+			, conflictColumns = args.matchColumns
+		);
+		params = _convertDataToQueryParams(
+			  objectName        = args.objectName
+			, columnDefinitions = obj.properties
+			, data              = cleanedData
+			, dbAdapter         = adapter
+		);
+		params = _arrayMerge( params, _convertDataToQueryParams(
+			  objectName        = args.objectName
+			, columnDefinitions = obj.properties
+			, data              = cleanedData
+			, dbAdapter         = adapter
+			, preFix            = "set__"
+		) );
+
+		result = _runSql( sql=sql[1], dsn=obj.dsn, params=params, returnType=adapter.getInsertReturnType(), timeout=args.timeout );
+
+		if ( adapter.requiresManualCommitForTransactions() ) {
+			_runSql( sql='commit', dsn=obj.dsn );
+		}
+
+		recordId  = Len( Trim( cleanedData[ idField ] ?: "" ) ) ? cleanedData[ idField ] : ( adapter.getGeneratedKey( result ) ?: "" );
+		inserted  = !existedBefore;
+
+		if ( !Len( Trim( recordId ) ) ) {
+			var matchedRecord = selectData(
+				  objectName     = args.objectName
+				, filter           = matchFilter
+				, selectFields     = [ "#idField# as id" ]
+				, returntype       = "array"
+			);
+			recordId = matchedRecord[ 1 ].id ?: "";
+		}
+
+		if ( Len( Trim( recordId ) ) ) {
+			for( key in manyToManyData ) {
+				var relationship = getObjectPropertyAttribute( objectName, key, "relationship", "none" );
+
+				if ( relationship == "many-to-many" ) {
+					syncManyToManyData(
+						  sourceObject        = args.objectName
+						, sourceProperty      = key
+						, sourceId            = recordId
+						, targetIdList        = manyToManyData[ key ]
+						, requiresVersionSync = false
+						, isDraft             = args.isDraft
+					);
+				} else if ( relationship == "one-to-many" ) {
+					if ( isOneToManyConfiguratorObject( args.objectName, key ) ) {
+						syncOneToManyConfiguratorData(
+							  sourceObject     = args.objectName
+							, sourceProperty   = key
+							, sourceId         = recordId
+							, configuratorData = manyToManyData[ key ]
+							, versionNumber    = versionNumber
+						);
+					} else {
+						syncOneToManyData(
+							  sourceObject   = args.objectName
+							, sourceProperty = key
+							, sourceId       = recordId
+							, targetIdList   = manyToManyData[ key ]
+						);
+					}
+				}
+			}
+		}
+
+		if ( !requiresVersioning && objectIsVersioned( args.objectName ) && !existedBefore && Len( Trim( recordId ) ) ) {
+			_getVersioningService().saveVersionForInsert(
+				  objectName     = args.objectName
+				, data           = cleanedData
+				, manyToManyData = manyToManyData
+				, versionNumber  = args.versionNumber ? args.versionNumber : getNextVersionNumber()
+				, isDraft        = args.isDraft
+			);
+		}
+
+		if ( args.clearCaches ) {
+			clearRelatedCaches(
+				  objectName              = args.objectName
+				, filter                  = ""
+				, filterParams            = {}
+				, clearSingleRecordCaches = false
+			);
+		}
+
+		var interceptionArgs           = args;
+		    interceptionArgs.id        = recordId;
+		    interceptionArgs.inserted  = inserted;
+		    interceptionArgs.result    = result;
+		_announceInterception( "postUpsertObjectData", interceptionArgs );
+
+		return { id=recordId, inserted=inserted };
+	}
+
+	/**
 	 * Updates records in the database with a new set of data. Returns the number of records affected by the operation.
 	 * \n
 	 * ${arguments}
@@ -3783,6 +4096,66 @@ component displayName="Preside Object Service" {
 		} ;
 
 		return final;
+	}
+
+	private struct function _upsertDataWithUpdateInsert( required struct args ) {
+		var matchFilter  = {};
+		var updateData   = StructCopy( args.data );
+		var key          = "";
+		var updatedCount = 0;
+		var recordId     = "";
+		var inserted     = false;
+
+		for( key in args.matchColumns ) {
+			matchFilter[ key ] = args.data[ key ];
+			StructDelete( updateData, key );
+		}
+
+		updatedCount = updateData(
+			  objectName              = args.objectName
+			, data                    = updateData
+			, filter                  = matchFilter
+			, updateManyToManyRecords = args.insertManyToManyRecords
+			, isDraft                 = args.isDraft
+			, useVersioning           = args.useVersioning
+			, versionNumber           = args.versionNumber
+			, clearCaches             = false
+			, timeout                 = args.timeout
+		);
+
+		if ( updatedCount ) {
+			var idField = getIdField( args.objectName );
+			var records = selectData(
+				  objectName   = args.objectName
+				, filter       = matchFilter
+				, selectFields = [ "#idField# as id" ]
+				, returntype   = "array"
+			);
+			recordId = records[ 1 ].id ?: "";
+		} else {
+			recordId = insertData(
+				  objectName              = args.objectName
+				, data                    = args.data
+				, insertManyToManyRecords = args.insertManyToManyRecords
+				, isDraft                 = args.isDraft
+				, useVersioning           = args.useVersioning
+				, versionNumber           = args.versionNumber
+				, clearCaches             = false
+				, timeout                 = args.timeout
+			);
+			inserted = true;
+		}
+
+		if ( args.clearCaches ) {
+			clearRelatedCaches(
+				  objectName              = args.objectName
+				, filter                  = ""
+				, filterParams            = {}
+				, clearSingleRecordCaches = false
+			);
+		}
+
+		return { id=recordId, inserted=inserted };
 	}
 
 	private boolean function _isEmptyFilter( required any filter ) {

--- a/system/services/presideObjects/PresideObjectService.cfc
+++ b/system/services/presideObjects/PresideObjectService.cfc
@@ -923,6 +923,19 @@ component displayName="Preside Object Service" {
 			}
 		}
 
+		if ( existedBefore && oldData.recordCount ) {
+			for( var existingRecord in oldData ) {
+				for( var fieldName in ListToArray( obj.dbFieldList ) ) {
+					if ( StructKeyExists( existingRecord, fieldName ) ) {
+						if ( fieldName == idField || !StructKeyExists( cleanedData, fieldName ) ) {
+							cleanedData[ fieldName ] = existingRecord[ fieldName ];
+						}
+					}
+				}
+				break;
+			}
+		}
+
 		if ( !ArrayLen( args.updateColumns ) ) {
 			args.updateColumns = [ args.matchColumns[ 1 ] ];
 		}
@@ -931,34 +944,35 @@ component displayName="Preside Object Service" {
 			return _upsertDataWithUpdateInsert( argumentCollection=args );
 		}
 
-		var preparedFilter = _prepareFilter(
-			  adapter            = adapter
-			, columnDefinitions  = obj.properties
-			, objectName         = args.objectName
-			, filter             = matchFilter
-		);
-		var changedData = {};
-
-		if ( requiresVersioning && existedBefore ) {
-			for( var record in oldData ) {
-				var changedFields = _getVersioningService().getChangedFields(
-					  objectName   = args.objectName
-					, recordId     = record[ idField ]
-					, newData      = cleanedData
-					, existingData = record
-				);
-
-				if ( ArrayLen( changedFields ) ) {
-					changedData[ record[ idField ] ] = {};
-					for( var field in changedFields ) {
-						changedData[ record[ idField ] ][ field ] = cleanedData[ field ] ?: "";
-					}
-				}
-			}
-		}
-
 		if ( requiresVersioning ) {
 			if ( existedBefore ) {
+				var preparedFilter = _prepareFilter(
+					  adapter            = adapter
+					, columnDefinitions  = obj.properties
+					, objectName         = args.objectName
+					, filter             = matchFilter
+					, filterParams       = {}
+					, extraFilters       = []
+					, savedFilters       = []
+				);
+				var changedData = {};
+
+				for( var record in oldData ) {
+					var changedFields = _getVersioningService().getChangedFields(
+						  objectName   = args.objectName
+						, recordId     = record[ idField ]
+						, newData      = cleanedData
+						, existingData = record
+					);
+
+					if ( ArrayLen( changedFields ) ) {
+						changedData[ record[ idField ] ] = {};
+						for( var field in changedFields ) {
+							changedData[ record[ idField ] ][ field ] = cleanedData[ field ] ?: "";
+						}
+					}
+				}
+
 				versionNumber = _getVersioningService().saveVersionForUpdate(
 					  objectName       = args.objectName
 					, data             = cleanedData
@@ -1013,10 +1027,12 @@ component displayName="Preside Object Service" {
 			_runSql( sql='commit', dsn=obj.dsn );
 		}
 
-		recordId  = Len( Trim( cleanedData[ idField ] ?: "" ) ) ? cleanedData[ idField ] : ( adapter.getGeneratedKey( result ) ?: "" );
-		inserted  = !existedBefore;
+		recordId = Len( Trim( cleanedData[ idField ] ?: "" ) ) ? cleanedData[ idField ] : ( adapter.getGeneratedKey( result ) ?: "" );
+		inserted = !existedBefore;
 
-		if ( !Len( Trim( recordId ) ) ) {
+		if ( existedBefore && oldData.recordCount ) {
+			recordId = oldData[ idField ][ 1 ];
+		} else if ( !Len( Trim( recordId ) ) ) {
 			var matchedRecord = selectData(
 				  objectName     = args.objectName
 				, filter           = matchFilter

--- a/system/services/taskmanager/TaskManagerService.cfc
+++ b/system/services/taskmanager/TaskManagerService.cfc
@@ -219,13 +219,11 @@ component displayName="Task Manager Service" {
 			var newLogId    = createTaskHistoryLog( arguments.taskKey, newThreadId );
 			var logger      =  _getLogger( newLogId );
 
-			transaction {
-				if ( taskIsRunning( arguments.taskKey ) ) {
-					return;
-				}
-
-				markTaskAsRunning( arguments.taskKey, newThreadId );
+			if ( taskIsRunning( arguments.taskKey ) ) {
+				return;
 			}
+
+			markTaskAsRunning( arguments.taskKey, newThreadId );
 
 			if ( !_getExecutor().isStarted() ) {
 				_getExecutor().start();

--- a/tests/unit/api/configuration/SystemConfigurationServiceTest.cfc
+++ b/tests/unit/api/configuration/SystemConfigurationServiceTest.cfc
@@ -2,6 +2,8 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 
 	function run(){
 
+		variables.testDirs = [ "/tests/resources/systemConfiguration/dir1", "/tests/resources/systemConfiguration/dir2", "/tests/resources/systemConfiguration/dir3" ];
+
 		describe( "listConfigCategories", function(){
 
 			it( "should return empty array when no configuration categories defined", function(){
@@ -75,6 +77,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" }
 						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 						, updateColumns = [ "value" ]
+						, useVersioning = true
 					)
 					.$results( { id=newId, inserted=true } );
 
@@ -89,6 +92,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" }
 					, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 					, updateColumns = [ "value" ]
+					, useVersioning = true
 				} );
 			} );
 
@@ -104,6 +108,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" }
 						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 						, updateColumns = [ "value" ]
+						, useVersioning = true
 					)
 					.$results( { id=existingId, inserted=false } );
 
@@ -129,6 +134,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" }
 						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 						, updateColumns = [ "value" ]
+						, useVersioning = true
 					)
 					.$results( { id=newId, inserted=true } );
 
@@ -144,6 +150,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					  data          = { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" }
 					, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 					, updateColumns = [ "value" ]
+					, useVersioning = true
 				} );
 			} );
 
@@ -160,6 +167,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" }
 						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 						, updateColumns = [ "value" ]
+						, useVersioning = true
 					)
 					.$results( { id=existingId, inserted=false } );
 
@@ -194,6 +202,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id=customTenantId }
 						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 						, updateColumns = [ "value" ]
+						, useVersioning = true
 					)
 					.$results( { id=newId, inserted=true } );
 
@@ -209,6 +218,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id=customTenantId }
 					, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
 					, updateColumns = [ "value" ]
+					, useVersioning = true
 				} );
 			} );
 
@@ -437,7 +447,6 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 // PRIVATE HELPERS
 	private any function _getConfigSvc( array autoDiscoverDirectories=[], struct injectedConfig={} ) ouput=false {
 		mockDao                 = createEmptyMock( object=_getPresideObjectService().getObject( "system_config" ) );
-		testDirs                = [ "/tests/resources/systemConfiguration/dir1", "/tests/resources/systemConfiguration/dir2", "/tests/resources/systemConfiguration/dir3" ];
 		mockFormsService        = createEmptyMock( "preside.system.services.forms.FormsService" );
 		mockTenancyService      = createEmptyMock( "preside.system.services.tenancy.TenancyService" );
 		mockSystemAlertsService = createEmptyMock( "preside.system.services.systemAlerts.SystemAlertsService" );

--- a/tests/unit/api/configuration/SystemConfigurationServiceTest.cfc
+++ b/tests/unit/api/configuration/SystemConfigurationServiceTest.cfc
@@ -65,15 +65,18 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 		describe( "saveSetting", function(){
 			it( "should insert a new db record when no existing record exists for the given config key", function(){
 				var configService = _getConfigSvc( testDirs );
-				var category = "mycategory";
+				var category      = "mycategory";
+				var newId         = CreateUUId();
 
 				configService.$( "getConfigCategoryTenancy" ).$args( category ).$results( "site" );
 
-				mockDao.$( "updateData" )
-					.$args( filter="category = :category and setting = :setting and tenant_id is null and site is null", filterParams={ category=category, setting="mysetting" }, data={ value="this is the value of my setting" } )
-					.$results( 0 );
-
-				mockDao.$( "insertData", CreateUUId() );
+				mockDao.$( "upsertData" )
+					.$args(
+						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" }
+						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+						, updateColumns = [ "value" ]
+					)
+					.$results( { id=newId, inserted=true } );
 
 				configService.saveSetting(
 					  category = category
@@ -81,24 +84,28 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					, value    = "this is the value of my setting"
 				);
 
-				var log = mockDao.$callLog().insertData;
-
-				expect( log.len() ).toBe( 1 );
-				expect( log[1] ).toBe( [ { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" } ] );
+				expect( mockDao.$callLog().upsertData.len() ).toBe( 1 );
+				expect( mockDao.$callLog().upsertData[1] ).toBe( {
+					  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" }
+					, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+					, updateColumns = [ "value" ]
+				} );
 			} );
 
 			it( "should update existing db record when record already exists in db", function(){
 				var configService = _getConfigSvc( testDirs );
-				var category = "mycategory";
+				var category      = "mycategory";
+				var existingId    = CreateUUId();
 
 				configService.$( "getConfigCategoryTenancy" ).$args( category ).$results( "site" );
 
-
-				mockDao.$( "updateData" )
-					.$args( filter="category = :category and setting = :setting and tenant_id is null and site is null", filterParams={ category=category, setting="mysetting" }, data={ value="this is the value of my setting" } )
-					.$results( 1 );
-
-				mockDao.$( "insertData", CreateUUId() );
+				mockDao.$( "upsertData" )
+					.$args(
+						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id="" }
+						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+						, updateColumns = [ "value" ]
+					)
+					.$results( { id=existingId, inserted=false } );
 
 				configService.saveSetting(
 					  category = category
@@ -106,25 +113,24 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					, value    = "this is the value of my setting"
 				);
 
-				var log = mockDao.$callLog().insertData;
-				expect( log.len() ).toBe( 0 );
-
-				log = mockDao.$callLog().updateData;
-				expect( log.len() ).toBe( 1 );
+				expect( mockDao.$callLog().upsertData.len() ).toBe( 1 );
 			} );
 
 			it( "should insert a new db record with site ID when site id passed", function(){
 				var configService = _getConfigSvc( testDirs );
 				var siteId        = CreateUUId();
 				var category      = "mycategory";
+				var newId         = CreateUUId();
 
 				configService.$( "getConfigCategoryTenancy" ).$args( category ).$results( "site" );
 
-				mockDao.$( "updateData" )
-					.$args( filter="category = :category and setting = :setting and site = :site", filterParams={ category=category, setting="mysetting", site=siteId }, data={ value="this is the value of my setting" } )
-					.$results( 0 );
-
-				mockDao.$( "insertData", CreateUUId() );
+				mockDao.$( "upsertData" )
+					.$args(
+						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" }
+						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+						, updateColumns = [ "value" ]
+					)
+					.$results( { id=newId, inserted=true } );
 
 				configService.saveSetting(
 					  category = category
@@ -133,25 +139,29 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					, tenantId = siteId
 				);
 
-				var log = mockDao.$callLog().insertData;
-
-				expect( log.len() ).toBe( 1 );
-				expect( log[1] ).toBe( [ { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" } ] );
+				expect( mockDao.$callLog().upsertData.len() ).toBe( 1 );
+				expect( mockDao.$callLog().upsertData[1] ).toBe( {
+					  data          = { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" }
+					, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+					, updateColumns = [ "value" ]
+				} );
 			} );
 
 			it( "should clear related caches", function(){
 				var configService = _getConfigSvc( testDirs );
 				var siteId        = CreateUUId();
 				var category      = "mycategory";
+				var existingId    = CreateUUId();
 
 				configService.$( "getConfigCategoryTenancy" ).$args( category ).$results( "site" );
 
-				mockDao.$( "updateData" )
-					.$args( filter="category = :category and setting = :setting and site = :site", filterParams={ category=category, setting="mysetting", site=siteId }, data={ value="this is the value of my setting" } )
-					.$results( 1 );
-
-				mockDao.$( "insertData", CreateUUId() );
-
+				mockDao.$( "upsertData" )
+					.$args(
+						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site=siteId, tenant_id="" }
+						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+						, updateColumns = [ "value" ]
+					)
+					.$results( { id=existingId, inserted=false } );
 
 				configService.saveSetting(
 					  category = category
@@ -170,19 +180,22 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 				} );
 			} );
 
-			it( "should insert a new db record with temamt ID when category uses custom tenancy", function(){
+			it( "should insert a new db record with tenant ID when category uses custom tenancy", function(){
 				var configService  = _getConfigSvc( testDirs );
 				var customTenantId = CreateUUId();
 				var category       = "mycategory";
+				var newId          = CreateUUId();
 
 				configService.$( "getConfigCategoryTenancy" ).$args( category ).$results( "custom" );
 				mockTenancyService.$( "getTenantId" ).$args( "custom" ).$results( customTenantId );
 
-				mockDao.$( "updateData" )
-					.$args( filter="category = :category and setting = :setting and tenant_id = :tenant_id", filterParams={ category=category, setting="mysetting", tenant_id=customTenantId }, data={ value="this is the value of my setting" } )
-					.$results( 0 );
-
-				mockDao.$( "insertData", CreateUUId() );
+				mockDao.$( "upsertData" )
+					.$args(
+						  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id=customTenantId }
+						, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+						, updateColumns = [ "value" ]
+					)
+					.$results( { id=newId, inserted=true } );
 
 				configService.saveSetting(
 					  category = category
@@ -191,10 +204,12 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase"{
 					, tenantId = customTenantId
 				);
 
-				var log = mockDao.$callLog().insertData;
-
-				expect( log.len() ).toBe( 1 );
-				expect( log[1] ).toBe( [ { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id=customTenantId } ] );
+				expect( mockDao.$callLog().upsertData.len() ).toBe( 1 );
+				expect( mockDao.$callLog().upsertData[1] ).toBe( {
+					  data          = { category=category, setting="mysetting", value="this is the value of my setting", site="", tenant_id=customTenantId }
+					, matchColumns  = [ "category", "setting", "site", "tenant_id" ]
+					, updateColumns = [ "value" ]
+				} );
 			} );
 
 		} );

--- a/tests/unit/api/forms/FormsServiceTest.cfc
+++ b/tests/unit/api/forms/FormsServiceTest.cfc
@@ -908,6 +908,7 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase" {
 		mockFeatureService.$( "isFeatureEnabled", true );
 
 		mockConfigService.$( "saveSetting" );
+		mockConfigService.$( "getSetting", "" );
 
 		var service = createMock( object=new preside.system.services.forms.FormsService(
 			  presideObjectService = poService

--- a/tests/unit/api/presideObjects/PresideObjectServiceTest.cfc
+++ b/tests/unit/api/presideObjects/PresideObjectServiceTest.cfc
@@ -4639,38 +4639,188 @@
 			poService.dbSync();
 
 			result = poService.upsertData(
-				  objectName   = "an_object"
-				, data         = { field1=1, field2=2, field3=100, field4=10 }
-				, matchColumns = [ "field1", "field2" ]
+				  objectName    = "an_object"
+				, data          = { field1=1, field2=2, field3=100, field4=10, label="upsert test one" }
+				, matchColumns  = [ "field1", "field2" ]
 				, useVersioning = false
 			);
 
 			super.assertTrue( result.inserted, "Expected first upsert to insert a new record" );
+			super.assertTrue( Len( Trim( result.id ?: "" ) ), "Expected upsert to return the record id" );
 
 			record = poService.selectData(
-				  objectName   = "an_object"
-				, filter       = { field1=1, field2=2 }
-				, returntype   = "array"
+				  objectName = "an_object"
+				, filter     = { field1=1, field2=2 }
+				, returntype = "array"
 			);
 			super.assertEquals( 100, record[ 1 ].field3 );
 
 			result = poService.upsertData(
-				  objectName   = "an_object"
-				, data         = { field1=1, field2=2, field3=200, field4=20 }
-				, matchColumns = [ "field1", "field2" ]
+				  objectName    = "an_object"
+				, data          = { field1=1, field2=2, field3=200, field4=20 }
+				, matchColumns  = [ "field1", "field2" ]
 				, useVersioning = false
 			);
 
 			super.assertFalse( result.inserted, "Expected second upsert to update the existing record" );
+			super.assertEquals( result.id, record[ 1 ].id, "Expected upsert to return the existing record id" );
 
 			record = poService.selectData(
-				  objectName   = "an_object"
-				, filter       = { field1=1, field2=2 }
-				, returntype   = "array"
+				  objectName = "an_object"
+				, filter     = { field1=1, field2=2 }
+				, returntype = "array"
 			);
 			super.assertEquals( 200, record[ 1 ].field3 );
 			super.assertEquals( 20, record[ 1 ].field4 );
+			super.assertEquals( "upsert test one", record[ 1 ].label, "Expected label to be preserved when not included in update data" );
 			super.assertEquals( 1, poService.selectData( objectName="an_object", filter={ field1=1, field2=2 } ).recordCount, "Expected only one record for the unique key" );
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="test024_upsertData_shouldOnlyUpdateSpecifiedColumns_whenUpdateColumnsArgumentIsPassed" returntype="void">
+		<cfscript>
+			var poService = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentWithIndexes/" ] );
+			var result    = "";
+			var record    = "";
+
+			poService.dbSync();
+
+			poService.upsertData(
+				  objectName    = "an_object"
+				, data          = { field1=10, field2=20, field3=300, field4=40, label="explicit update columns" }
+				, matchColumns  = [ "field1", "field2" ]
+				, useVersioning = false
+			);
+
+			result = poService.upsertData(
+				  objectName     = "an_object"
+				, data           = { field1=10, field2=20, field3=301, field4=99 }
+				, matchColumns   = [ "field1", "field2" ]
+				, updateColumns  = [ "field3" ]
+				, useVersioning  = false
+			);
+
+			super.assertFalse( result.inserted );
+
+			record = poService.selectData(
+				  objectName = "an_object"
+				, filter     = { field1=10, field2=20 }
+				, returntype = "array"
+			);
+			super.assertEquals( 301, record[ 1 ].field3 );
+			super.assertEquals( 40, record[ 1 ].field4, "Expected field4 to remain unchanged when omitted from updateColumns" );
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="test025_upsertData_shouldMatchOnSingleColumnUniqueIndex" returntype="void">
+		<cfscript>
+			var poService = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentWithIndexes/" ] );
+			var result    = "";
+			var record    = "";
+
+			poService.dbSync();
+
+			result = poService.upsertData(
+				  objectName    = "an_object"
+				, data          = { field1=5, field2=6, field3=700, label="single column unique" }
+				, matchColumns  = [ "field3" ]
+				, useVersioning = false
+			);
+
+			super.assertTrue( result.inserted );
+
+			result = poService.upsertData(
+				  objectName    = "an_object"
+				, data          = { field1=99, field2=99, field3=700, field4=77, label="should not replace label" }
+				, matchColumns  = [ "field3" ]
+				, updateColumns = [ "field4" ]
+				, useVersioning = false
+			);
+
+			super.assertFalse( result.inserted );
+
+			record = poService.selectData(
+				  objectName = "an_object"
+				, filter     = { field3=700 }
+				, returntype = "array"
+			);
+			super.assertEquals( 1, record.len() );
+			super.assertEquals( 5, record[ 1 ].field1, "Expected field1 to remain unchanged when omitted from updateColumns" );
+			super.assertEquals( 6, record[ 1 ].field2, "Expected field2 to remain unchanged when omitted from updateColumns" );
+			super.assertEquals( 77, record[ 1 ].field4 );
+			super.assertEquals( "single column unique", record[ 1 ].label );
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="test026_upsertData_shouldThrowInformativeError_whenMatchColumnsAreMissing" returntype="void">
+		<cfscript>
+			var poService   = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentWithIndexes/" ] );
+			var errorThrown = false;
+
+			poService.dbSync();
+
+			try {
+				poService.upsertData(
+					  objectName   = "an_object"
+					, data         = { field1=1, field2=2, label="missing match columns" }
+					, matchColumns = []
+				);
+			} catch ( "PresideObjects.upsertData.MissingMatchColumns" e ) {
+				super.assertEquals( "upsertData() requires one or more match columns that map to a unique index on [an_object]", e.message );
+				errorThrown = true;
+			}
+
+			super.assert( errorThrown, "An appropriate error was not thrown when matchColumns was empty" );
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="test027_upsertData_shouldThrowInformativeError_whenMatchColumnValueIsMissingFromData" returntype="void">
+		<cfscript>
+			var poService   = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentWithIndexes/" ] );
+			var errorThrown = false;
+
+			poService.dbSync();
+
+			try {
+				poService.upsertData(
+					  objectName   = "an_object"
+					, data         = { field1=1, label="missing match value" }
+					, matchColumns = [ "field1", "field2" ]
+				);
+			} catch ( "PresideObjects.upsertData.MissingMatchColumnValue" e ) {
+				super.assertEquals( "upsertData() requires a value for match column [field2] in the data argument", e.message );
+				errorThrown = true;
+			}
+
+			super.assert( errorThrown, "An appropriate error was not thrown when a match column value was missing" );
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="test028_upsertData_shouldInsertSeparateRecords_forDifferentUniqueKeys" returntype="void">
+		<cfscript>
+			var poService = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentWithIndexes/" ] );
+			var resultOne = "";
+			var resultTwo = "";
+
+			poService.dbSync();
+
+			resultOne = poService.upsertData(
+				  objectName    = "an_object"
+				, data          = { field1=1, field2=1, field3=801, label="unique key one" }
+				, matchColumns  = [ "field1", "field2" ]
+				, useVersioning = false
+			);
+			resultTwo = poService.upsertData(
+				  objectName    = "an_object"
+				, data          = { field1=2, field2=2, field3=802, label="unique key two" }
+				, matchColumns  = [ "field1", "field2" ]
+				, useVersioning = false
+			);
+
+			super.assertTrue( resultOne.inserted );
+			super.assertTrue( resultTwo.inserted );
+			super.assert( resultOne.id != resultTwo.id, "Expected different records to receive different ids" );
+			super.assertEquals( 2, poService.selectData( objectName="an_object" ).recordCount );
 		</cfscript>
 	</cffunction>
 

--- a/tests/unit/api/presideObjects/PresideObjectServiceTest.cfc
+++ b/tests/unit/api/presideObjects/PresideObjectServiceTest.cfc
@@ -4630,6 +4630,50 @@
 		</cfscript>
 	</cffunction>
 
+	<cffunction name="test023_upsertData_shouldInsertWhenNoMatchExists_andUpdateWhenUniqueKeyMatches" returntype="void">
+		<cfscript>
+			var poService = _getService( objectDirectories=[ "/tests/resources/PresideObjectService/componentWithIndexes/" ] );
+			var result    = "";
+			var record    = "";
+
+			poService.dbSync();
+
+			result = poService.upsertData(
+				  objectName   = "an_object"
+				, data         = { field1=1, field2=2, field3=100, field4=10 }
+				, matchColumns = [ "field1", "field2" ]
+				, useVersioning = false
+			);
+
+			super.assertTrue( result.inserted, "Expected first upsert to insert a new record" );
+
+			record = poService.selectData(
+				  objectName   = "an_object"
+				, filter       = { field1=1, field2=2 }
+				, returntype   = "array"
+			);
+			super.assertEquals( 100, record[ 1 ].field3 );
+
+			result = poService.upsertData(
+				  objectName   = "an_object"
+				, data         = { field1=1, field2=2, field3=200, field4=20 }
+				, matchColumns = [ "field1", "field2" ]
+				, useVersioning = false
+			);
+
+			super.assertFalse( result.inserted, "Expected second upsert to update the existing record" );
+
+			record = poService.selectData(
+				  objectName   = "an_object"
+				, filter       = { field1=1, field2=2 }
+				, returntype   = "array"
+			);
+			super.assertEquals( 200, record[ 1 ].field3 );
+			super.assertEquals( 20, record[ 1 ].field4 );
+			super.assertEquals( 1, poService.selectData( objectName="an_object", filter={ field1=1, field2=2 } ).recordCount, "Expected only one record for the unique key" );
+		</cfscript>
+	</cffunction>
+
 	<cffunction name="_getNowSql" access="private" returntype="string" output="false">
 		<cfreturn _getDbAdapter().getNowFunctionSql() />
 	</cffunction>


### PR DESCRIPTION
* New upsertData() method available to logic that wants to insert when not existing, and update when does - can avoid use of transactions
* Optimize system config saving to use upsertData + add option to avoid versioning
* Optimize forms service saving of dynamic forms: only save when data changed, do not version changes
* Remove various other transaction blocks that are over zealous