### PR TITLE
Feature PRESIDECMS-3316: sysconfig form permission keys

### DIFF
--- a/system/handlers/admin/SysConfig.cfc
+++ b/system/handlers/admin/SysConfig.cfc
@@ -2,6 +2,7 @@ component extends="preside.system.base.AdminHandler" {
 
 	property name="systemConfigurationService" inject="systemConfigurationService";
 	property name="presideObjectService"       inject="presideObjectService";
+	property name="formsService"               inject="formsService";
 	property name="messageBox"                 inject="messagebox@cbmessagebox";
 	property name="tenancyConfig"              inject="coldbox:setting:tenancy";
 	property name="systemAlertsService"        inject="systemAlertsService";
@@ -15,18 +16,22 @@ component extends="preside.system.base.AdminHandler" {
 			event.notFound();
 		}
 
-		if ( !hasCmsPermission( permissionKey="systemConfiguration.manage" ) ) {
-			event.adminAccessDenied();
-		}
+		prc.hasGlobalConfigPermission = hasCmsPermission( permissionKey="systemConfiguration.manage" );
 
-		event.addAdminBreadCrumb(
-			  title = translateResource( "cms:sysConfig" )
-			, link  = event.buildAdminLink( linkTo="sysConfig" )
-		);
+		if ( prc.hasGlobalConfigPermission ) {
+			event.addAdminBreadCrumb(
+				  title = translateResource( "cms:sysConfig" )
+				, link  = event.buildAdminLink( linkTo="sysConfig" )
+			);
+		}
 	}
 
 // FIRST CLASS EVENTS
 	public any function index( event, rc, prc ) {
+		if ( !prc.hasGlobalConfigPermission ) {
+			event.adminAccessDenied();
+		}
+
 		prc.categories = systemConfigurationService.listConfigCategories();
 		ArraySort( prc.categories, function(a,b){
 			var aTitle = LCase( translateResource( uri=a.getName(), defaultValue=a.getId() ) );
@@ -50,6 +55,10 @@ component extends="preside.system.base.AdminHandler" {
 			prc.category = systemConfigurationService.getConfigCategory( id=categoryId );
 		} catch( "SystemConfigurationService.category.notFound" e ) {
 			event.notFound();
+		}
+
+		if ( !_userCanAccessCategory( argumentCollection=arguments, category=prc.category ) ) {
+			event.adminAccessDenied();
 		}
 
 		prc.tenancy = systemConfigurationService.getConfigCategoryTenancy( id=categoryId );
@@ -105,6 +114,10 @@ component extends="preside.system.base.AdminHandler" {
 			prc.category = systemConfigurationService.getConfigCategory( id=categoryId );
 		} catch( "SystemConfigurationService.category.notFound" e ) {
 			event.notFound();
+		}
+
+		if ( !_userCanAccessCategory( argumentCollection=arguments, category=prc.category ) ) {
+			event.adminAccessDenied();
 		}
 
 		var formName = Len( Trim( tenantId ) ) ? prc.category.getSiteForm() : prc.category.getForm();
@@ -177,9 +190,29 @@ component extends="preside.system.base.AdminHandler" {
 
 // VIEWLETS
 	private string function categoryMenu( event, rc, prc, args ) {
-		args.categories = systemConfigurationService.listConfigCategories();
+		var categories = systemConfigurationService.listConfigCategories();
+
+		args.categories = [];
+		for ( var category in categories ) {
+			if ( _userCanAccessCategory( argumentCollection=arguments, category=category ) ) {
+				ArrayAppend( args.categories, category );
+			}
+		}
 
 		return renderView( view="admin/sysconfig/categoryMenu", args=args );
+	}
+
+// PRIVATE HELPERS
+	private boolean function _userCanAccessCategory( event, rc, prc, required any category ) {
+		if ( hasCmsPermission( permissionKey="systemConfiguration.manage" ) ) {
+			return true;
+		}
+
+		// categories without a form-level permissionKey stay restricted to systemConfiguration.manage
+		return formsService.userCanAccessForm(
+			  formName                 = arguments.category.getForm()
+			, allowedIfNoPermissionKey = false
+		);
 	}
 
 }

--- a/system/services/forms/FormsService.cfc
+++ b/system/services/forms/FormsService.cfc
@@ -866,6 +866,40 @@ component displayName="Forms service" {
 	}
 
 	/**
+	 * Returns whether or not the currently logged in admin user has permission
+	 * to access the given form, based on the optional `permissionKey` attribute
+	 * declared on the root `form` element of the form's definition. Forms that
+	 * do not declare a permission key are treated as accessible by default;
+	 * use the `allowedIfNoPermissionKey` argument to change that behaviour.
+	 *
+	 * @autodoc                        true
+	 * @formName.hint                  The name of the form whose access you wish to check
+	 * @permissionContext.hint         Optional context for permission lookups (see [[permissionsservice-haspermission]])
+	 * @permissionContextKeys.hint     Optional array of context keys for permission lookups (see [[permissionsservice-haspermission]])
+	 * @allowedIfNoPermissionKey.hint  Whether or not access is allowed when the form does not declare a permission key
+	 *
+	 */
+	public boolean function userCanAccessForm(
+		  required string  formName
+		,          string  permissionContext        = ""
+		,          array   permissionContextKeys    = []
+		,          boolean allowedIfNoPermissionKey = true
+	) {
+		var theForm       = getForm( arguments.formName );
+		var permissionKey = Trim( theForm.permissionKey ?: "" );
+
+		if ( !Len( permissionKey ) ) {
+			return arguments.allowedIfNoPermissionKey;
+		}
+
+		return $hasAdminPermission(
+			  permissionKey = permissionKey
+			, context       = arguments.permissionContext
+			, contextKeys   = arguments.permissionContextKeys
+		);
+	}
+
+	/**
 	 * Takes a form definition (struct) and removes all the tabs, fieldsets and fields
 	 * to which the currently logged in admin user does not have permission to edit.
 	 * Returns a new structure with the potentially removed elements.

--- a/tests/resources/formsService/permissionKey/folder1/inheritedKeyForm.xml
+++ b/tests/resources/formsService/permissionKey/folder1/inheritedKeyForm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form permissionKey="folder1.key">
+	<tab id="default">
+		<fieldset id="default">
+			<field name="somefield" />
+		</fieldset>
+	</tab>
+</form>

--- a/tests/resources/formsService/permissionKey/folder1/keyedForm.xml
+++ b/tests/resources/formsService/permissionKey/folder1/keyedForm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form permissionKey="some.key">
+	<tab id="default">
+		<fieldset id="default">
+			<field name="somefield" />
+		</fieldset>
+	</tab>
+</form>

--- a/tests/resources/formsService/permissionKey/folder1/overriddenKeyForm.xml
+++ b/tests/resources/formsService/permissionKey/folder1/overriddenKeyForm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form permissionKey="folder1.key">
+	<tab id="default">
+		<fieldset id="default">
+			<field name="somefield" />
+		</fieldset>
+	</tab>
+</form>

--- a/tests/resources/formsService/permissionKey/folder1/unkeyedForm.xml
+++ b/tests/resources/formsService/permissionKey/folder1/unkeyedForm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<tab id="default">
+		<fieldset id="default">
+			<field name="somefield" />
+		</fieldset>
+	</tab>
+</form>

--- a/tests/resources/formsService/permissionKey/folder2/inheritedKeyForm.xml
+++ b/tests/resources/formsService/permissionKey/folder2/inheritedKeyForm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<tab id="default">
+		<fieldset id="default">
+			<field name="anotherfield" />
+		</fieldset>
+	</tab>
+</form>

--- a/tests/resources/formsService/permissionKey/folder2/overriddenKeyForm.xml
+++ b/tests/resources/formsService/permissionKey/folder2/overriddenKeyForm.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form permissionKey="folder2.key">
+	<tab id="default">
+		<fieldset id="default">
+			<field name="somefield" />
+		</fieldset>
+	</tab>
+</form>

--- a/tests/unit/api/forms/FormsServiceTest.cfc
+++ b/tests/unit/api/forms/FormsServiceTest.cfc
@@ -886,6 +886,93 @@ component extends="tests.resources.HelperObjects.PresideBddTestCase" {
 				) ).toBe( expectedStrippedForm );
 			} );
 		} );
+
+		describe( "userCanAccessForm()", function(){
+			it( "should return true when the form does not declare a root permissionKey", function(){
+				var service = _getFormsService( "/tests/resources/formsService/permissionKey/folder1" );
+
+				service.$( "$hasAdminPermission", false );
+
+				expect( service.userCanAccessForm( formName="unkeyedForm" ) ).toBeTrue();
+			} );
+
+			it( "should return false when the form does not declare a root permissionKey and allowedIfNoPermissionKey is passed as false", function(){
+				var service = _getFormsService( "/tests/resources/formsService/permissionKey/folder1" );
+
+				expect( service.userCanAccessForm( formName="unkeyedForm", allowedIfNoPermissionKey=false ) ).toBeFalse();
+			} );
+
+			it( "should return true when the logged in user has the permission declared on the root form element", function(){
+				var service = _getFormsService( "/tests/resources/formsService/permissionKey/folder1" );
+
+				service.$( "$hasAdminPermission" ).$args(
+					  permissionKey = "some.key"
+					, context       = ""
+					, contextKeys   = []
+				).$results( true );
+
+				expect( service.userCanAccessForm( formName="keyedForm" ) ).toBeTrue();
+			} );
+
+			it( "should return false when the logged in user does not have the permission declared on the root form element", function(){
+				var service = _getFormsService( "/tests/resources/formsService/permissionKey/folder1" );
+
+				service.$( "$hasAdminPermission" ).$args(
+					  permissionKey = "some.key"
+					, context       = ""
+					, contextKeys   = []
+				).$results( false );
+
+				expect( service.userCanAccessForm( formName="keyedForm" ) ).toBeFalse();
+			} );
+
+			it( "should pass the given permission context and context keys through to the admin permission check", function(){
+				var service     = _getFormsService( "/tests/resources/formsService/permissionKey/folder1" );
+				var contextKeys = [ CreateUUId() ];
+
+				service.$( "$hasAdminPermission", false );
+				service.$( "$hasAdminPermission" ).$args(
+					  permissionKey = "some.key"
+					, context       = "somecontext"
+					, contextKeys   = contextKeys
+				).$results( true );
+
+				expect( service.userCanAccessForm(
+					  formName              = "keyedForm"
+					, permissionContext     = "somecontext"
+					, permissionContextKeys = contextKeys
+				) ).toBeTrue();
+			} );
+
+			it( "should use a root permissionKey declared in an earlier form directory when a later directory's definition does not redeclare it", function(){
+				var service = _getFormsService( "/tests/resources/formsService/permissionKey/folder1,/tests/resources/formsService/permissionKey/folder2" );
+
+				service.$( "$hasAdminPermission" ).$args(
+					  permissionKey = "folder1.key"
+					, context       = ""
+					, contextKeys   = []
+				).$results( false );
+
+				expect( service.userCanAccessForm( formName="inheritedKeyForm" ) ).toBeFalse();
+			} );
+
+			it( "should use the root permissionKey declared in the last form directory when redeclared there", function(){
+				var service = _getFormsService( "/tests/resources/formsService/permissionKey/folder1,/tests/resources/formsService/permissionKey/folder2" );
+
+				service.$( "$hasAdminPermission" ).$args(
+					  permissionKey = "folder1.key"
+					, context       = ""
+					, contextKeys   = []
+				).$results( true );
+				service.$( "$hasAdminPermission" ).$args(
+					  permissionKey = "folder2.key"
+					, context       = ""
+					, contextKeys   = []
+				).$results( false );
+
+				expect( service.userCanAccessForm( formName="overriddenKeyForm" ) ).toBeFalse();
+			} );
+		} );
 	}
 
 	private any function _getFormsService(


### PR DESCRIPTION
Form-level permissionKey is only enforced where explicitly called. SysConfig is the only caller; unlike tab/fieldset/field keys, the root key is not applied by removePermissionedFieldsFromFormDefinition() or renderForm