### PR TITLE
PRESIDECMS-3314 object picker filter by and radio list

### DIFF
--- a/system/assets/js/admin/presidecore/preside.object.picker.js
+++ b/system/assets/js/admin/presidecore/preside.object.picker.js
@@ -251,13 +251,21 @@
 		};
 
 		PresideObjectPicker.prototype.getFilterValue = function( filterBy ) {
-			var field = $( 'input[name="' + filterBy + '"]' );
+			var field = $( 'input[name="' + filterBy + '"], select[name="' + filterBy + '"]' );
 
-			if ( field.length ) {
-				return field.val();
+			if ( !field.length ) {
+				return cfrequest[ filterBy ] || null;
 			}
 
-			return cfrequest[ filterBy ] || null;
+			if ( field.is( ":radio" ) ) {
+				return field.filter( ":checked" ).val();
+			}
+
+			if ( field.is( ":checkbox" ) ) {
+				return field.filter( ":checked" ).map( function(){ return this.value; } ).get().join( "," );
+			}
+
+			return field.val();
 		}
 
 		return PresideObjectPicker;

--- a/system/assets/js/admin/presidecore/preside.uber.select.js
+++ b/system/assets/js/admin/presidecore/preside.uber.select.js
@@ -609,26 +609,42 @@
 
 					if ( filterInput.length ) {
 						this.filter_field = filterInput;
-						filterByValue = this.filter_field.val();
+						filterByValue = this.get_filter_field_value( filterInput );
 					} else {
 						filterByValue = cfrequest[ filterBy[ i ] ] || null;
 					}
 
-					if ( filterByValue !== null && typeof filterByValue !== "undefined" ) {
+					if ( filterByValue !== null && typeof filterByValue !== "undefined" && filterByValue.length ) {
 						filters.push ( '&', filterByField[ i ], '=', filterByValue, '&filterByFields=', filterByField[ i ] );
 					}
 				}
 
-				if ( filters.length ) {
-					this.filter = filters.join( '' );
-				}
+				this.filter = filters.length ? filters.join( '' ) : "";
 			}
 
 		};
 
+		UberSelect.prototype.get_filter_field_value = function( $field ) {
+			if ( !$field || !$field.length ) {
+				return null;
+			}
+
+			// Radio groups: .val() on the collection returns the first input's value,
+			// not the checked one. Object-picker filterBy must use :checked.
+			if ( $field.is( ":radio" ) ) {
+				return $field.filter( ":checked" ).val();
+			}
+
+			if ( $field.is( ":checkbox" ) ) {
+				return $field.filter( ":checked" ).map( function(){ return this.value; } ).get().join( "," );
+			}
+
+			return $field.val();
+		};
+
 		UberSelect.prototype.disable_if_unfiltered = function() {
 			if ( this.disabled_if_unfiltered ) {
-				if ( this.filter_field.val().length ) {
+				if ( this.get_filter_field_value( this.filter_field ) ) {
 					this.form_field_jq.removeAttr( 'disabled' );
 					this.container.siblings( '.quick-add-btn' ).removeClass( 'disabled' );
 				} else {


### PR DESCRIPTION
This change ensures that when the related filterBy field is a radio list or checkbox list, that the actual selected values are used, rather than just the first value.