### PR TITLE
PRESIDECMS-3311 Add configurability to select fields in enhanced datamanager view record screen

### DIFF
--- a/system/base/EnhancedDataManagerBase.cfc
+++ b/system/base/EnhancedDataManagerBase.cfc
@@ -78,7 +78,12 @@ component extends="preside.system.base.AdminHandler" {
 		var objectName = event.getCurrentEvent().reReplaceNoCase( "admin\.datamanager\.(.*?)\.viewRecord", "\1" );
 		var recordId = rc.id ?: "";
 
-		event.initializeDatamanagerPage( objectName=objectName, recordId=recordId, includeAllFormulaFields=true );
+		event.initializeDatamanagerPage(
+			  objectName              = objectName
+			, recordId                = recordId
+			, includeAllFormulaFields = isTrue( variables.includeAllFormulaFieldsForViewRecord ?: true )
+			, extraSelectFields       = IsArray( variables.extraSelectFieldsForViewRecord ?: "" ) && ArrayLen( variables.extraSelectFieldsForViewRecord ) ? variables.extraSelectFieldsForViewRecord : []
+		);
 
 		announceInterception( "preViewRecord", { objectName=objectName, recordId=recordId } );
 

--- a/system/handlers/admin/DataManager.cfc
+++ b/system/handlers/admin/DataManager.cfc
@@ -4333,7 +4333,7 @@ component extends="preside.system.base.AdminHandler" {
 		return rootForm;
 	}
 
-	private void function _loadCommonVariables( event, action, eventArguments, includeAllFormulaFields=( arguments.action == "viewRecord" ) ) {
+	private void function _loadCommonVariables( event, action, eventArguments, includeAllFormulaFields=( arguments.action == "viewRecord" ), extraSelectFields=[] ) {
 		var rc  = event.getCollection();
 		var prc = event.getCollection( private=true );
 
@@ -4454,15 +4454,25 @@ component extends="preside.system.base.AdminHandler" {
 				}
 
 				if ( !prc.isTranslationAction ) {
+					var selectDataArgs = {
+						  objectName              = prc.objectName
+						, id                      = prc.recordId
+						, useCache                = false
+						, includeAllFormulaFields = arguments.includeAllFormulaFields
+						, extraSelectFields       = arguments.extraSelectFields
+						, allowDraftVersions      = true
+						, autoGroupBy             = arguments.includeAllFormulaFields || ArrayLen( arguments.extraSelectFields )
+					};
+
 					if ( prc.useVersioning && prc.version ) {
 						if ( !presideObjectService.dataExists( objectName=prc.objectName, id=prc.recordId, useCache=false ) ) {
 							messageBox.error( translateResource( uri="cms:datamanager.recordNotFound.error", data=[ prc.objectTitle  ] ) );
 							setNextEvent( url=event.buildAdminLink( objectName=prc.objectName, operation="listing" ) );
 						}
 
-						prc.record = presideObjectService.selectData( objectName=prc.objectName, id=prc.recordId, useCache=false, includeAllFormulaFields=arguments.includeAllFormulaFields, fromVersionTable=true, specificVersion=prc.version, allowDraftVersions=true, autoGroupBy=arguments.includeAllFormulaFields );
+						prc.record = presideObjectService.selectData( argumentCollection=selectDataArgs, fromVersionTable=true, specificVersion=prc.version );
 					} else {
-						prc.record = presideObjectService.selectData( objectName=prc.objectName, id=prc.recordId, useCache=false, includeAllFormulaFields=arguments.includeAllFormulaFields, allowDraftVersions=true, autoGroupBy=arguments.includeAllFormulaFields );
+						prc.record = presideObjectService.selectData( argumentCollection=selectDataArgs );
 					}
 
 					if ( !prc.record.recordCount ) {


### PR DESCRIPTION
* allow setting `variables.includeAllFormulaFieldsForViewRecord = false;` to turn off auto including all formula fields
* allow setting `variables.extraSelectFieldsForViewRecord = [ "x",..];` to set specific formula fields, etc. that you need

This allows for a more performant query for objects with a large number of complex formula fields (or a lot of related records for count formulas, etc.)
 